### PR TITLE
CSPACE-4661: removing 'provided' scope for log4j dependency. This will f...

### DIFF
--- a/services/JaxRsServiceProvider/pom.xml
+++ b/services/JaxRsServiceProvider/pom.xml
@@ -33,7 +33,7 @@
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
             <version>1.2.14</version>
-            <scope>provided</scope>
+            <!--scope>provided</scope-->
         </dependency>
         <!-- somewhere dependency is added 1.5.8 unnecessarily -->
         <dependency>


### PR DESCRIPTION
...orce the log4j jar file to be added to the deployed services war file, and will catch the log4j.properties settings for the services app. This is necessary for proper log rolling across tomcat and deployed apps.
