### PR TITLE
CSPACE-5152: Add borrowersAuthorizer authRef to loansout_common part configuration.

### DIFF
--- a/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto.xml
+++ b/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto.xml
@@ -1041,6 +1041,10 @@
               <types:value>borrowersContact</types:value>
             </types:item>
             <types:item xmlns:types="http://collectionspace.org/services/config/types">
+                <types:key>authRef</types:key>
+                <types:value>borrowersAuthorizer</types:value>
+            </types:item>
+            <types:item xmlns:types="http://collectionspace.org/services/config/types">
               <types:key>authRef</types:key>
               <types:value>lendersAuthorizer</types:value>
             </types:item>


### PR DESCRIPTION
This is an update to tenant-bindings-proto.xml so that the Borrower's Authorizer field in Loan Out shows up in the Terms Used sidebar.
