### PR TITLE
DRYD-1145: Get version info from implementation version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,6 +210,28 @@
 				</plugin>
 
 				<plugin>
+					<groupId>pl.project13.maven</groupId>
+					<artifactId>git-commit-id-plugin</artifactId>
+					<version>4.9.10</version>
+					<executions>
+						<execution>
+							<goals>
+								<goal>revision</goal>
+							</goals>
+							<phase>initialize</phase>
+						</execution>
+					</executions>
+					<configuration>
+						<generateGitPropertiesFile>true</generateGitPropertiesFile>
+						<generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+						<includeOnlyProperties>
+							<includeOnlyProperty>^git.commit.id.abbrev$</includeOnlyProperty>
+						</includeOnlyProperties>
+						<commitIdGenerationMode>full</commitIdGenerationMode>
+					</configuration>
+				</plugin>
+
+				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-dependency-plugin</artifactId>
 					<executions>
@@ -370,6 +392,11 @@
                     </files>
                 </configuration>
             </plugin>
+
+			<plugin>
+				<groupId>pl.project13.maven</groupId>
+				<artifactId>git-commit-id-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,8 @@
 						<archive>
 							<manifest>
 								<addClasspath>true</addClasspath>
+								<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+								<addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
 							</manifest>
 						</archive>
 					</configuration>
@@ -197,6 +199,14 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
 					<version>2.2</version>
+					<configuration>
+						<archive>
+							<manifest>
+								<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+								<addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+							</manifest>
+						</archive>
+					</configuration>
 				</plugin>
 
 				<plugin>

--- a/services/common/src/main/java/org/collectionspace/services/common/ServiceMain.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/ServiceMain.java
@@ -75,10 +75,6 @@ public class ServiceMain {
 	final static Logger logger = LoggerFactory.getLogger(ServiceMain.class);
 
 	public static final String VER_DISPLAY_NAME = "CollectionSpace Services v7.1";
-	public static final String VER_MAJOR = "7";
-	public static final String VER_MINOR = "1";
-	public static final String VER_PATCH = "0";
-	public static final String VER_BUILD = "1";
 
 	private static final int PRIMARY_REPOSITORY_DOMAIN = 0;
 
@@ -1045,7 +1041,7 @@ public class ServiceMain {
 	}
 
 	private void initRepositoryDatabaseVersion(String dataSourceName, String repositoryName, String cspaceInstanceId) throws Exception {
-		String version = ServiceMain.VER_MAJOR + "." + ServiceMain.VER_MINOR + "." + ServiceMain.VER_PATCH;
+		String version = getClass().getPackage().getImplementationVersion();
 		Connection conn = null;
 
 		try {

--- a/services/common/src/main/java/org/collectionspace/services/common/ServiceMain.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/ServiceMain.java
@@ -74,7 +74,6 @@ import org.slf4j.LoggerFactory;
 public class ServiceMain {
 	final static Logger logger = LoggerFactory.getLogger(ServiceMain.class);
 
-	public static final String VER_DISPLAY_NAME = "CollectionSpace Services v7.1";
 
 	private static final int PRIMARY_REPOSITORY_DOMAIN = 0;
 

--- a/services/systeminfo/service/src/main/java/org/collectionspace/services/systeminfo/SystemInfoResource.java
+++ b/services/systeminfo/service/src/main/java/org/collectionspace/services/systeminfo/SystemInfoResource.java
@@ -28,6 +28,7 @@ import org.collectionspace.services.common.security.UnauthorizedException;
 @Consumes({"application/xml"})
 public class SystemInfoResource extends AbstractCollectionSpaceResourceImpl<SystemInfoCommon, SystemInfoCommon> {
 
+    private static final String VER_DISPLAY_NAME = "CollectionSpace Services v%s.%s";
     private static final int MAJOR_IDX = 0;
     private static final int MINOR_IDX = 1;
     private static final int PATCH_IDX = 2;
@@ -58,12 +59,13 @@ public class SystemInfoResource extends AbstractCollectionSpaceResourceImpl<Syst
         SystemInfoCommon result;
 
         try {
-            result = new SystemInfoCommon();
-            result.setInstanceId(ServiceMain.getInstance().getCspaceInstanceId());
-            result.setDisplayName(ServiceMain.VER_DISPLAY_NAME);
-
             String packageVersion = SystemInfoResource.class.getPackage().getImplementationVersion();
             String[] versionParts = packageVersion.split("\\.");
+
+            result = new SystemInfoCommon();
+            result.setInstanceId(ServiceMain.getInstance().getCspaceInstanceId());
+            result.setDisplayName(String.format(VER_DISPLAY_NAME, versionParts[MAJOR_IDX], versionParts[MINOR_IDX]));
+
             Version ver = new Version();
             ver.setMajor(versionParts[MAJOR_IDX]);
             ver.setMinor(versionParts[MINOR_IDX]);

--- a/services/systeminfo/service/src/main/java/org/collectionspace/services/systeminfo/SystemInfoResource.java
+++ b/services/systeminfo/service/src/main/java/org/collectionspace/services/systeminfo/SystemInfoResource.java
@@ -3,24 +3,21 @@ package org.collectionspace.services.systeminfo;
 import java.nio.charset.Charset;
 import java.util.Locale;
 import java.util.TimeZone;
-
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
-import javax.ws.rs.HttpMethod;
 
 import org.collectionspace.services.authorization.AuthZ;
-import org.collectionspace.services.authorization.CSpaceAction;
 import org.collectionspace.services.authorization.CSpaceResource;
 import org.collectionspace.services.authorization.URIResourceImpl;
 import org.collectionspace.services.common.AbstractCollectionSpaceResourceImpl;
 import org.collectionspace.services.common.CSWebApplicationException;
 import org.collectionspace.services.common.ServiceMain;
-import org.collectionspace.services.common.UriInfoWrapper;
 import org.collectionspace.services.common.context.RemoteServiceContextFactory;
 import org.collectionspace.services.common.context.ServiceContext;
 import org.collectionspace.services.common.context.ServiceContextFactory;
@@ -31,74 +28,80 @@ import org.collectionspace.services.common.security.UnauthorizedException;
 @Consumes({"application/xml"})
 public class SystemInfoResource extends AbstractCollectionSpaceResourceImpl<SystemInfoCommon, SystemInfoCommon> {
 
-	@Override
-	public Class<?> getCommonPartClass() {
-		// TODO Auto-generated method stub
-		return null;
-	}
+    @Override
+    public Class<?> getCommonPartClass() {
+        // TODO Auto-generated method stub
+        return null;
+    }
 
-	@Override
-	public String getServiceName() {
-		return SystemInfoClient.SERVICE_NAME;
-	}
+    @Override
+    public String getServiceName() {
+        return SystemInfoClient.SERVICE_NAME;
+    }
 
-	@Override
-	protected String getVersionString() {
-		// TODO Auto-generated method stub
-		return null;
-	}
+    @Override
+    protected String getVersionString() {
+        // TODO Auto-generated method stub
+        return null;
+    }
 
-	//
-	// API Endpoints
-	//
+    //
+    // API Endpoints
+    //
 
     @GET
     public SystemInfoCommon get(@Context UriInfo ui) {
-    	SystemInfoCommon result = null;
+        SystemInfoCommon result;
 
-    	try {
-    		result = new SystemInfoCommon();
-    		result.setInstanceId(ServiceMain.getInstance().getCspaceInstanceId());
-    		result.setDisplayName(ServiceMain.VER_DISPLAY_NAME);
-    		Version ver = new Version();
-    		ver.setMajor(ServiceMain.VER_MAJOR);
-    		ver.setMinor(ServiceMain.VER_MINOR);
-    		ver.setPatch(ServiceMain.VER_PATCH);
-    		ver.setBuild(ServiceMain.VER_BUILD);
-    		result.setVersion(ver);
+        try {
+            result = new SystemInfoCommon();
+            result.setInstanceId(ServiceMain.getInstance().getCspaceInstanceId());
+            result.setDisplayName(ServiceMain.VER_DISPLAY_NAME);
+            Version ver = new Version();
+            ver.setMajor(ServiceMain.VER_MAJOR);
+            ver.setMinor(ServiceMain.VER_MINOR);
+            ver.setPatch(ServiceMain.VER_PATCH);
+            ver.setBuild(ServiceMain.VER_BUILD);
+            result.setVersion(ver);
 
-    		result.setHostTimezone(TimeZone.getDefault().getID());
-    		result.setHostLocale(Locale.getDefault().toLanguageTag());
-    		result.setHostCharset(Charset.defaultCharset().name());
-    		//
-    		// To get the full set of the system information, we required the user be authenticated *and* have "DELETE" privs on the "systeminfo" resource
-    		//
-    		try {
-    			ServiceContext<SystemInfoCommon, SystemInfoCommon> ctx = createServiceContext(getServiceName(), ui);
-    			CSpaceResource res = new URIResourceImpl(ctx.getTenantId(), SystemInfoClient.SERVICE_NAME, HttpMethod.DELETE);
-    			if (AuthZ.get().isAccessAllowed(res)) {
-							// TODO: Stop hardcoding this!
-							// result.setNuxeoVersionString("7.10-HF17");
-							result.setHost(String.format("Architecture:%s Name:%s Version:%s",
-									System.getProperty("os.arch"), System.getProperty("os.name"), System.getProperty("os.version")));
-							result.setJavaVersionString(System.getProperty("java.version"));
-							// TODO: Stop hardcoding this!
-							// result.setPostgresVersionString("9.5.7");
-					}
-				} catch (UnauthorizedException e) {
-    				logger.trace(e.getMessage(), e);
-    		}
+            result.setHostTimezone(TimeZone.getDefault().getID());
+            result.setHostLocale(Locale.getDefault().toLanguageTag());
+            result.setHostCharset(Charset.defaultCharset().name());
 
-    	} catch(Exception e) {
-    		Response response = Response.status(Response.Status.BAD_REQUEST).entity(e.getMessage()).type("text/plain").build();
+            // To get the full set of the system information, we required the user be authenticated *and* have "DELETE"
+            // privs on the "systeminfo" resource
+            try {
+                ServiceContext<SystemInfoCommon, SystemInfoCommon> ctx = createServiceContext(getServiceName(), ui);
+                CSpaceResource res = new URIResourceImpl(ctx.getTenantId(), SystemInfoClient.SERVICE_NAME,
+                                                         HttpMethod.DELETE);
+                if (AuthZ.get().isAccessAllowed(res)) {
+                    // TODO: Stop hardcoding this!
+                    // result.setNuxeoVersionString("7.10-HF17");
+                    result.setHost(String.format("Architecture:%s Name:%s Version:%s",
+                                                 System.getProperty("os.arch"),
+                                                 System.getProperty("os.name"),
+                                                 System.getProperty("os.version")));
+                    result.setJavaVersionString(System.getProperty("java.version"));
+                    // TODO: Stop hardcoding this!
+                    // result.setPostgresVersionString("9.5.7");
+                }
+            } catch (UnauthorizedException e) {
+                logger.trace(e.getMessage(), e);
+            }
+
+        } catch (Exception e) {
+            logger.error("Error generating system info", e);
+            Response response = Response.status(Response.Status.BAD_REQUEST)
+                                        .entity(e.getMessage())
+                                        .type("text/plain").build();
             throw new CSWebApplicationException(response);
-    	}
+        }
 
-    	return result;
+        return result;
     }
 
-	@Override
-	public ServiceContextFactory<SystemInfoCommon, SystemInfoCommon> getServiceContextFactory() {
+    @Override
+    public ServiceContextFactory<SystemInfoCommon, SystemInfoCommon> getServiceContextFactory() {
         return (ServiceContextFactory<SystemInfoCommon, SystemInfoCommon>) RemoteServiceContextFactory.get();
-	}
+    }
 }

--- a/services/systeminfo/service/src/main/java/org/collectionspace/services/systeminfo/SystemInfoResource.java
+++ b/services/systeminfo/service/src/main/java/org/collectionspace/services/systeminfo/SystemInfoResource.java
@@ -28,6 +28,10 @@ import org.collectionspace.services.common.security.UnauthorizedException;
 @Consumes({"application/xml"})
 public class SystemInfoResource extends AbstractCollectionSpaceResourceImpl<SystemInfoCommon, SystemInfoCommon> {
 
+    private static final int MAJOR_IDX = 0;
+    private static final int MINOR_IDX = 1;
+    private static final int PATCH_IDX = 2;
+
     @Override
     public Class<?> getCommonPartClass() {
         // TODO Auto-generated method stub
@@ -57,11 +61,14 @@ public class SystemInfoResource extends AbstractCollectionSpaceResourceImpl<Syst
             result = new SystemInfoCommon();
             result.setInstanceId(ServiceMain.getInstance().getCspaceInstanceId());
             result.setDisplayName(ServiceMain.VER_DISPLAY_NAME);
+
+            String packageVersion = SystemInfoResource.class.getPackage().getImplementationVersion();
+            String[] versionParts = packageVersion.split("\\.");
             Version ver = new Version();
-            ver.setMajor(ServiceMain.VER_MAJOR);
-            ver.setMinor(ServiceMain.VER_MINOR);
-            ver.setPatch(ServiceMain.VER_PATCH);
-            ver.setBuild(ServiceMain.VER_BUILD);
+            ver.setMajor(versionParts[MAJOR_IDX]);
+            ver.setMinor(versionParts[MINOR_IDX]);
+            ver.setPatch(versionParts[PATCH_IDX]);
+            ver.setBuild("1");
             result.setVersion(ver);
 
             result.setHostTimezone(TimeZone.getDefault().getID());

--- a/services/systeminfo/service/src/main/java/org/collectionspace/services/systeminfo/SystemInfoResource.java
+++ b/services/systeminfo/service/src/main/java/org/collectionspace/services/systeminfo/SystemInfoResource.java
@@ -1,7 +1,9 @@
 package org.collectionspace.services.systeminfo;
 
+import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Locale;
+import java.util.Properties;
 import java.util.TimeZone;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -70,7 +72,7 @@ public class SystemInfoResource extends AbstractCollectionSpaceResourceImpl<Syst
             ver.setMajor(versionParts[MAJOR_IDX]);
             ver.setMinor(versionParts[MINOR_IDX]);
             ver.setPatch(versionParts[PATCH_IDX]);
-            ver.setBuild("1");
+            ver.setBuild(readGitCommitId());
             result.setVersion(ver);
 
             result.setHostTimezone(TimeZone.getDefault().getID());
@@ -107,6 +109,12 @@ public class SystemInfoResource extends AbstractCollectionSpaceResourceImpl<Syst
         }
 
         return result;
+    }
+
+    private String readGitCommitId() throws IOException {
+        Properties properties = new Properties();
+        properties.load(getClass().getClassLoader().getResourceAsStream("git.properties"));
+        return properties.getProperty("git.commit.id.abbrev");
     }
 
     @Override


### PR DESCRIPTION
Jira: https://collectionspace.atlassian.net/browse/DRYD-1145

* Add build info to manifest for jar and wars
* Use implementation version when getting systeminfo

# Notes

* I'm not sure if we should add something different for the build number. I was considering pulling in the git commit hash, but left it hardcoded at the moment.
* I added the build info to both war and jars. I wasn't quite sure how everything is bundled together and how the classpath is impacted, and this seemed like the easiest way to make sure it made it into the systeminfo modules.
* The diff was kind of all over the place with formatting initially so I had intellij reformat SystemInfoResource and made changes on top of that.