### PR TITLE
DRYD-1200, DRYD-1160: Add ability to automatically de-urn report fields.

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/Group_List_Basic.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/Group_List_Basic.jrxml
@@ -50,6 +50,9 @@
 		: "WHERE hierarchy.name = '" + ($P{csid} ? $P{csid}.replace(/'/g, "''") : '') + "'"
 	)]]></defaultValueExpression>
 	</parameter>
+	<parameter name="deurnfields" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA["objectproductionorganization,objectproductionperson,objectproductionpeople,computedcurrentlocation"]]></defaultValueExpression>
+	</parameter>
 	<queryString>
 		<![CDATA[select
 						coc.objectnumber,
@@ -182,11 +185,7 @@
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
 				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="365" y="0" width="91" height="51" uuid="cd2614be-d303-42ec-b1ae-17986df423dd"/>
-				<textFieldExpression><![CDATA[(
-  (it) => (it && it.startsWith("urn:"))
-    ? it.substring(it.indexOf("'") + 1, it.length - 1)
-    : it
-).call(null, $F{objectproductionorganization})]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{objectproductionorganization}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
 				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="456" y="0" width="91" height="51" uuid="f9b9b475-9f9e-48a7-8016-330cbcfb0fae"/>
@@ -194,11 +193,7 @@
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
 				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="547" y="0" width="91" height="51" uuid="2c3a2c4b-9124-43c8-8be3-69c482f4e5ad"/>
-				<textFieldExpression><![CDATA[(
-  (it) => (it && it.startsWith("urn:"))
-    ? it.substring(it.indexOf("'") + 1, it.length - 1)
-    : it
-).call(null, $F{objectproductionperson})]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{objectproductionperson}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
 				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="638" y="0" width="91" height="51" uuid="baa2cb50-03d1-45e0-9e32-dac575891da9"/>
@@ -206,11 +201,7 @@
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
 				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="729" y="0" width="91" height="51" uuid="00f2e1c6-6a9d-445a-9bb0-8792754d5f66"/>
-				<textFieldExpression><![CDATA[(
-  (it) => (it && it.startsWith("urn:"))
-    ? it.substring(it.indexOf("'") + 1, it.length - 1)
-    : it
-).call(null, $F{objectproductionpeople})]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{objectproductionpeople}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
 				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="820" y="0" width="91" height="51" uuid="f28c35cd-bc86-49a7-95ff-cebf40b6434f"/>
@@ -228,11 +219,7 @@
 				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="1093" y="0" width="91" height="51" uuid="569e8c92-bc33-49c8-bad7-a80b144d5406">
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 				</reportElement>
-				<textFieldExpression><![CDATA[(
-  (it) => (it && it.startsWith("urn:"))
-    ? it.substring(it.indexOf("'") + 1, it.length - 1)
-    : it
-).call(null, $F{computedcurrentlocation})]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{computedcurrentlocation}]]></textFieldExpression>
 			</textField>
 		</band>
 	</detail>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/Group_List_Basic.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/Group_List_Basic.jrxml
@@ -51,7 +51,7 @@
 	)]]></defaultValueExpression>
 	</parameter>
 	<parameter name="deurnfields" class="java.lang.String" isForPrompting="false">
-		<defaultValueExpression><![CDATA["objectproductionorganization,objectproductionperson,objectproductionpeople,computedcurrentlocation"]]></defaultValueExpression>
+		<defaultValueExpression><![CDATA["objectname,objectproductionorganization,objectproductionorganizationrole,objectproductionperson,objectproductionpersonrole,objectproductionpeople,computedcurrentlocation"]]></defaultValueExpression>
 	</parameter>
 	<queryString>
 		<![CDATA[select

--- a/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/DefaultReportScriptlet.java
+++ b/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/DefaultReportScriptlet.java
@@ -1,0 +1,111 @@
+package org.collectionspace.services.report.nuxeo;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import net.sf.jasperreports.engine.JRDefaultScriptlet;
+import net.sf.jasperreports.engine.JRScriptletException;
+import net.sf.jasperreports.engine.JasperReport;
+import net.sf.jasperreports.engine.fill.JRFillField;
+
+import org.collectionspace.services.common.api.RefNameUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A JasperReports scriptlet to apply by default to all CollectionSpace reports. This handles the
+ * formatting of refname values as display names (aka de-urning) in specified fields. The names of
+ * fields to de-urn are supplied in the deurnfields parameter, as a comma-delimited list. If "*" is
+ * specified, all string-typed fields are de-urned.
+ */
+public class DefaultReportScriptlet extends JRDefaultScriptlet {
+	private final Logger logger = LoggerFactory.getLogger(DefaultReportScriptlet.class);
+
+	private static String DEURN_FIELDS_PARAM = "deurnfields";
+
+	protected boolean isDeurnAll = false;
+	protected Set<String> deurnFieldNames = null;
+
+	@Override
+	public void afterReportInit() throws JRScriptletException {
+		String deurnFieldsSpec = (String) this.getParameterValue(DEURN_FIELDS_PARAM, false);
+
+		if (deurnFieldsSpec != null) {
+			this.deurnFieldNames = new HashSet<String>();
+
+			for (String fieldSpec : deurnFieldsSpec.split(",")) {
+				String trimmedFieldSpec = fieldSpec.trim();
+
+				if (trimmedFieldSpec.equals("*")) {
+					this.isDeurnAll = true;
+				} else {
+					this.deurnFieldNames.add(trimmedFieldSpec);
+				}
+			}
+		}
+	}
+
+	@Override
+	public void beforeDetailEval() throws JRScriptletException {
+		if (this.isDeurnAll) {
+			deurnAllFields();
+		} else {
+			deurnSpecifiedFields();
+		}
+	}
+
+	private void deurnAllFields() {
+		if (this.fieldsMap != null) {
+			for (JRFillField field : this.fieldsMap.values()) {
+				if (field.getValueClass().equals(String.class)) {
+					deurnField(field);
+				}
+			}
+		}
+	}
+
+	private void deurnSpecifiedFields() {
+		if (this.fieldsMap != null && this.deurnFieldNames != null) {
+			for (String fieldName : this.deurnFieldNames) {
+				JRFillField field = this.fieldsMap.get(fieldName);
+
+				if (field == null) {
+					logger.warn("{}: deurn field not found: {}", getReportName(), fieldName);
+
+					continue;
+				}
+
+				if (!field.getValueClass().equals(String.class)) {
+					logger.warn("{}: deurn field is not a string: {}", getReportName(), fieldName);
+
+					continue;
+				}
+
+				deurnField(field);
+			}
+		}
+	}
+
+	private void deurnField(JRFillField field) {
+		String value = (String) field.getValue();
+
+		if (value != null) {
+			try {
+				field.setValue(RefNameUtils.getDisplayName(value));
+			} catch (IllegalArgumentException ex) {
+				// It wasn't a valid refname. Keep the value.
+			}
+		}
+	}
+
+	private String getReportName() {
+		JasperReport report = null;
+
+		try {
+			report = (JasperReport) this.getParameterValue("JASPER_REPORT", false);
+		}
+		catch (JRScriptletException ex) {}
+
+		return (report != null ? report.getName() : "Unknown report name");
+	}
+}

--- a/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
+++ b/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
@@ -47,6 +47,7 @@ import net.sf.jasperreports.engine.JRParameter;
 import net.sf.jasperreports.engine.JasperCompileManager;
 import net.sf.jasperreports.engine.JasperFillManager;
 import net.sf.jasperreports.engine.JasperPrint;
+import net.sf.jasperreports.engine.design.JasperDesign;
 import net.sf.jasperreports.engine.export.JRCsvExporter;
 import net.sf.jasperreports.engine.export.JRCsvExporterParameter;
 import net.sf.jasperreports.engine.export.JRHtmlExporter;
@@ -55,6 +56,7 @@ import net.sf.jasperreports.engine.export.JRXmlExporter;
 import net.sf.jasperreports.engine.export.ooxml.JRDocxExporter;
 import net.sf.jasperreports.engine.export.ooxml.JRPptxExporter;
 import net.sf.jasperreports.engine.export.ooxml.JRXlsxExporter;
+import net.sf.jasperreports.engine.xml.JRXmlLoader;
 
 import org.collectionspace.authentication.AuthN;
 import org.collectionspace.services.ReportJAXBSchema;
@@ -372,9 +374,15 @@ public class ReportDocumentModelHandler extends NuxeoDocumentModelHandler<Report
 									reportCSID, sourceFilePath);
 					throw new RuntimeException("Report is missing the specified source file!");
 				}
-            	logger.info("Report for csid={} is not compiled. Compiling first, and saving to: {}",
-            			reportCSID, compiledFilePath);
-            	JasperCompileManager.compileReportToFile(sourceFilePath, compiledFilePath);
+
+				logger.info("Report for csid={} is not compiled. Compiling first, and saving to: {}",
+					reportCSID, compiledFilePath);
+
+				JasperDesign design = JRXmlLoader.load(sourceFilePath);
+
+				design.setScriptletClass("org.collectionspace.services.report.nuxeo.DefaultReportScriptlet");
+
+				JasperCompileManager.compileReportToFile(design, compiledFilePath);
 			}
 
 			conn = getConnection();


### PR DESCRIPTION
**What does this do?**

This adds the ability to automatically format ref names as display names (aka, de-urn) when filling reports. This feature is enabled by specifying the `deurnfields` parameter in the report invocation (or by setting a default value for that parameter in the report itself). The `deurnfields` parameter should contain a comma-delimited list of field names. When filling the report, the CollectionSpace server will examine each of the specified fields. If it contains a URN (ref name), then the display name is extracted from the ref name, and used as the value in the field in the report. Otherwise, the value is left unchanged. The `deurnfields` parameter may be set to "*". In that case, all string fields in the report will undergo the de-urning process.

As an example, the Group Basic List report has been updated to use the `deurnfields` parameter.
 
**Why are we doing this? (with JIRA link)**

This makes it convenient for report authors to deal with ref name fields, without needing to add code to the SQL query or to the report's field expressions. It also allows us to use the same report in different tenants, in which the same field may or may not contain a ref name (since the automated de-urning is conditional upon the field actually containing a URN).

https://collectionspace.atlassian.net/browse/DRYD-1200
https://collectionspace.atlassian.net/browse/DRYD-1160

**How should this be tested? Do these changes have associated tests?**

Reports that use the `deurnfields` parameter should work.
- Create one or more Object records.
- Search for Object records, select all results, and run the Group Basic List report.
   The following fields should be de-urned, and contain correct values: 
   - objectname
   - objectproductionorganization
   - objectproductionorganizationrole
   - objectproductionperson
   - objectproductionpersonrole
   - objectproductionpeople
   - computedcurrentlocation
- Repeat in other tenants, especially ones where any of the above fields have been changed to be tied to an authority.

Reports that don't use the `deurnfields` parameter should continue to work.
- Search for Object records, select all results, and run the Object Valuation report.
   The report should run successfully, and all fields should contain the expected values.

**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

@ray-lee will update the user documentation, as soon as I figure out where to put it.

**Did someone actually run this code to verify it works?**

@ray-lee tested on a local installation.