### PR TITLE
CSPACE-4945

### DIFF
--- a/services/movement/client/src/test/java/org/collectionspace/services/client/test/MovementSortByTest.java
+++ b/services/movement/client/src/test/java/org/collectionspace/services/client/test/MovementSortByTest.java
@@ -122,7 +122,7 @@ public class MovementSortByTest extends BaseServiceTest<AbstractCommonList> {
             // Because movementNote is not currently a summary field
             // (returned in summary list items), we will need to verify
             // sort order by using the IDs provided in the summary list
-            // items to retrieve full records, amd then obtaining
+            // items to retrieve full records, and then obtaining
             // the value of that field from each of those records.
             MovementsCommon movement = read(AbstractCommonListUtils.ListItemGetCSID(item));
             values.add(i, movement.getMovementNote());
@@ -171,7 +171,7 @@ public class MovementSortByTest extends BaseServiceTest<AbstractCommonList> {
             // Because movementNote is not currently a summary field
             // (returned in summary list items), we will need to verify
             // sort order by using the IDs provided in the summary list
-            // items to retrieve full records, amd then obtaining
+            // items to retrieve full records, and then obtaining
             // the value of that field from each of those records.
             MovementsCommon movement = read(AbstractCommonListUtils.ListItemGetCSID(item));
             values.add(i, movement.getMovementNote());
@@ -218,7 +218,7 @@ public class MovementSortByTest extends BaseServiceTest<AbstractCommonList> {
             // Because movementNote is not currently a summary field
             // (returned in summary list items), we will need to verify
             // sort order by using the IDs provided in the summary list
-            // items to retrieve full records, amd then obtaining
+            // items to retrieve full records, and then obtaining
             // the value of that field from each of those records.
             MovementsCommon movement = read(AbstractCommonListUtils.ListItemGetCSID(item));
             values.add(i, movement.getMovementNote());
@@ -340,7 +340,7 @@ public class MovementSortByTest extends BaseServiceTest<AbstractCommonList> {
             // Because movementNote is not currently a summary field
             // (returned in summary list items), we will need to verify
             // sort order by using the IDs provided in the summary list
-            // items to retrieve full records, amd then obtaining
+            // items to retrieve full records, and then obtaining
             // the value of that field from each of those records.
             MovementsCommon movement = read(AbstractCommonListUtils.ListItemGetCSID(item));
             firstFieldValues.add(i, movement.getMovementNote());
@@ -391,7 +391,7 @@ public class MovementSortByTest extends BaseServiceTest<AbstractCommonList> {
             // Because movementNote is not currently a summary field
             // (returned in summary list items), we will need to verify
             // sort order by using the IDs provided in the summary list
-            // items to retrieve full records, amd then obtaining
+            // items to retrieve full records, and then obtaining
             // the value of that field from each of those records.
             MovementsCommon movement = read(AbstractCommonListUtils.ListItemGetCSID(item));
             firstFieldValues.add(i, movement.getLocationDate());


### PR DESCRIPTION
Change character case in test data used by services MovementSortByTest, to ensure that tests succeed regardless of locale-based case variations in sort order, since tests have no control over this configuration.  Mixed case text was being ordered differently on Linux / Windows systems and on Mac OS X systems.
