### PR TITLE
CSPACE-6291: Consolidate remaining <repository> references in POMs to th...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,18 @@
 		</repository>
 
 		<repository>
+			<id>nuxeo-public</id>
+			<name>nuxeo-public</name>
+			<url>http://nightly.collectionspace.org:8081/artifactory/nuxeo-public</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+    
+		<repository>
 			<id>public-snapshot</id>
 			<url>http://maven.nuxeo.org/public-snapshot</url>
 			<!-- Nuxeo Snapshots Repository is disabled. -->
@@ -143,23 +155,6 @@
 		</repository>
 
 		<repository>
-			<id>nuxeo-public</id>
-			<name>nuxeo-public</name>
-			<url>http://nightly.collectionspace.org:8081/artifactory/nuxeo-public</url>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-		<!-- This should no longer be needed since we're using only "releases" 
-			artifacts <repository> <id>nuxeo-public-snapshot</id> <name>nuxeo-public-snapshot</name> 
-			<url>http://nightly.collectionspace.org:8081/artifactory/nuxeo-public-snapshot</url> 
-			<releases> <enabled>false</enabled> </releases> <snapshots> <enabled>true</enabled> 
-			<updatePolicy>never</updatePolicy> </snapshots> </repository> -->
-
-		<repository>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -170,15 +165,26 @@
 			<name>External release repository of the EL4J project</name>
 			<url>http://public-el4.elca-services.ch/el4j/maven2repository</url>
 		</repository>
-
+    
+    <repository>
+      <snapshots>
+          <enabled>false</enabled>
+      </snapshots>
+      <releases>
+          <enabled>true</enabled>
+      </releases>
+      <id>Apache</id>
+      <name>External release repository of the Apache projects</name>
+      <url>https://repository.apache.org/content/groups/public/</url>
+    </repository>
 
 	</repositories>
 
 	<pluginRepositories>
 		<pluginRepository>
-			<id>collectionspace-plugins-remote-repos</id>
-			<name>collectionspace-plugins-remote-repos</name>
-			<url>http://nightly.collectionspace.org:8081/artifactory/plugins-remote-repos</url>
+			<id>collectionspace-remote-repos</id>
+			<name>collectionspace-remote-repos</name>
+			<url>http://nightly.collectionspace.org:8081/artifactory/remote-repos</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/services/common/pom.xml
+++ b/services/common/pom.xml
@@ -380,31 +380,6 @@
         </dependency>
     </dependencies>
 
-    <repositories>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <id>el4jReleaseRepositoryExternal</id>
-            <name>External release repository of the EL4J project</name>
-            <url>http://public-el4.elca-services.ch/el4j/maven2repository</url>
-        </repository>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <id>Apache</id>
-            <name>External release repository of the Apache projects</name>
-            <url>https://repository.apache.org/content/groups/public/</url>
-        </repository>
-    </repositories>
-
     <build>
         <finalName>collectionspace-services-common</finalName>
     	<defaultGoal>install</defaultGoal>

--- a/services/config/pom.xml
+++ b/services/config/pom.xml
@@ -60,20 +60,6 @@
 		</dependency>
     </dependencies>
 
-    <repositories>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <id>el4jReleaseRepositoryExternal</id>
-            <name>External release repository of the EL4J project</name>
-            <url>http://public-el4.elca-services.ch/el4j/maven2repository</url>
-        </repository>
-    </repositories>
-
     <build>
         <finalName>collectionspace-services-config</finalName>
     	<defaultGoal>install</defaultGoal>


### PR DESCRIPTION
...e project's top level POM. Move the repository reference to the project Maven repo's 'nuxeo-public' repo earlier, above two references to remote maven.nuxeo.org repos, to help ensure that cached copies of artifacts in the project repo are preferentially downloaded. Replace a non-existent pluginRepository reference.
