### PR TITLE
CSPACE-5418: Adding termRef block for historicalStatus in Concepts

### DIFF
--- a/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto.xml
+++ b/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto.xml
@@ -2642,6 +2642,10 @@
                             <types:key>termRef</types:key>
                             <types:value>conceptTermGroupList/*/termStatus</types:value>
                         </types:item>
+                        <types:item xmlns:types="http://collectionspace.org/services/config/types">
+                            <types:key>termRef</types:key>
+                            <types:value>conceptTermGroupList/*/historicalStatus</types:value>
+                        </types:item>
                     </service:properties>
                     <service:content contentType="application/xml">
                         <service:xmlContent namespaceURI="http://collectionspace.org/services/concept" schemaLocation="http://collectionspace.org/services/concept http://services.collectionspace.org/concept/concepts_common.xsd" />


### PR DESCRIPTION
... in tenant-bindings-proto.xml:

```
                    <types:key>termRef</types:key>
                        <types:value>conceptTermGroupList/*/historicalStatus</types:value>
                    </types:item>
```

Please merge into master.

I will follow up with a second pull request to push this to v2.5.

Thanks.
