### PR TITLE
CSPACE-6065: In services tenant bindings, remove extraneous config block...

### DIFF
--- a/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto.xml
+++ b/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto.xml
@@ -1618,12 +1618,6 @@
             <service:DocHandlerParams xmlns:service="http://collectionspace.org/services/config/service">
                 <service:params>
                     <service:SupportsHierarchy>true</service:SupportsHierarchy>
-                    <service:RefnameDisplayNameField>
-                        <service:ListResultField>
-                            <service:element>order</service:element>
-                            <service:xpath>order</service:xpath>
-                        </service:ListResultField>
-                    </service:RefnameDisplayNameField>
                     <service:ListResultsFields>
                         <!-- Omit the standard AuthorityItem fields (they are handled by the code) -->
                         <service:ListResultField>


### PR DESCRIPTION
... (service:RefnameDisplayNameField.../service:RefnameDisplayNameField) for the Vocabulary service.
