### PR TITLE
CSPACE-4983

### DIFF
--- a/services/authority/service/src/main/java/org/collectionspace/services/common/vocabulary/AuthorityResource.java
+++ b/services/authority/service/src/main/java/org/collectionspace/services/common/vocabulary/AuthorityResource.java
@@ -745,7 +745,7 @@ public abstract class AuthorityResource<AuthCommon, AuthItemHandler>
 
             List<String> serviceTypes = queryParams.remove(ServiceBindingUtils.SERVICE_TYPE_PROP);
             if(serviceTypes == null || serviceTypes.isEmpty()) {
-                // Temporary workaround for CSPACE-4963
+                // Temporary workaround for CSPACE-4983
             	// serviceTypes = ServiceBindingUtils.getCommonServiceTypes();
                 serviceTypes = ServiceBindingUtils.getCommonProcedureServiceTypes();
             }

--- a/services/common/src/main/java/org/collectionspace/services/common/context/ServiceBindingUtils.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/context/ServiceBindingUtils.java
@@ -206,7 +206,7 @@ public class ServiceBindingUtils {
     	return commonServiceTypes;
     }
     
-    // Temporary workaround for CSPACE-4963, to help reduce the
+    // Temporary workaround for CSPACE-4983, to help reduce the
     // number of service types searched for authority references
     // in AuthorityResource.getReferencingObjects(), to in turn
     // help reduce database query complexity.


### PR DESCRIPTION
Temporary workaround to reduce query complexity when retrieving lists of objects that reference an authority term.  This is a regression to query only procedural records, rather than both procedural records and cataloging records.
