### PR TITLE
CSPACE-5049,CSPACE-3917: Added an XmlReplay-based test of variable

### DIFF
--- a/services/IntegrationTests/src/test/resources/test-data/xmlreplay/imports/import-objectexit-docid.xml
+++ b/services/IntegrationTests/src/test/resources/test-data/xmlreplay/imports/import-objectexit-docid.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<imports>
+    <import service="ObjectExit" type="ObjectExit" CSID="${recordCSID}">
+        <schema xmlns:objectexit_common="http://collectionspace.org/services/objectexit" 
+                name="objectexit_common">
+            <exitNote>The value of a 'docID' variable in the original import document should be inserted here: ${docID}</exitNote>        
+            <exitNumber>OE-IMPORT-TEST-1999.8</exitNumber>
+        </schema>
+    </import>
+</imports>

--- a/services/IntegrationTests/src/test/resources/test-data/xmlreplay/imports/import-objectexit.xml
+++ b/services/IntegrationTests/src/test/resources/test-data/xmlreplay/imports/import-objectexit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <imports>
-    <import service="ObjectExit" type="ObjectExit" CSID="920c578f-e5d6-45da-adab-6f26f6a491ff">
+    <import service="ObjectExit" type="ObjectExit">
         <schema xmlns:objectexit_common="http://collectionspace.org/services/objectexit" 
             name="objectexit_common">
             <exitNote>This is an exit note.</exitNote>

--- a/services/IntegrationTests/src/test/resources/test-data/xmlreplay/imports/imports.xml
+++ b/services/IntegrationTests/src/test/resources/test-data/xmlreplay/imports/imports.xml
@@ -74,6 +74,41 @@
             <method>DELETE</method>
             <uri>/cspace-services/objectexit/${importObjectExitMedia.got("//csid[preceding-sibling::doctype[1][text()='ObjectExit']]")}</uri>
         </test>
+        
+        <!--
+            Import a record with a client-provided CSID.
+            Then also insert the value of that CSID into a field via the ${docID} variable. 
+            (See "Variables supported in expansion of request" in
+            http://wiki.collectionspace.org/display/collectionspace/Imports+Service+Home)
+        -->
+        <test ID="importObjectExitWithDocID">
+            <expectedCodes>200</expectedCodes>
+            <method>POST</method>
+            <uri>/cspace-services/imports</uri>
+            <filename>imports/import-objectexit-docid.xml</filename>
+            <vars>
+                <var ID="recordCSID">920c578f-e5d6-45da-adab-6f26f6a491ff</var>
+            </vars>
+            <response>
+                <expected level="TEXT" />
+                <filename>imports/res/import-objectexit.res.xml</filename>
+            </response>
+        </test>
+        <test ID="verifyObjectExitWithDocID">
+            <expectedCodes>200</expectedCodes>
+            <method>GET</method>
+            <uri>/cspace-services/objectexit/${importObjectExitWithDocID.recordCSID}</uri>
+            <response>
+                <expected level="ADDOK" />
+                <filename>imports/res/import-objectexit-docID.res.xml</filename>
+                <label>objectexit_common</label>
+            </response>
+        </test>
+        <test ID="deleteObjectExitWithDocID">
+            <expectedCodes>200</expectedCodes>
+            <method>DELETE</method>
+            <uri>/cspace-services/objectexit/${importObjectExitWithDocID.recordCSID}</uri>
+        </test>
 
     </testGroup>
     
@@ -121,7 +156,7 @@
         <test ID="deleteObjectExitUTF8">
             <expectedCodes>200</expectedCodes>
             <method>DELETE</method>
-            <uri cspace-services/objectexit/${importObjectExitUTF8.got("//csid")}</uri>
+            <uri>/cspace-services/objectexit/${importObjectExitUTF8.got("//csid")}</uri>
         </test>
         -->
         

--- a/services/IntegrationTests/src/test/resources/test-data/xmlreplay/imports/res/import-objectexit-docid.res.xml
+++ b/services/IntegrationTests/src/test/resources/test-data/xmlreplay/imports/res/import-objectexit-docid.res.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document name="objectexit">
+    <ns2:objectexit_common xmlns:ns2="http://collectionspace.org/services/objectexit" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <exitNote>The value of a 'docID' variable in the original import document should be inserted here: ${importObjectExitWithDocID.recordCSID}</exitNote>
+        <exitNumber>OE-IMPORT-TEST-1999.8</exitNumber>
+    </ns2:objectexit_common>
+</document>
+


### PR DESCRIPTION
expansion in an imported record. This test is needed in part to prevent regression when working on CSPACE-3917.
