### PR TITLE
CSPACE-4777

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+*tenant-bindings.merged.xml


### PR DESCRIPTION
One more minor detail for the transition of the services layer source code from SVN to Git: adding a default, top-level .gitignore file, akin to those in the application and ui layers.
