### PR TITLE
CSPACE-4711,CSPACE-3431: Added '-V' as a default mvn.opts value to work ...

### DIFF
--- a/3rdparty/build.xml
+++ b/3rdparty/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="build" location="build"/>
     <property name="dist"  location="dist"/>

--- a/3rdparty/nuxeo/build.xml
+++ b/3rdparty/nuxeo/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="build" location="build"/>
     <property name="dist"  location="dist"/>

--- a/3rdparty/nuxeo/nuxeo-platform-collectionspace/build.xml
+++ b/3rdparty/nuxeo/nuxeo-platform-collectionspace/build.xml
@@ -7,7 +7,7 @@
   <!-- environment should be declared before reading build.properties -->
   <property environment="env" />
   <property file="${services.trunk}/build.properties" />
-  <property name="mvn.opts" value="" />
+  <property name="mvn.opts" value="-V" />
   <property name="src" location="src"/>
   <property name="build" location="build"/>
   <property name="dist"  location="dist"/>

--- a/3rdparty/nuxeo/nuxeo-platform-listener/build.xml
+++ b/3rdparty/nuxeo/nuxeo-platform-listener/build.xml
@@ -9,7 +9,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="build" location="build"/>
     <property name="dist"  location="dist"/>

--- a/3rdparty/nuxeo/nuxeo-platform-listener/updateobjectlocationonmove/build.xml
+++ b/3rdparty/nuxeo/nuxeo-platform-listener/updateobjectlocationonmove/build.xml
@@ -10,7 +10,7 @@
   <property file="${services.trunk}/build.properties" />
   <!-- Set local properties for this build -->
   <property file="build.properties" />
-  <property name="mvn.opts" value="" />
+  <property name="mvn.opts" value="-V" />
   <property name="src" location="src"/>
   <property name="build" location="build"/>
   <property name="dist"  location="dist"/>

--- a/3rdparty/nuxeo/nuxeo-platform-listener/updaterelationsondelete/build.xml
+++ b/3rdparty/nuxeo/nuxeo-platform-listener/updaterelationsondelete/build.xml
@@ -10,7 +10,7 @@
   <property file="${services.trunk}/build.properties" />
   <!-- Set local properties for this build -->
   <property file="build.properties" />
-  <property name="mvn.opts" value="" />
+  <property name="mvn.opts" value="-V" />
   <property name="src" location="src"/>
   <property name="build" location="build"/>
   <property name="dist"  location="dist"/>

--- a/3rdparty/nuxeo/nuxeo-platform-quote-api/build.xml
+++ b/3rdparty/nuxeo/nuxeo-platform-quote-api/build.xml
@@ -7,7 +7,7 @@
   <!-- environment should be declared before reading build.properties -->
   <property environment="env" />
   <property file="${services.trunk}/build.properties" />
-  <property name="mvn.opts" value="" />
+  <property name="mvn.opts" value="-V" />
   <property name="src" location="src"/>
   <property name="build" location="build"/>
   <property name="dist"  location="dist"/>

--- a/3rdparty/nuxeo/nuxeo-platform-quote/build.xml
+++ b/3rdparty/nuxeo/nuxeo-platform-quote/build.xml
@@ -7,7 +7,7 @@
   <!-- environment should be declared before reading build.properties -->
   <property environment="env" />
   <property file="${services.trunk}/build.properties" />
-  <property name="mvn.opts" value="" />
+  <property name="mvn.opts" value="-V" />
   <property name="src" location="src"/>
   <property name="build" location="build"/>
   <property name="dist"  location="dist"/>

--- a/3rdparty/nuxeo/nuxeo-platform-thumbnail/build.xml
+++ b/3rdparty/nuxeo/nuxeo-platform-thumbnail/build.xml
@@ -7,7 +7,7 @@
   <!-- environment should be declared before reading build.properties -->
   <property environment="env" />
   <property file="${services.trunk}/build.properties" />
-  <property name="mvn.opts" value="" />
+  <property name="mvn.opts" value="-V" />
   <property name="src" location="src"/>
   <property name="build" location="build"/>
   <property name="dist"  location="dist"/>

--- a/build.xml
+++ b/build.xml
@@ -6,7 +6,7 @@
 	<property environment="env" />
 	<!-- set global properties for this build -->
 	<property file="build.properties" />
-	<property name="mvn.opts" value="" />
+	<property name="mvn.opts" value="-V" />
 	<property name="src" location="src"/>
 
 	<condition property="osfamily-unix">

--- a/services/JaxRsServiceProvider/build.xml
+++ b/services/JaxRsServiceProvider/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/account/build.xml
+++ b/services/account/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="build" location="build"/>
 

--- a/services/account/client/build.xml
+++ b/services/account/client/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/account/pstore/build.xml
+++ b/services/account/pstore/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/acquisition/3rdparty/build.xml
+++ b/services/acquisition/3rdparty/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/acquisition/3rdparty/nuxeo-platform-cs-acquisition/build.xml
+++ b/services/acquisition/3rdparty/nuxeo-platform-cs-acquisition/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="nuxeo.acquisition.jar"
         value="org.collectionspace.services.acquisition.3rdparty.nuxeo-${cspace.release}.jar"/>

--- a/services/acquisition/build.xml
+++ b/services/acquisition/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/authentication/build.xml
+++ b/services/authentication/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="build" location="build"/>
 

--- a/services/authentication/client/build.xml
+++ b/services/authentication/client/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/authentication/pstore/build.xml
+++ b/services/authentication/pstore/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/authentication/service/build.xml
+++ b/services/authentication/service/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="authentication.jar" value="cspace-services-authn.jar"/>
 

--- a/services/authority/build.xml
+++ b/services/authority/build.xml
@@ -8,7 +8,7 @@
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
 
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="build" location="build"/>
 

--- a/services/authorization-common/build.xml
+++ b/services/authorization-common/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="authorization-common.jar" value="cspace-services-authz-common.jar"/>
     <condition property="osfamily-unix">

--- a/services/authorization-mgt/build.xml
+++ b/services/authorization-mgt/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="build" location="build"/>
 

--- a/services/authorization-mgt/client/build.xml
+++ b/services/authorization-mgt/client/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/authorization-mgt/import/build.xml
+++ b/services/authorization-mgt/import/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/authorization-mgt/service/build.xml
+++ b/services/authorization-mgt/service/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="authorization.jar" value="collectionspace-services-authz-mgt.jar"/>
     <condition property="osfamily-unix">

--- a/services/authorization/build.xml
+++ b/services/authorization/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="build" location="build"/>
 

--- a/services/authorization/pstore/build.xml
+++ b/services/authorization/pstore/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/authorization/service/build.xml
+++ b/services/authorization/service/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="authorization.jar" value="cspace-services-authz.jar"/>
     <condition property="osfamily-unix">

--- a/services/batch/3rdparty/build.xml
+++ b/services/batch/3rdparty/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/batch/3rdparty/nuxeo-platform-cs-batch/build.xml
+++ b/services/batch/3rdparty/nuxeo-platform-cs-batch/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="nuxeo.batch.jar"
         value="org.collectionspace.services.batch.3rdparty.nuxeo-${cspace.release}.jar"/>

--- a/services/batch/build.xml
+++ b/services/batch/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/blob/3rdparty/build.xml
+++ b/services/blob/3rdparty/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/blob/3rdparty/nuxeo-platform-cs-blob/build.xml
+++ b/services/blob/3rdparty/nuxeo-platform-cs-blob/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="nuxeo.blob.jar"
         value="org.collectionspace.services.blob.3rdparty.nuxeo-${cspace.release}.jar"/>

--- a/services/blob/build.xml
+++ b/services/blob/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/build.xml
+++ b/services/build.xml
@@ -5,7 +5,7 @@
     <!-- set global properties for this build -->
     <property name="services.trunk" value=".."/>
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="javadoc.jar" value="org.collectionspace.services-javadoc.jar"/>
 

--- a/services/collectionobject/3rdparty/build.xml
+++ b/services/collectionobject/3rdparty/build.xml
@@ -10,7 +10,7 @@
     <property file="${services.trunk}/build.properties" />
 	<property name="nuxeo-platform-collectionobject" value="nuxeo-platform-cs-collectionobject"/>
 	<property name="nuxeo-platform-collectionobject-lifesci" value="nuxeo-platform-collectionobject-lifesci"/>
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="build" location="build"/>
 

--- a/services/collectionobject/3rdparty/nuxeo-platform-collectionobject-lifesci/build.xml
+++ b/services/collectionobject/3rdparty/nuxeo-platform-collectionobject-lifesci/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="build" location="build"/>
     <property name="dist"  location="dist"/>

--- a/services/collectionobject/3rdparty/nuxeo-platform-cs-collectionobject/build.xml
+++ b/services/collectionobject/3rdparty/nuxeo-platform-cs-collectionobject/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="build" location="build"/>
     <property name="dist"  location="dist"/>

--- a/services/collectionobject/build.xml
+++ b/services/collectionobject/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="build" location="build"/>
 

--- a/services/collectionobject/installer/build.xml
+++ b/services/collectionobject/installer/build.xml
@@ -6,7 +6,7 @@
   <!-- set global properties for this build -->
     <property name="services.trunk" value="../.."/>
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="build" location="build"/>
 

--- a/services/common/build.xml
+++ b/services/common/build.xml
@@ -8,7 +8,7 @@
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
 
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="build" location="build"/>
 

--- a/services/concept/3rdparty/build.xml
+++ b/services/concept/3rdparty/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/concept/3rdparty/nuxeo-platform-cs-concept/build.xml
+++ b/services/concept/3rdparty/nuxeo-platform-cs-concept/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="nuxeo.concept.jar"
         value="org.collectionspace.services.concept.3rdparty.nuxeo-${cspace.release}.jar"/>

--- a/services/concept/build.xml
+++ b/services/concept/build.xml
@@ -8,7 +8,7 @@
         <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/concept/installer/build.xml
+++ b/services/concept/installer/build.xml
@@ -6,7 +6,7 @@
   <!-- set global properties for this build -->
     <property name="services.trunk" value="../.."/>
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/contact/3rdparty/build.xml
+++ b/services/contact/3rdparty/build.xml
@@ -6,7 +6,7 @@
   <!-- set global properties for this build -->
     <property name="services.trunk" value="../../.."/>
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/contact/3rdparty/nuxeo-platform-cs-contact/build.xml
+++ b/services/contact/3rdparty/nuxeo-platform-cs-contact/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="build" location="build"/>
     <property name="dist"  location="dist"/>

--- a/services/contact/build.xml
+++ b/services/contact/build.xml
@@ -6,7 +6,7 @@
   <!-- set global properties for this build -->
     <property name="services.trunk" value="../.."/>
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/dimension/3rdparty/build.xml
+++ b/services/dimension/3rdparty/build.xml
@@ -6,7 +6,7 @@
   <!-- set global properties for this build -->
     <property name="services.trunk" value="../../.."/>
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/dimension/3rdparty/nuxeo-platform-cs-dimension/build.xml
+++ b/services/dimension/3rdparty/nuxeo-platform-cs-dimension/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="build" location="build"/>
     <property name="dist"  location="dist"/>

--- a/services/dimension/build.xml
+++ b/services/dimension/build.xml
@@ -6,7 +6,7 @@
   <!-- set global properties for this build -->
     <property name="services.trunk" value="../.."/>
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/group/3rdparty/build.xml
+++ b/services/group/3rdparty/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/group/3rdparty/nuxeo-platform-cs-group/build.xml
+++ b/services/group/3rdparty/nuxeo-platform-cs-group/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="nuxeo.group.jar"
         value="org.collectionspace.services.group.3rdparty.nuxeo-${cspace.release}.jar"/>

--- a/services/group/build.xml
+++ b/services/group/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/id/build.xml
+++ b/services/id/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="service/src"/>
 
     <condition property="osfamily-unix">

--- a/services/id/service/build.xml
+++ b/services/id/service/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/imports/3rdparty/build.xml
+++ b/services/imports/3rdparty/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/imports/3rdparty/nuxeo-platform-cs-imports/build.xml
+++ b/services/imports/3rdparty/nuxeo-platform-cs-imports/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="nuxeo.imports.jar"
         value="org.collectionspace.services.imports.3rdparty.nuxeo-${cspace.release}.jar"/>

--- a/services/imports/build.xml
+++ b/services/imports/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/installer/build.xml
+++ b/services/installer/build.xml
@@ -6,7 +6,7 @@
     <property name="installer.trunk" value=".."/>
     <property name="services.trunk" value="../../.."/>
     <property file="${installer.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/intake/3rdparty/build.xml
+++ b/services/intake/3rdparty/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/intake/3rdparty/nuxeo-platform-cs-intake/build.xml
+++ b/services/intake/3rdparty/nuxeo-platform-cs-intake/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="nuxeo.intake.jar"
         value="org.collectionspace.services.intake.3rdparty.nuxeo-${cspace.release}.jar"/>

--- a/services/intake/build.xml
+++ b/services/intake/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/loanin/3rdparty/build.xml
+++ b/services/loanin/3rdparty/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/loanin/3rdparty/nuxeo-platform-cs-loanin/build.xml
+++ b/services/loanin/3rdparty/nuxeo-platform-cs-loanin/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="nuxeo.loanin.jar"
         value="org.collectionspace.services.loanin.3rdparty.nuxeo-${cspace.release}.jar"/>

--- a/services/loanin/build.xml
+++ b/services/loanin/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/loanout/3rdparty/build.xml
+++ b/services/loanout/3rdparty/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/loanout/3rdparty/nuxeo-platform-cs-loanout/build.xml
+++ b/services/loanout/3rdparty/nuxeo-platform-cs-loanout/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="nuxeo.loanout.jar"
         value="org.collectionspace.services.loanout.3rdparty.nuxeo-${cspace.release}.jar"/>

--- a/services/loanout/build.xml
+++ b/services/loanout/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/location/3rdparty/build.xml
+++ b/services/location/3rdparty/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/location/3rdparty/nuxeo-platform-cs-location/build.xml
+++ b/services/location/3rdparty/nuxeo-platform-cs-location/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="nuxeo.location.jar"
         value="org.collectionspace.services.location.3rdparty.nuxeo-${cspace.release}.jar"/>

--- a/services/location/build.xml
+++ b/services/location/build.xml
@@ -8,7 +8,7 @@
         <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/location/installer/build.xml
+++ b/services/location/installer/build.xml
@@ -6,7 +6,7 @@
   <!-- set global properties for this build -->
     <property name="services.trunk" value="../.."/>
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/media/3rdparty/build.xml
+++ b/services/media/3rdparty/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/media/3rdparty/nuxeo-platform-cs-media/build.xml
+++ b/services/media/3rdparty/nuxeo-platform-cs-media/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="nuxeo.media.jar"
         value="org.collectionspace.services.media.3rdparty.nuxeo-${cspace.release}.jar"/>

--- a/services/media/build.xml
+++ b/services/media/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/movement/3rdparty/build.xml
+++ b/services/movement/3rdparty/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/movement/3rdparty/nuxeo-platform-cs-movement/build.xml
+++ b/services/movement/3rdparty/nuxeo-platform-cs-movement/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="nuxeo.movement.jar"
         value="org.collectionspace.services.movement.3rdparty.nuxeo-${cspace.release}.jar"/>

--- a/services/movement/build.xml
+++ b/services/movement/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/note/3rdparty/build.xml
+++ b/services/note/3rdparty/build.xml
@@ -6,7 +6,7 @@
   <!-- set global properties for this build -->
     <property name="services.trunk" value="../../.."/>
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/note/3rdparty/nuxeo-platform-cs-note/build.xml
+++ b/services/note/3rdparty/nuxeo-platform-cs-note/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="build" location="build"/>
     <property name="dist"  location="dist"/>

--- a/services/note/build.xml
+++ b/services/note/build.xml
@@ -6,7 +6,7 @@
   <!-- set global properties for this build -->
     <property name="services.trunk" value="../.."/>
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/objectexit/3rdparty/build.xml
+++ b/services/objectexit/3rdparty/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/objectexit/3rdparty/nuxeo-platform-cs-objectexit/build.xml
+++ b/services/objectexit/3rdparty/nuxeo-platform-cs-objectexit/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="nuxeo.objectexit.jar"
         value="org.collectionspace.services.objectexit.3rdparty.nuxeo-${cspace.release}.jar"/>

--- a/services/objectexit/build.xml
+++ b/services/objectexit/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/organization/3rdparty/build.xml
+++ b/services/organization/3rdparty/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/organization/3rdparty/nuxeo-platform-cs-organization/build.xml
+++ b/services/organization/3rdparty/nuxeo-platform-cs-organization/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="nuxeo.organization.jar"
         value="org.collectionspace.services.organization.3rdparty.nuxeo-${cspace.release}.jar"/>

--- a/services/organization/build.xml
+++ b/services/organization/build.xml
@@ -8,7 +8,7 @@
         <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/organization/installer/build.xml
+++ b/services/organization/installer/build.xml
@@ -6,7 +6,7 @@
   <!-- set global properties for this build -->
     <property name="services.trunk" value="../.."/>
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/person/3rdparty/build.xml
+++ b/services/person/3rdparty/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/person/3rdparty/nuxeo-platform-cs-person/build.xml
+++ b/services/person/3rdparty/nuxeo-platform-cs-person/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="nuxeo.person.jar"
         value="org.collectionspace.services.person.3rdparty.nuxeo-${cspace.release}.jar"/>

--- a/services/person/3rdparty/nuxeo-platform-person-lifesci/build.xml
+++ b/services/person/3rdparty/nuxeo-platform-person-lifesci/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="build" location="build"/>
     <property name="dist"  location="dist"/>

--- a/services/person/build.xml
+++ b/services/person/build.xml
@@ -8,7 +8,7 @@
         <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/person/installer/build.xml
+++ b/services/person/installer/build.xml
@@ -6,7 +6,7 @@
   <!-- set global properties for this build -->
     <property name="services.trunk" value="../.."/>
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/place/3rdparty/build.xml
+++ b/services/place/3rdparty/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/place/3rdparty/nuxeo-platform-cs-place/build.xml
+++ b/services/place/3rdparty/nuxeo-platform-cs-place/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="nuxeo.place.jar"
         value="org.collectionspace.services.place.3rdparty.nuxeo-${cspace.release}.jar"/>

--- a/services/place/build.xml
+++ b/services/place/build.xml
@@ -7,7 +7,7 @@
         <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/place/installer/build.xml
+++ b/services/place/installer/build.xml
@@ -6,7 +6,7 @@
   <!-- set global properties for this build -->
     <property name="services.trunk" value="../.."/>
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/relation/3rdparty/build.xml
+++ b/services/relation/3rdparty/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/relation/3rdparty/nuxeo-platform-cs-relation/build.xml
+++ b/services/relation/3rdparty/nuxeo-platform-cs-relation/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="nuxeo.relation.jar"
         value="org.collectionspace.services.relation.3rdparty.nuxeo-${cspace.release}.jar"/>

--- a/services/relation/build.xml
+++ b/services/relation/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/report/3rdparty/build.xml
+++ b/services/report/3rdparty/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/report/3rdparty/nuxeo-platform-cs-report/build.xml
+++ b/services/report/3rdparty/nuxeo-platform-cs-report/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="nuxeo.report.jar"
         value="org.collectionspace.services.report.3rdparty.nuxeo-${cspace.release}.jar"/>

--- a/services/report/build.xml
+++ b/services/report/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/security/build.xml
+++ b/services/security/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="build" location="build"/>
 

--- a/services/security/client/build.xml
+++ b/services/security/client/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/servicegroup/build.xml
+++ b/services/servicegroup/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/taxonomy/3rdparty/build.xml
+++ b/services/taxonomy/3rdparty/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/taxonomy/3rdparty/nuxeo-platform-cs-taxonomy/build.xml
+++ b/services/taxonomy/3rdparty/nuxeo-platform-cs-taxonomy/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="nuxeo.taxonomy.jar"
         value="org.collectionspace.services.taxonomy.3rdparty.nuxeo-${cspace.release}.jar"/>

--- a/services/taxonomy/build.xml
+++ b/services/taxonomy/build.xml
@@ -7,7 +7,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/vocabulary/3rdparty/build.xml
+++ b/services/vocabulary/3rdparty/build.xml
@@ -8,7 +8,7 @@
     <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/vocabulary/3rdparty/nuxeo-platform-cs-vocabulary/build.xml
+++ b/services/vocabulary/3rdparty/nuxeo-platform-cs-vocabulary/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="nuxeo.vocabulary.jar"
         value="org.collectionspace.services.vocabulary.3rdparty.nuxeo-${cspace.release}.jar"/>

--- a/services/vocabulary/build.xml
+++ b/services/vocabulary/build.xml
@@ -8,7 +8,7 @@
         <!-- enviornment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/vocabulary/installer/build.xml
+++ b/services/vocabulary/installer/build.xml
@@ -6,7 +6,7 @@
   <!-- set global properties for this build -->
     <property name="services.trunk" value="../.."/>
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/workflow/3rdparty/build.xml
+++ b/services/workflow/3rdparty/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">

--- a/services/workflow/3rdparty/nuxeo-platform-cs-workflow/build.xml
+++ b/services/workflow/3rdparty/nuxeo-platform-cs-workflow/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
     <property name="nuxeo.workflow.jar"
         value="org.collectionspace.services.workflow.3rdparty.nuxeo-${cspace.release}.jar"/>

--- a/services/workflow/build.xml
+++ b/services/workflow/build.xml
@@ -8,7 +8,7 @@
     <!-- environment should be declared before reading build.properties -->
     <property environment="env" />
     <property file="${services.trunk}/build.properties" />
-    <property name="mvn.opts" value="" />
+    <property name="mvn.opts" value="-V" />
     <property name="src" location="src"/>
 
     <condition property="osfamily-unix">


### PR DESCRIPTION
...around an issue on Mac OS X and at least some Linux distributions where Ant's handoff of parameters to Maven 3, when executing the latter, results in an 'Unknown lifestyle phase' error. Thanks go to Glen for a handy 'sed' script to make these batch changes.
