### PR TITLE
Remove data source binding errors in logs on cspace startup.

### DIFF
--- a/3rdparty/nuxeo/build.xml
+++ b/3rdparty/nuxeo/build.xml
@@ -134,6 +134,7 @@
         <copy todir="${jee.server.cspace}/cspace/config/services" overwrite="true">
             <fileset file="${basedir}/nuxeo-server/${nuxeo.release}/config/proto-datasource-config.xml"/>
             <filterset>
+                <filter token="JDBC_DEFAULT_DATASOURCE" value="${db.jdbc.default.datasource}"/>
                 <filter token="DB_SERVER_HOSTNAME" value="${db.host}"/>
                 <filter token="DB_PORT" value="${db.port}"/>
                 <filter token="DB_JDBC_OPTIONS" value="${db.jdbc.urloptions.encoded}"/>

--- a/3rdparty/nuxeo/nuxeo-server/7.10-HF17/config/proto-datasource-config.xml
+++ b/3rdparty/nuxeo/nuxeo-server/7.10-HF17/config/proto-datasource-config.xml
@@ -13,17 +13,17 @@
 	<!--
 		These links need to be moved into the context.xml file and become <Resource> instead of <link>
 	-->
-    <link name="jdbc/repository_default" global="jdbc/default" type="javax.sql.DataSource" />
-    <link name="jdbc/repository_default" global="jdbc/default" type="javax.sql.DataSource"/>
-    <link name="jdbc/NuxeoDS" global="jdbc/default" type="javax.sql.DataSource" />
-    <link name="jdbc/nxsqldirectory" global="jdbc/default" type="javax.sql.DataSource" />
-    <link name="jdbc/nxrelations-default-jena" global="jdbc/default" type="javax.sql.DataSource" />
-    <link name="jdbc/comment-relations" global="jdbc/default" type="javax.sql.DataSource" />
-    <link name="jdbc/nxaudit-logs" global="jdbc/default" type="javax.sql.DataSource" />
-    <link name="jdbc/nxjbpm" global="jdbc/default" type="javax.sql.DataSource" />
-    <link name="jdbc/placeful_service_ds" global="jdbc/default" type="javax.sql.DataSource" />
-    <link name="jdbc/nxwebwidgets" global="jdbc/default" type="javax.sql.DataSource" />
-    <link name="jdbc/nxuidsequencer" global="jdbc/default" type="javax.sql.DataSource" />
+    <link name="jdbc/repository_default" global="@JDBC_DEFAULT_DATASOURCE@" type="javax.sql.DataSource" />
+    <link name="jdbc/repository_default" global="@JDBC_DEFAULT_DATASOURCE@" type="javax.sql.DataSource"/>
+    <link name="jdbc/NuxeoDS" global="@JDBC_DEFAULT_DATASOURCE@" type="javax.sql.DataSource" />
+    <link name="jdbc/nxsqldirectory" global="@JDBC_DEFAULT_DATASOURCE@" type="javax.sql.DataSource" />
+    <link name="jdbc/nxrelations-default-jena" global="@JDBC_DEFAULT_DATASOURCE@" type="javax.sql.DataSource" />
+    <link name="jdbc/comment-relations" global="@JDBC_DEFAULT_DATASOURCE@" type="javax.sql.DataSource" />
+    <link name="jdbc/nxaudit-logs" global="@JDBC_DEFAULT_DATASOURCE@" type="javax.sql.DataSource" />
+    <link name="jdbc/nxjbpm" global="@JDBC_DEFAULT_DATASOURCE@" type="javax.sql.DataSource" />
+    <link name="jdbc/placeful_service_ds" global="@JDBC_DEFAULT_DATASOURCE@" type="javax.sql.DataSource" />
+    <link name="jdbc/nxwebwidgets" global="@JDBC_DEFAULT_DATASOURCE@" type="javax.sql.DataSource" />
+    <link name="jdbc/nxuidsequencer" global="@JDBC_DEFAULT_DATASOURCE@" type="javax.sql.DataSource" />
 	
 	<!-- These properties are passed into the CSpace code that generates the final version
 	of this Nuxeo configuration file.

--- a/build.properties
+++ b/build.properties
@@ -161,6 +161,15 @@ db.host=${env.DB_HOST}
 db.jdbc.baseurl=jdbc:${db}://${db.host}:${db.port}
 
 #
+# Used for misc Nuxeo services, plugins, and extensions
+#
+# Single tenant deployments of CollectionSpace, should set this to the datasource name
+# in the tenant's datasource config file found in the tomcat7/nuxeo-server/config directory.  For example,
+# "jdbc/cinefiles_domain" for the UCB cinefiles deployment.
+#
+db.jdbc.default.datasource=jdbc/cinefiles_domain
+
+#
 # JDBC options that can be added to the database URL.  We need to supply an "encoded" version
 # of the options for cases where the URL is processed inside of XML scripts/files
 #

--- a/build.properties
+++ b/build.properties
@@ -167,7 +167,7 @@ db.jdbc.baseurl=jdbc:${db}://${db.host}:${db.port}
 # in the tenant's datasource config file found in the tomcat7/nuxeo-server/config directory.  For example,
 # "jdbc/cinefiles_domain" for the UCB cinefiles deployment.
 #
-db.jdbc.default.datasource=jdbc/cinefiles_domain
+db.jdbc.default.datasource=jdbc/default
 
 #
 # JDBC options that can be added to the database URL.  We need to supply an "encoded" version


### PR DESCRIPTION
Adding a build property to override Nuxeo's default JDBC datasource value of "jdbc/default".