### PR TITLE
DRYD-1194: Updating main pom to use https (vs http)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 
 		<repository>
 			<id>nuxeo-public-releases</id>
-			<url>http://maven-eu.nuxeo.org/nexus/content/repositories/public-releases</url>
+			<url>https://maven-eu.nuxeo.org/nexus/content/repositories/public-releases</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -72,7 +72,7 @@
 
 		<repository>
 			<id>nuxeo-vendor-releases</id>
-			<url>http://maven-eu.nuxeo.org/nexus/content/repositories/vendor-releases</url>
+			<url>https://maven-eu.nuxeo.org/nexus/content/repositories/vendor-releases</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -102,7 +102,7 @@
 			<!-- Global Biodiversity Information Facility - http://www.gbif.org/ -->
 			<id>gbif-all</id>
 			<name>gbif-all</name>
-			<url>http://repository.gbif.org/content/groups/gbif</url>
+			<url>https://repository.gbif.org/content/groups/gbif</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>


### PR DESCRIPTION
When using maven 3.8.1+, the build of the services layer fails.

The issue appears to be that as of maven 3.8.1, maven no longer allows http addresses for repositories.