### PR TITLE
CSPACE-6406: Fix infinite loop in LazyAuthorityRefDocList.java when page...

### DIFF
--- a/services/common/src/main/java/org/collectionspace/services/common/vocabulary/LazyAuthorityRefDocList.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/vocabulary/LazyAuthorityRefDocList.java
@@ -174,7 +174,7 @@ public class LazyAuthorityRefDocList extends DocumentModelListImpl {
 			
 			// The current page is exhausted.
 			
-			if (currentPageDocList.size() < pageSize) {
+			if (pageSize == 0 || (currentPageDocList.size() < pageSize)) { 
 				// There are no more pages.
 				return endOfData();
 			}


### PR DESCRIPTION
... size is 0.
