### PR TITLE
DRYD-878: Added support for older run method to prevent a required version bump.

### DIFF
--- a/services/batch/service/src/main/java/org/collectionspace/services/batch/AbstractBatchInvocable.java
+++ b/services/batch/service/src/main/java/org/collectionspace/services/batch/AbstractBatchInvocable.java
@@ -235,4 +235,10 @@ public abstract class AbstractBatchInvocable implements BatchInvocable {
 
     @Override
     public abstract void run();
+    
+	@Override
+	public void run(BatchCommon batchCommon) {
+		throw new UnsupportedOperationException("This CollectionSpace batch-job/data-update class does not support the 'public void run(BatchCommon batchCommon)' method.");
+	}
+
 }

--- a/services/batch/service/src/main/java/org/collectionspace/services/batch/AbstractBatchInvocable.java
+++ b/services/batch/service/src/main/java/org/collectionspace/services/batch/AbstractBatchInvocable.java
@@ -235,10 +235,13 @@ public abstract class AbstractBatchInvocable implements BatchInvocable {
 
     @Override
     public abstract void run();
-    
+
+	/**
+	 * Subclasses should override this method.  See DRYD-878
+	 */
 	@Override
 	public void run(BatchCommon batchCommon) {
-		throw new UnsupportedOperationException("This CollectionSpace batch-job/data-update class does not support the 'public void run(BatchCommon batchCommon)' method.");
+		String errMsg = String.format("%s class does not support run(BatchCommon batchCommon) method.", getClass().getName());
+		throw new java.lang.UnsupportedOperationException(errMsg);
 	}
-
 }

--- a/services/batch/service/src/main/java/org/collectionspace/services/batch/nuxeo/AbstractBatchJob.java
+++ b/services/batch/service/src/main/java/org/collectionspace/services/batch/nuxeo/AbstractBatchJob.java
@@ -69,15 +69,6 @@ public abstract class AbstractBatchJob extends AbstractBatchInvocable {
         return (Set<T>) list.stream().collect(Collectors.toSet());
     }
 
-	/**
-	 * Subclasses should override this method.  See DRYD-878
-	 */
-	@Override
-	public void run(BatchCommon batchCommon) {
-		String errMsg = String.format("%s class does not support run(BatchCommon batchCommon) method.", getClass().getName());
-		throw new java.lang.UnsupportedOperationException(errMsg);
-	}
-
 	protected String getFieldXml(Map<String, String> fields, String fieldName) {
 		return getFieldXml(fieldName, fields.get(fieldName));
 	}

--- a/services/batch/service/src/main/java/org/collectionspace/services/batch/nuxeo/AbstractBatchJob.java
+++ b/services/batch/service/src/main/java/org/collectionspace/services/batch/nuxeo/AbstractBatchJob.java
@@ -69,6 +69,9 @@ public abstract class AbstractBatchJob extends AbstractBatchInvocable {
         return (Set<T>) list.stream().collect(Collectors.toSet());
     }
 
+	/**
+	 * Subclasses should override this method.  See DRYD-878
+	 */
 	@Override
 	public void run(BatchCommon batchCommon) {
 		String errMsg = String.format("%s class does not support run(BatchCommon batchCommon) method.", getClass().getName());

--- a/services/batch/service/src/main/java/org/collectionspace/services/batch/nuxeo/BatchDocumentModelHandler.java
+++ b/services/batch/service/src/main/java/org/collectionspace/services/batch/nuxeo/BatchDocumentModelHandler.java
@@ -296,7 +296,14 @@ public class BatchDocumentModelHandler extends NuxeoDocumentModelHandler<BatchCo
 				}
 			}
 
-			batchInstance.run(batchCommon);
+			try {
+				batchInstance.run(batchCommon);
+			} catch (UnsupportedOperationException t) {
+				// Support for run() will be deprecated in a future release.  See DRYD-878
+				logger.debug(t.getMessage());
+				batchInstance.run();
+			}
+
 			int status = batchInstance.getCompletionStatus();
 			if (status == Invocable.STATUS_ERROR) {
 				InvocationError error = batchInstance.getErrorInfo();

--- a/services/batch/service/src/main/java/org/collectionspace/services/batch/nuxeo/BatchDocumentModelHandler.java
+++ b/services/batch/service/src/main/java/org/collectionspace/services/batch/nuxeo/BatchDocumentModelHandler.java
@@ -300,7 +300,7 @@ public class BatchDocumentModelHandler extends NuxeoDocumentModelHandler<BatchCo
 				batchInstance.run(batchCommon);
 			} catch (UnsupportedOperationException t) {
 				// Support for run() will be deprecated in a future release.  See DRYD-878
-				logger.debug(t.getMessage());
+				logger.info(t.getMessage());
 				batchInstance.run();
 			}
 

--- a/services/batch/service/src/main/java/org/collectionspace/services/batch/nuxeo/TestBatchJob.java
+++ b/services/batch/service/src/main/java/org/collectionspace/services/batch/nuxeo/TestBatchJob.java
@@ -3,7 +3,6 @@ package org.collectionspace.services.batch.nuxeo;
 import java.util.Arrays;
 
 import org.collectionspace.services.batch.AbstractBatchInvocable;
-import org.collectionspace.services.batch.BatchCommon;
 
 public class TestBatchJob extends AbstractBatchInvocable {
 
@@ -16,10 +15,5 @@ public class TestBatchJob extends AbstractBatchInvocable {
 	@Override
 	public void run() {
 		// An empty batch job used just for testing.
-	}
-	
-	@Override
-	public void run(BatchCommon batchCommon) {
-		// An empty batch job used just for testing.
-	}
+	}	
 }


### PR DESCRIPTION
See DRYD-878.  This update provides backward compatibility with batch jobs written for <= v6.0.