### PR TITLE
DRYD-562: Update default Elasticsearch configuration.

### DIFF
--- a/3rdparty/nuxeo/nuxeo-server/7.10-HF17/config/proto-elasticsearch-extension.xml
+++ b/3rdparty/nuxeo/nuxeo-server/7.10-HF17/config/proto-elasticsearch-extension.xml
@@ -1,175 +1,162 @@
-  <extension target="org.nuxeo.elasticsearch.ElasticSearchComponent"
-    point="elasticSearchIndex">
-    <elasticSearchIndex name="index_name_placeholder" type="doc" repository="repository_name_placeholder">
-      <fetchFromSource>
-        <include>ecm:*</include>
-        <include>dc:*</include>
-        <exclude>ecm:binarytext</exclude>
-      </fetchFromSource>
+<extension target="org.nuxeo.elasticsearch.ElasticSearchComponent" point="elasticSearchIndex">
+  <elasticSearchIndex name="index_name_placeholder" type="doc" repository="repository_name_placeholder">
+    <fetchFromSource>
+      <include>ecm:*</include>
+      <include>dc:*</include>
+      <exclude>ecm:binarytext</exclude>
+    </fetchFromSource>
 
-      <settings>
-{
-   "analysis" : {
-      "filter" : {
-         "en_stem_filter" : {
-            "name" : "minimal_english",
-            "type" : "stemmer"
-         },
-         "en_stop_filter" : {
-            "stopwords" : [
-               "_english_"
-            ],
-            "type" : "stop"
-         },
-         "fr_elision_filter" : {
-            "articles" : [
-               "c",
-               "l",
-               "m",
-               "t",
-               "qu",
-               "n",
-               "s",
-               "j"
-            ],
-            "type" : "elision"
-         },
-         "fr_stem_filter" : {
-            "name" : "minimal_french",
-            "type" : "stemmer"
-         },
-         "fr_stop_filter" : {
-            "stopwords" : [
-               "_french_"
-            ],
-            "type" : "stop"
-         }
-      },
-      "tokenizer" : {
-         "path_tokenizer" : {
-            "delimiter" : "/",
-            "type" : "path_hierarchy"
-         }
-      },
-      "analyzer" : {
-         "en_analyzer" : {
-            "alias" : "fulltext",
-            "filter" : [
-               "lowercase",
-               "en_stop_filter",
-               "en_stem_filter",
-               "asciifolding"
-            ],
-            "type" : "custom",
-            "tokenizer" : "standard"
-         },
-         "fr_analyzer" : {
-            "filter" : [
-               "lowercase",
-               "fr_stop_filter",
-               "fr_stem_filter",
-               "asciifolding",
-               "fr_elision_filter"
-            ],
-            "type" : "custom",
-            "tokenizer" : "standard"
-         },
-         "path_analyzer" : {
-            "type" : "custom",
-            "tokenizer" : "path_tokenizer"
-         },
-         "default" : {
-            "type" : "custom",
-            "tokenizer" : "keyword"
-         }
-      }
-   }
-}
-      </settings>
-      <mapping>
-{
-   "_size" : {
-      "enabled" : true
-   },
-   "_all" : {
-      "analyzer" : "fulltext"
-   },
-   "properties" : {
-      "dc:title" : {
-         "type" : "multi_field",
-         "fields" : {
-           "dc:title" : {
-             "index" : "not_analyzed",
-             "type" : "string"
-           },
-           "fulltext" : {
-             "boost": 2,
-             "type": "string",
-             "analyzer" : "fulltext"
-          }
-        }
-      },
-      "dc:description" : {
-         "type" : "multi_field",
-         "fields" : {
-           "dc:description" : {
-             "index" : "no",
-             "include_in_all" : "true",
-             "type" : "string"
-           },
-           "fulltext" : {
-             "boost": 1.5,
-             "type": "string",
-             "analyzer" : "fulltext"
-          }
-        }
-      },
-      "note:note" : {
-         "type" : "multi_field",
-         "fields" : {
-           "note:note" : {
-             "index" : "no",
-             "include_in_all" : "true",
-             "type" : "string"
-           },
-           "fulltext" : {
-             "type": "string",
-             "analyzer" : "fulltext"
-          }
-        }
-      },
-      "ecm:binarytext*" : {
-         "type" : "string",
-         "analyzer" : "fulltext"
-      },
-      "ecm:path" : {
-         "type" : "multi_field",
-         "fields" : {
-            "children" : {
-               "search_analyzer" : "keyword",
-               "index_analyzer" : "path_analyzer",
-               "type" : "string"
+    <settings>
+      {
+        "analysis" : {
+          "char_filter" : {
+            "refname_displayname" : {
+              "type" : "pattern_replace",
+              "pattern" : "^.*?'(.*)'$",
+              "replacement" : "$1"
             },
-            "ecm:path" : {
-               "index" : "not_analyzed",
-               "type" : "string"
+            "refname_shortid" : {
+              "type" : "pattern_replace",
+              "pattern" : "^.*:item:name\\((.*)\\).*$",
+              "replacement" : "$1"
+            },
+            "doctype_tenant_unqualified" : {
+              "type" : "pattern_replace",
+              "pattern" : "^(.*?)(Tenant.*)?$",
+              "replacement" : "$1"
             }
-         }
-      },
-      "ecm:pos": {
-         "type": "integer"
-      },
-      "dc:created": {
-         "format": "dateOptionalTime",
-        "type": "date"
-      },
-      "dc:modified": {
-         "format": "dateOptionalTime",
-        "type": "date"
+          },
+          "filter" : {
+            "en_stem_filter" : {
+              "name" : "minimal_english",
+              "type" : "stemmer"
+            },
+            "en_stop_filter" : {
+              "stopwords" : [
+                "_english_"
+              ],
+              "type" : "stop"
+            },
+            "fr_elision_filter" : {
+              "articles" : [
+                "c",
+                "l",
+                "m",
+                "t",
+                "qu",
+                "n",
+                "s",
+                "j"
+              ],
+              "type" : "elision"
+            },
+            "fr_stem_filter" : {
+              "name" : "minimal_french",
+              "type" : "stemmer"
+            },
+            "fr_stop_filter" : {
+              "stopwords" : [
+                "_french_"
+              ],
+              "type" : "stop"
+            }
+          },
+          "tokenizer" : {
+            "path_tokenizer" : {
+              "delimiter" : "/",
+              "type" : "path_hierarchy"
+            }
+          },
+          "analyzer" : {
+            "en_analyzer" : {
+              "alias" : "fulltext",
+              "filter" : [
+                "lowercase",
+                "en_stop_filter",
+                "en_stem_filter",
+                "asciifolding"
+              ],
+              "type" : "custom",
+              "tokenizer" : "standard"
+            },
+            "fr_analyzer" : {
+              "filter" : [
+                "lowercase",
+                "fr_stop_filter",
+                "fr_stem_filter",
+                "asciifolding",
+                "fr_elision_filter"
+              ],
+              "type" : "custom",
+              "tokenizer" : "standard"
+            },
+            "path_analyzer" : {
+              "type" : "custom",
+              "tokenizer" : "path_tokenizer"
+            },
+            "refname_displayname_analyzer" : {
+              "type" : "custom",
+              "tokenizer" : "keyword",
+              "char_filter" : ["refname_displayname"]
+            },
+            "refname_displayname_fulltext_analyzer" : {
+              "char_filter" : ["refname_displayname"],
+              "filter" : [
+                "lowercase",
+                "en_stop_filter",
+                "en_stem_filter",
+                "asciifolding"
+              ],
+              "type" : "custom",
+              "tokenizer" : "standard"
+            },
+            "refname_shortid_analyzer" : {
+              "type" : "custom",
+              "tokenizer" : "keyword",
+              "char_filter" : ["refname_shortid"]
+            },
+            "doctype_analyzer" : {
+              "type" : "custom",
+              "tokenizer" : "keyword",
+              "char_filter" : ["doctype_tenant_unqualified"]
+            },
+            "sorting_analyzer" : {
+              "filter" : [
+                "lowercase",
+                "asciifolding"
+              ],
+              "type" : "custom",
+              "tokenizer" : "keyword"
+            },
+            "default" : {
+              "type" : "custom",
+              "tokenizer" : "keyword"
+            }
+          }
+        }
       }
-   }
-}
-      </mapping>
+    </settings>
 
-    </elasticSearchIndex>
-  </extension>
+    <mapping>
+      {
+        "_size" : {
+          "enabled" : true
+        },
+        "_all" : {
+          "analyzer" : "fulltext"
+        },
+        "properties" : {
+          "ecm:currentLifeCycleState": {
+            "type": "string",
+            "include_in_all": "false"
+          },
+          "ecm:primaryType": {
+            "type": "string",
+            "analyzer" : "doctype_analyzer",
+            "include_in_all": "false"
+          }
+        }
+      }
+    </mapping>
+  </elasticSearchIndex>
+</extension>


### PR DESCRIPTION
Update the default Nuxeo Elasticsearch configuration in 3rdparty/nuxeo/nuxeo-server/7.10-HF17/config/proto-elasticsearch-extension.xml.

Add analyzers that are useful for cspace:

- analyzer to extract the display name from a ref name for indexing
- analyzer to extract the short id of a ref name for indexing
- analyzer to remove the tenant qualification from a doctype when indexing
- analyzer to lowercase and ascii-fold a value, for case- and accent-insensitive sorting

Remove mappings for fields that are not used by cspace, like all dc and some ecm fields.

