### PR TITLE
Place 2.4 fixes

### DIFF
--- a/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto.xml
+++ b/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto.xml
@@ -2328,6 +2328,10 @@
                             <types:value>placeOwnerGroupList/*/owner</types:value>
                         </types:item>
                         <types:item xmlns:types="http://collectionspace.org/services/config/types">
+                            <types:key>authRef</types:key>
+                            <types:value>placeGeoRefGroupList/*/geoReferencedBy</types:value>
+                        </types:item>
+                        <types:item xmlns:types="http://collectionspace.org/services/config/types">
                             <types:key>termRef</types:key>
                             <types:value>termStatus</types:value>
                         </types:item>


### PR DESCRIPTION
Please pull these commits into the collectionspace/services master branch. This request reflects fixes based on CSPACE-5116, stemming from 2.3 QA: because the geoReferencedBy field is now tied to the person and org authorities, an authRef has been added for it to tenant-bindings-proto.xml
