### PR TITLE
CSPACE-6129: When computing a Cataloging record's current location from ...

### DIFF
--- a/services/IntegrationTests/src/test/resources/test-data/xmlreplay/batch/batch-update-object-loc.xml
+++ b/services/IntegrationTests/src/test/resources/test-data/xmlreplay/batch/batch-update-object-loc.xml
@@ -7,6 +7,7 @@
     </auths>
         
     <!-- This tests the UpdateObjectLocationBatchJob -->
+    <!-- in various invocation modes -->
         
     <testGroup ID="invocationModeSingle" autoDeletePOSTS="true">
         
@@ -280,6 +281,207 @@
             <expectedCodes>200</expectedCodes>
         </test>
         
+    </testGroup>
+    
+    <testGroup ID="invocationModeSingleWithTiebreaker" autoDeletePOSTS="true">
+                    
+        <test ID="createBatchRecordWithTiebreaker">
+            <method>POST</method>
+            <uri>/cspace-services/batch</uri>
+            <filename>batch/batch-create-updateobjloc.xml</filename>
+            <expectedCodes>201</expectedCodes>
+        </test>
+                
+        <test ID="createCollectionObjectWithTiebreaker">
+            <method>POST</method>
+            <uri>/cspace-services/collectionobjects</uri>
+            <filename>batch/collObj1.xml</filename>
+            <expectedCodes>201</expectedCodes>
+        </test>
+        
+        <test ID="createMovement1WithTiebreaker">
+            <method>POST</method>
+            <uri>/cspace-services/movements</uri>
+            <filename>batch/movement.xml</filename>
+            <vars>
+                <var ID="currentLocation">location-1-with-tiebreaker</var>
+                <var ID="locationDate">1900-01-01</var>
+            </vars>
+            <expectedCodes>201</expectedCodes>
+        </test>
+        
+        <test ID="createMovement2WithTiebreaker">
+            <method>POST</method>
+            <uri>/cspace-services/movements</uri>
+            <filename>batch/movement.xml</filename>
+            <vars>
+                <var ID="currentLocation">location-2-with-tiebreaker</var>
+                <var ID="locationDate">${createMovement1WithTiebreaker.locationDate}</var>
+            </vars>
+            <expectedCodes>201</expectedCodes>
+        </test>
+        
+        <test ID="createMovement3WithTiebreaker">
+            <method>POST</method>
+            <uri>/cspace-services/movements</uri>
+            <filename>batch/movement.xml</filename>
+            <vars>
+                <var ID="currentLocation">location-3-with-tiebreaker</var>
+                <var ID="locationDate">${createMovement1WithTiebreaker.locationDate}</var>
+            </vars>
+            <expectedCodes>201</expectedCodes>
+        </test>
+        
+        <test ID="relateCollectionObjectToMovement1WithTiebreaker">
+            <method>POST</method>
+            <uri>/cspace-services/relations</uri>
+            <filename>batch/relation.xml</filename>
+            <vars>
+                <var ID="subjectCsid">${createCollectionObjectWithTiebreaker.CSID}</var>
+                <var ID="subjectDocumentType">CollectionObject</var>
+                <var ID="objectCsid">${createMovement1WithTiebreaker.CSID}</var>
+                <var ID="objectDocumentType">Movement</var>
+            </vars>
+            <expectedCodes>201</expectedCodes>
+        </test>
+        
+        <test ID="relateCollectionObjectToMovement2WithTiebreaker">
+            <method>POST</method>
+            <uri>/cspace-services/relations</uri>
+            <filename>batch/relation.xml</filename>
+            <vars>
+                <var ID="subjectCsid">${createCollectionObjectWithTiebreaker.CSID}</var>
+                <var ID="subjectDocumentType">CollectionObject</var>
+                <var ID="objectCsid">${createMovement2WithTiebreaker.CSID}</var>
+                <var ID="objectDocumentType">Movement</var>
+            </vars>
+            <expectedCodes>201</expectedCodes>
+        </test>
+         
+        <test ID="relateCollectionObjectToMovement3WithTiebreaker">
+            <method>POST</method>
+            <uri>/cspace-services/relations</uri>
+            <filename>batch/relation.xml</filename>
+            <vars>
+                <var ID="subjectCsid">${createCollectionObjectWithTiebreaker.CSID}</var>
+                <var ID="subjectDocumentType">CollectionObject</var>
+                <var ID="objectCsid">${createMovement3WithTiebreaker.CSID}</var>
+                <var ID="objectDocumentType">Movement</var>
+            </vars>
+            <expectedCodes>201</expectedCodes>
+        </test>
+
+        <test ID="modifyMovement1WithTiebreaker">
+            <method>PUT</method>
+            <uri>/cspace-services/movements/${createMovement1WithTiebreaker.CSID}</uri>
+            <filename>batch/movement.xml</filename>
+            <vars>
+                <var ID="currentLocation">location-1-modified-with-tiebreaker</var>
+                <var ID="locationDate">${createMovement1WithTiebreaker.locationDate}</var>
+            </vars>
+            <expectedCodes>200</expectedCodes>
+        </test>
+ 
+        <test ID="invokeBatchAfterMovement1ModificationWithTiebreaker" auth="test" autoDeletePOSTS="false">
+            <method>POST</method>
+            <uri>/cspace-services/batch/${createBatchRecordWithTiebreaker.CSID}</uri>
+            <filename>batch/batch-invoke-updateobjloc-single.xml</filename>
+            <vars>
+                <var ID="collectionObjectCSID">${createCollectionObjectWithTiebreaker.CSID}</var>
+            </vars>
+            <expectedCodes>200</expectedCodes>
+        </test> 
+        
+        <!-- Verify that, following the invocation of the batch job, the -->
+        <!-- computedCurrentLocation field in the CollectionObject record has -->
+        <!-- been updated to the appropriate value, reflecting the most recent -->
+        <!-- movement (e.g. the Movement record with the most recent locationDate, -->
+        <!-- and, as in this test group - where two Movement records have identical -->
+        <!-- locationDate values - the Movement record that has been updated most recently. -->
+        <test ID="readCollectionObjectAfterMovement1ModificationWithTiebreaker">
+            <method>GET</method>
+            <uri>/cspace-services/collectionobjects/${createCollectionObjectWithTiebreaker.CSID}</uri>
+            <filename>batch/updateobjloc.xml</filename>
+            <response>
+                <expected level="ADDOK" />
+                <filename>batch/res/collectionobject.res.xml</filename>
+                <vars>
+                    <var ID="computedCurrentLocationValue">${modifyMovement1WithTiebreaker.currentLocation}</var>
+                </vars>
+            </response>
+            <expectedCodes>200</expectedCodes>
+        </test>      
+
+        <test ID="modifyMovement2WithTiebreaker">
+            <method>PUT</method>
+            <uri>/cspace-services/movements/${createMovement2WithTiebreaker.CSID}</uri>
+            <filename>batch/movement.xml</filename>
+            <vars>
+                <var ID="currentLocation">location-2-modified-with-tiebreaker</var>
+                <var ID="locationDate">${createMovement1WithTiebreaker.locationDate}</var>
+            </vars>
+            <expectedCodes>200</expectedCodes>
+        </test>
+ 
+        <test ID="invokeBatchAfterMovement2ModificationWithTiebreaker" auth="test" autoDeletePOSTS="false">
+            <method>POST</method>
+            <uri>/cspace-services/batch/${createBatchRecordWithTiebreaker.CSID}</uri>
+            <filename>batch/batch-invoke-updateobjloc-single.xml</filename>
+            <vars>
+                <var ID="collectionObjectCSID">${createCollectionObjectWithTiebreaker.CSID}</var>
+            </vars>
+            <expectedCodes>200</expectedCodes>
+        </test> 
+        
+        <test ID="readCollectionObjectRecordAfterMovement2ModificationWithTiebreaker">
+            <method>GET</method>
+            <uri>/cspace-services/collectionobjects/${createCollectionObjectWithTiebreaker.CSID}</uri>
+            <filename>batch/updateobjloc.xml</filename>
+            <response>
+                <expected level="ADDOK" />
+                <filename>batch/res/collectionobject.res.xml</filename>
+                <vars>
+                    <var ID="computedCurrentLocationValue">${modifyMovement2WithTiebreaker.currentLocation}</var>
+                </vars>
+            </response>
+            <expectedCodes>200</expectedCodes>
+        </test>
+        
+        <test ID="modifyMovement3WithTiebreaker">
+            <method>PUT</method>
+            <uri>/cspace-services/movements/${createMovement3WithTiebreaker.CSID}</uri>
+            <filename>batch/movement.xml</filename>
+            <vars>
+                <var ID="currentLocation">location-3-modified-with-tiebreaker</var>
+                <var ID="locationDate">${createMovement1WithTiebreaker.locationDate}</var>
+            </vars>
+            <expectedCodes>200</expectedCodes>
+        </test>
+ 
+        <test ID="invokeBatchAfterMovement3ModificationWithTiebreaker" auth="test" autoDeletePOSTS="false">
+            <method>POST</method>
+            <uri>/cspace-services/batch/${createBatchRecordWithTiebreaker.CSID}</uri>
+            <filename>batch/batch-invoke-updateobjloc-single.xml</filename>
+            <vars>
+                <var ID="collectionObjectCSID">${createCollectionObjectWithTiebreaker.CSID}</var>
+            </vars>
+            <expectedCodes>200</expectedCodes>
+        </test> 
+        
+        <test ID="readCollectionObjectRecordAfterMovement3ModificationWithTiebreaker">
+            <method>GET</method>
+            <uri>/cspace-services/collectionobjects/${createCollectionObjectWithTiebreaker.CSID}</uri>
+            <filename>batch/updateobjloc.xml</filename>
+            <response>
+                <expected level="ADDOK" />
+                <filename>batch/res/collectionobject.res.xml</filename>
+                <vars>
+                    <var ID="computedCurrentLocationValue">${modifyMovement3WithTiebreaker.currentLocation}</var>
+                </vars>
+            </response>
+            <expectedCodes>200</expectedCodes>
+        </test>
+            
     </testGroup>
     
     <testGroup ID="invocationModeList" autoDeletePOSTS="true">


### PR DESCRIPTION
...related L/M/I (Movement) records, if two or more such records have identical location dates, use their update timestamps as a tiebreaker.
