### PR TITLE
DRYD-961 - Added code to prevent more than one contact per authority term.

### DIFF
--- a/services/IntegrationTests/src/main/resources/log4j2-surefire.xml
+++ b/services/IntegrationTests/src/main/resources/log4j2-surefire.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+	This config is used by the maven surefire plugin (for tests), as configured in services/pom.xml.
+	For runtime logging config, see services/JaxRsServiceProvider/src/main/resources/log4j2.xml.
+-->
+<Configuration status="WARN">
+	<Properties>
+		<Property name="logPattern">%d %-5p [%t] [%c:%L] %m%n</Property>
+	</Properties>
+
+	<Appenders>
+		<Console name="ConsoleAppender" target="SYSTEM_OUT">
+			<PatternLayout pattern="${logPattern}" />
+		</Console>
+
+		<File name="LogFileAppender" append="false" fileName="target/test.log">
+			<PatternLayout pattern="${logPattern}" />
+		</File>
+	</Appenders>
+
+	<Loggers>
+		<Root level="DEBUG">
+			<AppenderRef ref="ConsoleAppender"/>
+			<AppenderRef ref="LogFileAppender" />
+		</Root>
+
+		<Logger name="httpclient" level="INFO" />
+		<Logger name="org.apache" level="INFO" />
+		<Logger name="org.collectionspace.services.client.PoxPayloadIn" level="DEBUG" />
+		<Logger name="org.collectionspace.services.client.PoxPayloadOut" level="DEBUG" />
+		<Logger name="org.collectionspace" level="DEBUG" />
+		<Logger name="org.jboss.resteasy" level="INFO" />
+	</Loggers>
+</Configuration>

--- a/services/IntegrationTests/src/test/resources/test-data/xmlreplay/authority/authority.xml
+++ b/services/IntegrationTests/src/test/resources/test-data/xmlreplay/authority/authority.xml
@@ -1,11 +1,80 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xmlReplay>
     
-    <auths>
 	<!-- IMPORTANT: THESE ARE STICKY :: THEY STICK AROUND UNTIL RESET, IN EXEC ORDER OF THIS FILE. -->
+    <auths default="admin@core.collectionspace.org">
         <auth ID="admin@core.collectionspace.org">YWRtaW5AY29yZS5jb2xsZWN0aW9uc3BhY2Uub3JnOkFkbWluaXN0cmF0b3I=</auth>
     </auths>
-        
+
+    <testGroup ID="TestAuthorityItemsWithContacts" autoDeletePOSTS="true" expectedCodesStrict="true">
+        <test ID="createPersonAuthority1" auth="admin@core.collectionspace.org">
+            <expectedCodes>201</expectedCodes>
+            <method>POST</method>
+            <uri>/cspace-services/personauthorities</uri>
+            <filename>authority/personauthority.xml</filename>
+            <vars>
+                <!-- Nonsense words to build short identifiers and display -->
+                <!-- names, and to populate text field(s). -->
+                <var ID="word1">word_1111</var>
+                <var ID="word2">word_2222</var>
+                <var ID="word3">word_3333</var>
+                <var ID="word4">word_4444</var>
+                <var ID="word5">word_555</var>
+                <!-- Partial term searches using one or more of those words. -->
+                <var ID="word1PartialTermStem">stem_111</var>
+                <var ID="word2PartialTermStem">stem_222</var>
+                <var ID="word2PartialTermMid">stem_333</var>
+                <!-- Populate the current record with those words. -->
+                <var ID="authDisplayName">display_name2</var>
+                <var ID="authShortIdentifier">short_id_value2</var>
+            </vars>
+        </test>
+        <test ID="personitemWithContact1">
+            <expectedCodes>201</expectedCodes>
+            <method>POST</method>
+            <uri>/cspace-services/personauthorities/${createPersonAuthority1.CSID}/items</uri>
+            <filename>authority/personitemWithContact1.xml</filename>
+            <vars>
+                <var ID="itemDisplayName">${createPersonAuthority1.word1} ${createPersonAuthority1.word2}</var>
+                <var ID="itemShortIdentifier">${createPersonAuthority1.word1}item1</var>
+                <var ID="itemBioNote">A bio note for this Person.</var>
+                <var ID="emailAddress">${createPersonAuthority1.word1}@${createPersonAuthority1.word2}.com</var>
+            </vars>
+        </test>
+        <test ID="getPersonitemWithContact1ContactList">
+            <expectedCodes>200</expectedCodes>
+            <method>GET</method>
+            <uri>/cspace-services/personauthorities/${createPersonAuthority1.CSID}/items/${personitemWithContact1.CSID}/contacts</uri>
+            <response>
+                <expected level="TEXT"/>
+                <filename>authority/res/contactItems.res.xml</filename>
+                <vars>
+                	<var ID="emailAddress">${createPersonAuthority1.word1}@${createPersonAuthority1.word2}.com</var>
+                </vars>
+            </response>
+        </test>
+        <test ID="personitemWithContact2">
+            <expectedCodes>400</expectedCodes>
+            <method>POST</method>
+            <uri>/cspace-services/personauthorities/${createPersonAuthority1.CSID}/items</uri>
+            <filename>authority/personitemWithContact2.xml</filename>
+            <vars>
+                <var ID="itemDisplayName">${createPersonAuthority1.word2} ${createPersonAuthority1.word2}</var>
+                <var ID="itemShortIdentifier">${createPersonAuthority2.word2}item2</var>
+                <var ID="itemBioNote">A bio note for this Person with two contacts.</var>
+            </vars>
+        </test>
+        <test ID="contactSubresource">
+            <expectedCodes>409</expectedCodes>
+            <method>POST</method>
+            <uri>/cspace-services/personauthorities/${createPersonAuthority1.CSID}/items/${personitemWithContact1.CSID}/contacts</uri>
+            <filename>authority/contactSubresource.xml</filename>
+            <vars>
+                <var ID="emailAddress">${createPersonAuthority1.word1}@${createPersonAuthority1.word2}.net</var>
+            </vars>
+        </test>
+ 	</testGroup>
+	
     <testGroup ID="TestAuthoritiesMultiVocabSearch" autoDeletePOSTS="true">
         
         <!--

--- a/services/IntegrationTests/src/test/resources/test-data/xmlreplay/authority/contactSubresource.xml
+++ b/services/IntegrationTests/src/test/resources/test-data/xmlreplay/authority/contactSubresource.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<document name="contacts">
+    <ns2:contacts_common xmlns:ns2="http://collectionspace.org/services/contact" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <emailGroupList>
+            <emailGroup>
+                <emailType>business</emailType>
+                <email>richard@ronny.com</email>
+            </emailGroup>
+        </emailGroupList>
+    </ns2:contacts_common>
+</document>

--- a/services/IntegrationTests/src/test/resources/test-data/xmlreplay/authority/personitemWithContact1.xml
+++ b/services/IntegrationTests/src/test/resources/test-data/xmlreplay/authority/personitemWithContact1.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<document name="persons">
+    <ns2:persons_common xmlns:ns2="http://collectionspace.org/services/person" xmlns:ns3="http://collectionspace.org/services/jaxb">
+        <personTermGroupList>
+            <personTermGroup>
+                <termDisplayName>${itemDisplayName}</termDisplayName>
+            </personTermGroup>   
+        </personTermGroupList>
+        <shortIdentifier>${itemShortIdentifier}</shortIdentifier>
+        <bioNote>${itemBioNote}</bioNote>
+        <foreName>${itemDisplayName}</foreName>
+    </ns2:persons_common>
+    <ns2:contacts_common xmlns:ns2="http://collectionspace.org/services/contact">
+        <emailGroupList>
+            <emailGroup>
+                <email>${emailAddress}</email>
+                <emailType>business</emailType>
+            </emailGroup>
+        </emailGroupList>
+    </ns2:contacts_common>
+</document>

--- a/services/IntegrationTests/src/test/resources/test-data/xmlreplay/authority/personitemWithContact2.xml
+++ b/services/IntegrationTests/src/test/resources/test-data/xmlreplay/authority/personitemWithContact2.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<document name="persons">
+    <ns2:persons_common xmlns:ns2="http://collectionspace.org/services/person" xmlns:ns3="http://collectionspace.org/services/jaxb">
+        <personTermGroupList>
+            <personTermGroup>
+                <termDisplayName>${itemDisplayName}</termDisplayName>
+            </personTermGroup>   
+        </personTermGroupList>
+        <shortIdentifier>${itemShortIdentifier}</shortIdentifier>
+        <bioNote>${itemBioNote}</bioNote>
+        <foreName>${itemDisplayName}</foreName>
+    </ns2:persons_common>
+    <ns2:contacts_common xmlns:ns2="http://collectionspace.org/services/contact">
+        <emailGroupList>
+            <emailGroup>
+                <email>abc@town.com</email>
+                <emailType>business</emailType>
+            </emailGroup>
+        </emailGroupList>
+    </ns2:contacts_common>
+    <ns2:contacts_common xmlns:ns2="http://collectionspace.org/services/contact">
+        <emailGroupList>
+            <emailGroup>
+                <email>def@town.com</email>
+                <emailType>business</emailType>
+            </emailGroup>
+        </emailGroupList>
+    </ns2:contacts_common>    
+</document>

--- a/services/IntegrationTests/src/test/resources/test-data/xmlreplay/authority/res/contactItems.res.xml
+++ b/services/IntegrationTests/src/test/resources/test-data/xmlreplay/authority/res/contactItems.res.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns2:abstract-common-list xmlns:ns2="http://collectionspace.org/services/jaxb">
+    <itemsInPage>1</itemsInPage>
+    <fieldsReturned>csid|uri|refName|updatedAt|workflowState|displayName</fieldsReturned>
+    <list-item>
+        <workflowState>project</workflowState>
+        <displayName>${emailAddress}</displayName>
+    </list-item>
+</ns2:abstract-common-list>

--- a/services/IntegrationTests/src/test/resources/test-data/xmlreplay/authority/res/personItemsWithContact.res.xml
+++ b/services/IntegrationTests/src/test/resources/test-data/xmlreplay/authority/res/personItemsWithContact.res.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns2:abstract-common-list xmlns:ns2="http://collectionspace.org/services/jaxb">
+    <pageNum>0</pageNum>
+    <pageSize>${numItems}</pageSize>
+    <itemsInPage>${numItems}</itemsInPage>
+</ns2:abstract-common-list>
+

--- a/services/IntegrationTests/src/test/resources/test-data/xmlreplay/xml-replay-master.xml
+++ b/services/IntegrationTests/src/test/resources/test-data/xmlreplay/xml-replay-master.xml
@@ -43,6 +43,7 @@
     <run controlFile="authrefs/authrefsSimple.xml" testGroup="AuthRefsSimple" />
     <run controlFile="authrefs/authrefsComplex.xml" testGroup="AuthRefsComplex" />
     <run controlFile="authority/authority.xml" testGroup="TestAuthoritiesMultiVocabSearch" />
+	<run controlFile="authority/authority.xml" testGroup="TestAuthorityItemsWithContacts" />
     
     <run controlFile="imports/imports.xml" testGroup="importsTestGroup" />
     <run controlFile="imports/imports.xml" testGroup="importsSeparateRepoTestGroup" />

--- a/services/organization/client/src/test/java/org/collectionspace/services/client/test/OrgAuthorityServiceTest.java
+++ b/services/organization/client/src/test/java/org/collectionspace/services/client/test/OrgAuthorityServiceTest.java
@@ -65,7 +65,8 @@ import org.testng.annotations.Test;
  */
 public class OrgAuthorityServiceTest extends AbstractAuthorityServiceTest<OrgauthoritiesCommon, OrganizationsCommon> {
 
-    /** The logger. */
+    private static final int MAX_CONTACTS = 1;
+	/** The logger. */
     private final String CLASS_NAME = OrgAuthorityServiceTest.class.getName();
     private final Logger logger = LoggerFactory.getLogger(CLASS_NAME);
 
@@ -270,21 +271,6 @@ public class OrgAuthorityServiceTest extends AbstractAuthorityServiceTest<Orgaut
         allContactResourceIdsCreated.put(newID, itemcsid);
 
         return newID;
-    }
-
-    /**
-     * Creates the contact list.
-     *
-     * @param testName the test name
-     * @throws Exception the exception
-     */
-    @Test(dataProvider = "testName", groups = {"createList"},
-    		dependsOnMethods = {"createItemList"})
-    public void createContactList(String testName) throws Exception {
-        // Add contacts to the initially-created, known item record.
-        for (int j = 0; j < nItemsToCreateInList; j++) {
-            createContact(testName);
-        }
     }
 
     // ---------------------------------------------------------------
@@ -712,7 +698,7 @@ public class OrgAuthorityServiceTest extends AbstractAuthorityServiceTest<Orgaut
         // In addition, there will be 'nItemsToCreateInList'
         // additional items created by the createItemList test,
         // all associated with the same parent resource.
-        int nExpectedItems = nItemsToCreateInList + 1;
+        int nExpectedItems = MAX_CONTACTS;
         if (logger.isDebugEnabled()) {
             logger.debug(testName + ": Expected "
                     + nExpectedItems + " items; got: " + nItemsReturned);

--- a/services/person/client/src/test/java/org/collectionspace/services/client/test/PersonAuthorityServiceTest.java
+++ b/services/person/client/src/test/java/org/collectionspace/services/client/test/PersonAuthorityServiceTest.java
@@ -66,6 +66,9 @@ public class PersonAuthorityServiceTest extends AbstractAuthorityServiceTest<Per
     private final String CLASS_NAME = PersonAuthorityServiceTest.class.getName();
     private final Logger logger = LoggerFactory.getLogger(CLASS_NAME);
     
+    // number of contacts supported by the Services API
+    private static final int MAX_CONTACTS = 1;
+    
     /**
      * Default constructor.  Used to set the short ID for all tests authority items
      */
@@ -510,21 +513,6 @@ public class PersonAuthorityServiceTest extends AbstractAuthorityServiceTest<Per
         }
     }
 
-    /**
-     * Creates the contact list.
-     *
-     * @param testName the test name
-     * @throws Exception the exception
-     */
-    @Test(dataProvider = "testName", groups = {"createList"},
-    		dependsOnMethods = {"org.collectionspace.services.client.test.AbstractAuthorityServiceTest.createItemList"})
-    public void createContactList(String testName) throws Exception {
-        // Add contacts to the initially-created, known item record.
-        for (int j = 0; j < nItemsToCreateInList; j++) {
-            createContact(testName);
-        }
-    }
-
     // ---------------------------------------------------------------
     // CRUD tests : READ tests
     // ---------------------------------------------------------------
@@ -849,7 +837,7 @@ public class PersonAuthorityServiceTest extends AbstractAuthorityServiceTest<Per
         // In addition, there will be 'nItemsToCreateInList'
         // additional items created by the createItemList test,
         // all associated with the same parent resource.
-        int nExpectedItems = nItemsToCreateInList + 1;
+        int nExpectedItems = MAX_CONTACTS;
         if (logger.isDebugEnabled()) {
             logger.debug(testName + ": Expected "
                     + nExpectedItems + " items; got: " + nItemsReturned);

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -15,7 +15,7 @@
 	<properties>
 		<annox.version>0.5.0</annox.version>
 		<jaxb2-basics.version>0.6.2</jaxb2-basics.version>
-		<maven-jaxb2-plugin.version>0.13.1</maven-jaxb2-plugin.version>
+		<maven-jaxb2-plugin.version>0.13.3</maven-jaxb2-plugin.version>
 		<jaxb.version>2.2.11</jaxb.version>
 		<resteasy.version>3.0.19.Final</resteasy.version>
 		<mysql.driver.version>5.1.8</mysql.driver.version>


### PR DESCRIPTION
DRYD-961 - Added code to prevent more than one contact per authority term.  Also, added new XMLReplay unit tests and adjusted existing Surefire tests.