### PR TITLE
DRYD-1133: Chronology Authority

### DIFF
--- a/services/JaxRsServiceProvider/pom.xml
+++ b/services/JaxRsServiceProvider/pom.xml
@@ -398,6 +398,11 @@
             <artifactId>org.collectionspace.services.iterationreport.service</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+          <groupId>org.collectionspace.services</groupId>
+          <artifactId>org.collectionspace.services.chronology.service</artifactId>
+          <version>${project.version}</version>
+        </dependency>
         <!--dependency>
             <groupId>org.collectionspace.services</groupId>
             <artifactId>org.collectionspace.services.query.service</artifactId>

--- a/services/JaxRsServiceProvider/src/main/java/org/collectionspace/services/jaxrs/CollectionSpaceJaxRsApplication.java
+++ b/services/JaxRsServiceProvider/src/main/java/org/collectionspace/services/jaxrs/CollectionSpaceJaxRsApplication.java
@@ -25,6 +25,7 @@ package org.collectionspace.services.jaxrs;
 import org.collectionspace.services.account.AccountResource;
 import org.collectionspace.services.account.TenantResource;
 import org.collectionspace.services.blob.BlobResource;
+import org.collectionspace.services.chronology.ChronologyAuthorityResource;
 import org.collectionspace.services.collectionobject.CollectionObjectResource;
 import org.collectionspace.services.id.IDResource;
 import org.collectionspace.services.insurance.InsuranceResource;
@@ -158,6 +159,7 @@ public class CollectionSpaceJaxRsApplication extends Application
         addResourceToMapAndSingletons(new PublicItemResource());
         addResourceToMapAndSingletons(new TransportResource());
         addResourceToMapAndSingletons(new IterationreportResource());
+        addResourceToMapAndSingletons(new ChronologyAuthorityResource());
 
         singletons.add(new IDResource());
 

--- a/services/chronology/build.xml
+++ b/services/chronology/build.xml
@@ -1,0 +1,124 @@
+
+<project name="chronology" default="package" basedir=".">
+    <description>
+      chronology service
+    </description>
+  <!-- set global properties for this build -->
+    <property name="services.trunk" value="../.."/>
+    <!-- environment should be declared before reading build.properties -->
+    <property environment="env" />
+    <property file="${services.trunk}/build.properties" />
+    <property name="mvn.opts" value="-V" />
+    <property name="src" location="src"/>
+
+    <condition property="osfamily-unix">
+        <os family="unix" />
+    </condition>
+    <condition property="osfamily-windows">
+        <os family="windows" />
+    </condition>
+
+    <target name="package" depends="package-unix,package-windows"
+  description="Package CollectionSpace Services" />
+  
+    <target name="package-unix" if="osfamily-unix">
+        <exec executable="mvn" failonerror="true">
+            <arg value="package" />
+            <arg value="-Dmaven.test.skip=true" />
+            <arg value="-f" />
+            <arg value="${basedir}/pom.xml" />
+            <arg value="-N" />
+            <arg value="${mvn.opts}" />
+        </exec>
+    </target>
+    
+    <target name="package-windows" if="osfamily-windows">
+        <exec executable="cmd" failonerror="true">
+            <arg value="/c" />
+            <arg value="mvn" />
+            <arg value="package" />
+            <arg value="-Dmaven.test.skip=true" />
+            <arg value="-f" />
+            <arg value="${basedir}/pom.xml" />
+            <arg value="-N" />
+            <arg value="${mvn.opts}" />
+        </exec>
+    </target>
+
+
+    <target name="install" depends="install-unix,install-windows"
+  description="Install" />
+    <target name="install-unix" if="osfamily-unix">
+        <exec executable="mvn" failonerror="true">
+            <arg value="install" />
+            <arg value="-Dmaven.test.skip=true" />
+            <arg value="-f" />
+            <arg value="${basedir}/pom.xml" />
+            <arg value="-N" />
+            <arg value="${mvn.opts}" />
+        </exec>
+    </target>
+    <target name="install-windows" if="osfamily-windows">
+        <exec executable="cmd" failonerror="true">
+            <arg value="/c" />
+            <arg value="mvn" />
+            <arg value="install" />
+            <arg value="-Dmaven.test.skip=true" />
+            <arg value="-f" />
+            <arg value="${basedir}/pom.xml" />
+            <arg value="-N" />
+            <arg value="${mvn.opts}" />
+        </exec>
+    </target>
+
+    <target name="clean" depends="clean-unix,clean-windows"
+  description="Delete target directories" >
+        <delete dir="${build}"/>
+    </target>
+    <target name="clean-unix" if="osfamily-unix">
+        <exec executable="mvn" failonerror="true">
+            <arg value="clean" />
+            <arg value="${mvn.opts}" />
+        </exec>
+    </target>
+    <target name="clean-windows" if="osfamily-windows">
+        <exec executable="cmd" failonerror="true">
+            <arg value="/c" />
+            <arg value="mvn" />
+            <arg value="clean" />
+            <arg value="${mvn.opts}" />
+        </exec>
+    </target>
+
+    <target name="test" depends="test-unix,test-windows" description="Run tests" />
+    <target name="test-unix" if="osfamily-unix">
+        <exec executable="mvn" failonerror="true">
+            <arg value="test" />
+            <arg value="${mvn.opts}" />
+        </exec>
+    </target>
+    <target name="test-windows" if="osfamily-windows">
+        <exec executable="cmd" failonerror="true">
+            <arg value="/c" />
+            <arg value="mvn" />
+            <arg value="test" />
+            <arg value="${mvn.opts}" />
+        </exec>
+    </target>
+
+    <target name="deploy" depends="install"
+    description="deploy chronology service">
+        <ant antfile="3rdparty/build.xml" target="deploy" inheritall="false"/>
+    </target>
+
+    <target name="undeploy"
+    description="undeploy chronology service">
+        <ant antfile="3rdparty/build.xml" target="undeploy" inheritall="false"/>
+    </target>
+
+    <target name="dist" depends="package"
+    description="distribute chronology service">
+        <ant antfile="3rdparty/build.xml" target="dist" inheritall="false"/>
+    </target>
+
+</project>

--- a/services/chronology/client/pom.xml
+++ b/services/chronology/client/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <groupId>org.collectionspace.services</groupId>
+    <artifactId>org.collectionspace.services.chronology</artifactId>
+    <version>${revision}</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>org.collectionspace.services.chronology.client</artifactId>
+  <name>services.chronology.client</name>
+
+  <dependencies>
+    <!-- CollectionSpace dependencies -->
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.authority.jaxb</artifactId>
+      <optional>true</optional>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.jaxb</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.common</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.client</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.chronology.jaxb</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.person.client</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <!-- External dependencies -->
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxrs</artifactId>
+      <!-- filter out unwanted jars -->
+      <exclusions>
+        <exclusion>
+          <groupId>tjws</groupId>
+          <artifactId>webserver</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxb-provider</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-multipart-provider</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-httpclient</groupId>
+      <artifactId>commons-httpclient</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>collectionspace-services-chronology-client</finalName>
+  </build>
+</project>

--- a/services/chronology/client/src/main/java/org/collectionspace/services/client/ChronologyAuthorityClient.java
+++ b/services/chronology/client/src/main/java/org/collectionspace/services/client/ChronologyAuthorityClient.java
@@ -1,0 +1,87 @@
+/**
+ * This document is a part of the source code and related artifacts
+ * for CollectionSpace, an open source collections management system
+ * for museums and related institutions:
+ *
+ * http://www.collectionspace.org
+ * http://wiki.collectionspace.org
+ *
+ * Licensed under the Educational Community License (ECL), Version 2.0.
+ * You may not use this file except in compliance with this License.
+ *
+ * You may obtain a copy of the ECL 2.0 License at
+ * https://source.collectionspace.org/collection-space/LICENSE.txt
+ */
+package org.collectionspace.services.client;
+
+import org.collectionspace.services.chronology.ChronologiesCommon;
+import org.collectionspace.services.chronology.ChronologyauthoritiesCommon;
+
+/**
+ * ChronologyClient.java
+ */
+public class ChronologyAuthorityClient
+    extends AuthorityClientImpl<ChronologyauthoritiesCommon, ChronologiesCommon, ChronologyAuthorityProxy> {
+
+    public static final String SERVICE_NAME = "chronologyauthorities";
+    public static final String SERVICE_ITEM_NAME = "chronologies";
+    public static final String SERVICE_PATH_COMPONENT = SERVICE_NAME;
+    public static final String SERVICE_PATH = "/" + SERVICE_PATH_COMPONENT;
+    public static final String SERVICE_PATH_PROXY = SERVICE_PATH + "/";
+    public static final String SERVICE_PAYLOAD_NAME = SERVICE_NAME;
+    public static final String SERVICE_COMMON_PART_NAME = SERVICE_NAME + PART_LABEL_SEPARATOR + PART_COMMON_LABEL;
+    public static final String SERVICE_ITEM_NAME_COMMON_PART_NAME =
+        SERVICE_ITEM_NAME + PART_LABEL_SEPARATOR + PART_COMMON_LABEL;
+    public static final String TERM_INFO_GROUP_XPATH_BASE = "chronologyTermGroupList";
+    public static final String SERVICE_BINDING_NAME = "ChronologyAuthority";
+
+    public ChronologyAuthorityClient() throws Exception {
+        super();
+    }
+
+    public ChronologyAuthorityClient(String clientPropertiesFilename) throws Exception {
+        super(clientPropertiesFilename);
+    }
+
+    @Override
+    public String getServiceName() {
+        return SERVICE_NAME;
+    }
+
+    @Override
+    public String getServicePathComponent() {
+        return SERVICE_PATH_COMPONENT;
+    }
+
+    @Override
+    public String getItemCommonPartName() {
+        return getCommonPartName(SERVICE_ITEM_NAME);
+    }
+
+    @Override
+    public Class<ChronologyAuthorityProxy> getProxyClass() {
+        return ChronologyAuthorityProxy.class;
+    }
+
+    @Override
+    public String getInAuthority(ChronologiesCommon item) {
+        return item.getInAuthority();
+    }
+
+    @Override
+    public void setInAuthority(ChronologiesCommon item, String inAuthorityCsid) {
+        item.setInAuthority(inAuthorityCsid);
+    }
+
+    @Override
+    public String createAuthorityInstance(String shortIdentifier, String displayName) {
+        final PoxPayloadOut poxPayloadOut = ChronologyAuthorityClientUtils.createChronologyAuthorityInstance(
+            displayName, shortIdentifier, SERVICE_COMMON_PART_NAME);
+        return poxPayloadOut.asXML();
+    }
+
+    @Override
+    public String createAuthorityItemInstance(String shortIdentifier, String displayName) {
+        return null;
+    }
+}

--- a/services/chronology/client/src/main/java/org/collectionspace/services/client/ChronologyAuthorityClientUtils.java
+++ b/services/chronology/client/src/main/java/org/collectionspace/services/client/ChronologyAuthorityClientUtils.java
@@ -1,0 +1,37 @@
+package org.collectionspace.services.client;
+
+import javax.ws.rs.core.MediaType;
+
+import org.collectionspace.services.chronology.ChronologyauthoritiesCommon;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ChronologyAuthorityClientUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(ChronologyAuthorityClientUtils.class);
+
+    /**
+     * Create a new Chronology authority
+     *
+     * @param displayName           the display name
+     * @param shortIdentifier       the short identifier
+     * @param serviceCommonPartName the common part label
+     * @return The PoxPayloadOut for the create call
+     */
+    public static PoxPayloadOut createChronologyAuthorityInstance(final String displayName,
+                                                                  final String shortIdentifier,
+                                                                  final String serviceCommonPartName) {
+        final ChronologyauthoritiesCommon common = new ChronologyauthoritiesCommon();
+        common.setDisplayName(displayName);
+        common.setShortIdentifier(shortIdentifier);
+        common.setVocabType(ChronologyAuthorityClient.SERVICE_BINDING_NAME);
+
+        final PoxPayloadOut poxPayloadOut = new PoxPayloadOut(ChronologyAuthorityClient.SERVICE_PAYLOAD_NAME);
+        final PayloadOutputPart payloadPart = poxPayloadOut.addPart(common, MediaType.APPLICATION_XML_TYPE);
+        payloadPart.setLabel(serviceCommonPartName);
+
+        logger.debug("to be created, chronologyAuthority common {}", common);
+        return poxPayloadOut;
+    }
+
+}

--- a/services/chronology/client/src/main/java/org/collectionspace/services/client/ChronologyAuthorityClientUtils.java
+++ b/services/chronology/client/src/main/java/org/collectionspace/services/client/ChronologyAuthorityClientUtils.java
@@ -1,8 +1,34 @@
+/**
+ * This document is a part of the source code and related artifacts
+ * for CollectionSpace, an open source collections management system
+ * for museums and related institutions:
+ * <p>
+ * http://www.collectionspace.org
+ * http://wiki.collectionspace.org
+ * <p>
+ * Licensed under the Educational Community License (ECL), Version 2.0.
+ * You may not use this file except in compliance with this License.
+ * <p>
+ * You may obtain a copy of the ECL 2.0 License at
+ * https://source.collectionspace.org/collection-space/LICENSE.txt
+ */
 package org.collectionspace.services.client;
 
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
 
+import org.collectionspace.services.ChronologyJAXBSchema;
+import org.collectionspace.services.chronology.ChronologiesCommon;
+import org.collectionspace.services.chronology.ChronologyTermGroup;
+import org.collectionspace.services.chronology.ChronologyTermGroupList;
 import org.collectionspace.services.chronology.ChronologyauthoritiesCommon;
+import org.collectionspace.services.client.test.ServiceRequestType;
+import org.collectionspace.services.common.api.Tools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +58,123 @@ public class ChronologyAuthorityClientUtils {
 
         logger.debug("to be created, chronologyAuthority common {}", common);
         return poxPayloadOut;
+    }
+
+    /**
+     *
+     * @param vcsid the csid of the authority
+     * @param authRefName the refname of the authority
+     * @param materialMap properties for the new chronology
+     * @param terms terms for the new chronology
+     * @param client the service client
+     * @return the csid of the new item
+     */
+    public static String createItemInAuthority(final String vcsid,
+                                               final String authRefName,
+                                               final Map<String, String> materialMap,
+                                               final List<ChronologyTermGroup> terms,
+                                               final ChronologyAuthorityClient client) {
+        // Expected status code: 201 Created
+        final int EXPECTED_STATUS_CODE = Response.Status.CREATED.getStatusCode();
+        // Type of service request being tested
+        final ServiceRequestType REQUEST_TYPE = ServiceRequestType.CREATE;
+
+        String displayName = "";
+        if (terms != null && !terms.isEmpty()) {
+            displayName = terms.get(0).getTermDisplayName();
+        }
+        logger.debug("Creating item with display name: {} in chronologyAuthority: {}", displayName, vcsid);
+        PoxPayloadOut multipart = createChronologyInstance(materialMap, terms, client.getItemCommonPartName());
+        String newID;
+
+        final Response res = client.createItem(vcsid, multipart);
+        try {
+            int statusCode = res.getStatus();
+
+            if(!REQUEST_TYPE.isValidStatusCode(statusCode)) {
+                final String error = "Could not create Item: %s in chronologyAuthority: %s, %s";
+                throw new RuntimeException(String.format(error,
+                                                         materialMap.get(ChronologyJAXBSchema.SHORT_IDENTIFIER),
+                                                         authRefName,
+                                                         invalidStatusCodeMessage(REQUEST_TYPE, statusCode)));
+            }
+            if(statusCode != EXPECTED_STATUS_CODE) {
+                final String error = "Unexpected Status when creating Item: %s in chronologyAuthority %s, Status: %d";
+                throw new RuntimeException(String.format(error,
+                                                         materialMap.get(ChronologyJAXBSchema.SHORT_IDENTIFIER),
+                                                         authRefName,
+                                                         statusCode));
+            }
+            newID = extractId(res);
+        } finally {
+            res.close();
+        }
+
+        return newID;
+    }
+
+    public static PoxPayloadOut createChronologyInstance(final Map<String, String> chronologyInfo,
+                                                         final List<ChronologyTermGroup> terms,
+                                                         final String headerLabel) {
+        final ChronologiesCommon common = new ChronologiesCommon();
+        common.setShortIdentifier(chronologyInfo.get(ChronologyJAXBSchema.SHORT_IDENTIFIER));
+
+        ChronologyTermGroupList termList = new ChronologyTermGroupList();
+        if (terms == null || terms.isEmpty()) {
+            termList.getChronologyTermGroup().addAll(getTermGroupInstance(getGeneratedIdentifier()));
+        } else {
+            termList.getChronologyTermGroup().addAll(terms);
+        }
+        common.setChronologyTermGroupList(termList);
+
+        PoxPayloadOut mp = new PoxPayloadOut(ChronologyAuthorityClient.SERVICE_ITEM_NAME);
+        PayloadOutputPart commonPart = mp.addPart(common, MediaType.APPLICATION_XML_TYPE);
+        commonPart.setLabel(headerLabel);
+        logger.debug("To be created, chronologies common {}", common);
+
+        return mp;
+    }
+
+    public static List<ChronologyTermGroup> getTermGroupInstance(String identifier) {
+        if (Tools.isBlank(identifier)) {
+            identifier = getGeneratedIdentifier();
+        }
+
+        ChronologyTermGroup term = new ChronologyTermGroup();
+        term.setTermName(identifier);
+        term.setTermDisplayName(identifier);
+        return Collections.singletonList(term);
+    }
+
+    /**
+     *
+     * @param res
+     * @return
+     */
+    public static String extractId(final Response res) {
+        final MultivaluedMap<String, Object> mvm = res.getMetadata();
+        final String uri = (String) mvm.get("Location").get(0);
+        logger.debug("extractId:uri={}", uri);
+
+        final String[] segments = uri.split("/");
+        final String id = segments[segments.length - 1];
+        logger.debug("id=" + id);
+        return id;
+    }
+
+    /**
+     *
+     * @param requestType
+     * @param statusCode
+     * @return
+     */
+    public static String invalidStatusCodeMessage(final ServiceRequestType requestType, final int statusCode) {
+        return String.format("Status code '%d' is not within the expected set: %s", statusCode,
+                             requestType.validStatusCodesAsString());
+    }
+
+    private static String getGeneratedIdentifier() {
+        return "id" + new Date().getTime();
     }
 
 }

--- a/services/chronology/client/src/main/java/org/collectionspace/services/client/ChronologyAuthorityProxy.java
+++ b/services/chronology/client/src/main/java/org/collectionspace/services/client/ChronologyAuthorityProxy.java
@@ -1,0 +1,28 @@
+/**        
+ * This document is a part of the source code and related artifacts
+ * for CollectionSpace, an open source collections management system
+ * for museums and related institutions:
+ *
+ * http://www.collectionspace.org
+ * http://wiki.collectionspace.org
+ *
+ * Licensed under the Educational Community License (ECL), Version 2.0.
+ * You may not use this file except in compliance with this License.
+ *
+ * You may obtain a copy of the ECL 2.0 License at
+ * https://source.collectionspace.org/collection-space/LICENSE.txt
+ */
+package org.collectionspace.services.client;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+/**
+ * ChronologyProxy.java
+ */
+@Path(ChronologyAuthorityClient.SERVICE_PATH_PROXY)
+@Produces({"application/xml"})
+@Consumes({"application/xml"})
+public interface ChronologyAuthorityProxy extends AuthorityProxy {
+}

--- a/services/chronology/client/src/test/java/org/collectionspace/services/client/ChronologyAuthorityServiceTest.java
+++ b/services/chronology/client/src/test/java/org/collectionspace/services/client/ChronologyAuthorityServiceTest.java
@@ -1,0 +1,319 @@
+/**
+ * This document is a part of the source code and related artifacts
+ * for CollectionSpace, an open source collections management system
+ * for museums and related institutions:
+ * <p>
+ * http://www.collectionspace.org
+ * http://wiki.collectionspace.org
+ * <p>
+ * Licensed under the Educational Community License (ECL), Version 2.0.
+ * You may not use this file except in compliance with this License.
+ * <p>
+ * You may obtain a copy of the ECL 2.0 License at
+ * https://source.collectionspace.org/collection-space/LICENSE.txt
+ */
+package org.collectionspace.services.client;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
+import org.collectionspace.services.ChronologyJAXBSchema;
+import org.collectionspace.services.chronology.ChronologiesCommon;
+import org.collectionspace.services.chronology.ChronologyTermGroup;
+import org.collectionspace.services.chronology.ChronologyTermGroupList;
+import org.collectionspace.services.chronology.ChronologyauthoritiesCommon;
+import org.collectionspace.services.client.test.AbstractAuthorityServiceTest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+/**
+ * Test against a deployed ChronologyAuthority Service
+ */
+public class ChronologyAuthorityServiceTest
+    extends AbstractAuthorityServiceTest<ChronologyauthoritiesCommon, ChronologiesCommon> {
+
+    private static final Logger logger = LoggerFactory.getLogger(ChronologyAuthorityServiceTest.class);
+
+    private static final String TEST_CHRONOLOGY_DESCRIPTION = "A Chronology description";
+    private static final String TEST_CHRONOLOGY_TERM_NAME = "ChronoTerm";
+    private static final String TEST_CHRONOLOGY_TERM_DISPLAY_NAME = "Chronology 1";
+    private static final String TEST_CHRONOLOGY_TERM_STATUS = "accepted";
+    private static final String TEST_CHRONOLOGY_TERM_SOURCE = "source";
+    private static final String TEST_CHRONOLOGY_TERM_SOURCE_DETAIL = "detail";
+
+    public ChronologyAuthorityServiceTest() {
+        super();
+        TEST_SHORTID = "chronology1";
+    }
+
+    @Test(dataProvider="testName")
+    public void verifyIllegalItemDisplayName(String testName) throws Exception {
+        // Perform setup for read
+        setupRead();
+
+        // Submit the request to the service and store the response.
+        final ChronologyAuthorityClient client = new ChronologyAuthorityClient();
+        final Response res = client.readItem(knownResourceId, knownItemResourceId);
+        final ChronologiesCommon chronology;
+        try {
+            assertStatusCode(res, testName);
+            final String commonPartName = client.getItemCommonPartName();
+            final PoxPayloadIn input = new PoxPayloadIn(res.readEntity(String.class));
+            chronology = (ChronologiesCommon) extractPart(input, commonPartName, ChronologiesCommon.class);
+            assertNotNull(chronology);
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+
+        //
+        // Make an invalid UPDATE request, without a display name
+        //
+        ChronologyTermGroupList termList = chronology.getChronologyTermGroupList();
+        assertNotNull(termList);
+        List<ChronologyTermGroup> terms = termList.getChronologyTermGroup();
+        assertNotNull(terms);
+        assertTrue(terms.size() > 0);
+        terms.get(0).setTermDisplayName(null);
+        terms.get(0).setTermName(null);
+
+        // we expect a failure
+        setupUpdateWithInvalidBody();
+
+        // Submit the updated resource to the service and store the response.
+        PoxPayloadOut output = new PoxPayloadOut(ChronologyAuthorityClient.SERVICE_ITEM_NAME);
+        output.addPart(client.getItemCommonPartName(), chronology);
+
+        // we expected a failure here.
+        setupUpdateWithInvalidBody();
+        final Response updateResponse = client.updateItem(knownResourceId, knownItemResourceId, output);
+        try {
+            assertStatusCode(updateResponse, testName);
+        } finally {
+            if (updateResponse != null) {
+                updateResponse.close();
+            }
+        }
+    }
+
+    @Test(dataProvider = "testName", dependsOnMethods = {"localDeleteItem"})
+    public void localDelete(String testName) throws Exception {
+        super.delete(testName);
+    }
+
+    @Test(dataProvider = "testName", groups = {"delete"}, dependsOnMethods = {"verifyIllegalItemDisplayName"})
+    public void localDeleteItem(String testName) throws Exception {
+        super.deleteItem(testName);
+    }
+
+    @Override
+    @AfterClass(alwaysRun = true)
+    public void cleanUp() throws Exception {
+        final String noTestCleanup = System.getProperty("noTestCleanup");
+        if (Boolean.parseBoolean(noTestCleanup)) {
+            logger.debug("Skipping cleanup");
+            return;
+        }
+
+        logger.debug("Cleaning temporary resources for testing");
+
+        ChronologyAuthorityClient client = new ChronologyAuthorityClient();
+        for (Map.Entry<String, String> entry : allResourceItemIdsCreated.entrySet()) {
+            final String itemResourceId = entry.getKey();
+            final String parentResourceId = entry.getValue();
+            client.deleteItem(parentResourceId, itemResourceId).close();
+        }
+
+        for (String resourceId : allResourceIdsCreated) {
+            client.delete(resourceId).close();
+        }
+    }
+
+    @Override
+    public void authorityTests(String testName) {
+        // empty
+    }
+
+    @Override
+    public void delete(String testName) {
+        // Do nothing. Ensures proper test order.
+    }
+
+    @Override
+    public void deleteItem(String testName) {
+        // Do nothing. Ensures proper test order.
+    }
+
+    @Override
+    protected String createItemInAuthority(final AuthorityClient client, final String vcsid, final String shortId) {
+        return createItemInAuthority(client, vcsid, shortId, null);
+    }
+
+    private String createItemInAuthority(final AuthorityClient client,
+                                         final String vcsid,
+                                         final String shortId,
+                                         final String authRefName) {
+        final String testName = String.format("createItemInAuthority(%s, %s)", vcsid, shortId);
+
+        Map<String, String> materialMap = new HashMap<>();
+        materialMap.put(ChronologyJAXBSchema.SHORT_IDENTIFIER, shortId);
+        materialMap.put(ChronologyJAXBSchema.CHRONOLOGY_DESCRIPTION, TEST_CHRONOLOGY_DESCRIPTION);
+
+        List<ChronologyTermGroup> terms = new ArrayList<>();
+        ChronologyTermGroup term = new ChronologyTermGroup();
+        term.setTermName(TEST_CHRONOLOGY_TERM_NAME);
+        term.setTermDisplayName(TEST_CHRONOLOGY_TERM_DISPLAY_NAME);
+        term.setTermSource(TEST_CHRONOLOGY_TERM_SOURCE);
+        term.setTermSourceDetail(TEST_CHRONOLOGY_TERM_SOURCE_DETAIL);
+        term.setTermStatus(TEST_CHRONOLOGY_TERM_STATUS);
+        terms.add(term);
+
+        final String id = ChronologyAuthorityClientUtils.createItemInAuthority(vcsid, authRefName, materialMap, terms,
+                                                                               (ChronologyAuthorityClient) client);
+
+        // Store the id returned from the first item resource created for additional tests
+        if (knownItemResourceId == null) {
+            setKnownItemResource(id, shortId);
+            logger.debug("{}: knownResourceId={}", testName, id);
+        }
+
+        // Store item resource ids and parent ids so that they can be deleted after all tests run
+        allResourceItemIdsCreated.put(id, vcsid);
+
+        return id;
+    }
+
+    @Override
+    protected ChronologiesCommon updateItemInstance(final ChronologiesCommon authorityItem) {
+        final ChronologyTermGroupList termList = authorityItem.getChronologyTermGroupList();
+        assertNotNull(termList);
+        final List<ChronologyTermGroup> terms = termList.getChronologyTermGroup();
+        assertNotNull(terms);
+        assertTrue(terms.size() > 0);
+        terms.get(0).setTermDisplayName("updated-" + terms.get(0).getTermDisplayName());
+        terms.get(0).setTermName("updated-" + terms.get(0).getTermName());
+        authorityItem.setChronologyTermGroupList(termList);
+        return authorityItem;
+    }
+
+    @Override
+    protected void compareUpdatedItemInstances(final ChronologiesCommon original,
+                                               final ChronologiesCommon updated,
+                                               final boolean compareRevNumbers) {
+        final ChronologyTermGroupList originalTermList = original.getChronologyTermGroupList();
+        assertNotNull(originalTermList);
+        final List<ChronologyTermGroup> originalTerms = originalTermList.getChronologyTermGroup();
+        assertNotNull(originalTerms);
+        assertTrue(originalTerms.size() > 0);
+
+        final ChronologyTermGroupList updatedTermList = updated.getChronologyTermGroupList();
+        assertNotNull(updatedTermList);
+        final List<ChronologyTermGroup> updatedTerms = updatedTermList.getChronologyTermGroup();
+        assertNotNull(updatedTerms);
+        assertTrue(updatedTerms.size() > 0);
+
+        assertEquals(updatedTerms.get(0).getTermDisplayName(), originalTerms.get(0).getTermDisplayName(),
+                     "Value in updated record did not match submitted data.");
+
+        if (compareRevNumbers) {
+            assertEquals(original.getRev(), updated.getRev(), "Revision numbers should match.");
+        }
+    }
+
+    @Override
+    protected void verifyReadItemInstance(final ChronologiesCommon item) {
+        // empty
+    }
+
+    @Override
+    protected PoxPayloadOut createNonExistenceInstance(final String commonPartName, final String identifier) {
+        final String displayName = "displayName-NON_EXISTENT_ID";
+        return ChronologyAuthorityClientUtils.createChronologyAuthorityInstance(displayName, "nonEx", commonPartName);
+    }
+
+    @Override
+    protected PoxPayloadOut createNonExistenceItemInstance(String commonPartName, String identifier) {
+        Map<String, String> nonexMap = new HashMap<>();
+        nonexMap.put(ChronologyJAXBSchema.SHORT_IDENTIFIER, "nonEx");
+        nonexMap.put(ChronologyJAXBSchema.TERM_STATUS, TEST_CHRONOLOGY_TERM_STATUS);
+        nonexMap.put(ChronologyJAXBSchema.TERM_DISPLAY_NAME, TEST_CHRONOLOGY_TERM_DISPLAY_NAME);
+        final List<ChronologyTermGroup> termGroupInstance =
+            ChronologyAuthorityClientUtils.getTermGroupInstance(TEST_CHRONOLOGY_DESCRIPTION);
+
+        return ChronologyAuthorityClientUtils.createChronologyInstance(nonexMap, termGroupInstance, commonPartName);
+    }
+
+    @Override
+    protected PoxPayloadOut createInstance(final String commonPartName, final String identifier) {
+        // Submit the request to the service and store the response.
+        final String displayName = "displayName-" + identifier;
+        return ChronologyAuthorityClientUtils.createChronologyAuthorityInstance(displayName, identifier,
+                                                                                commonPartName);
+    }
+
+    @Override
+    protected ChronologyauthoritiesCommon updateInstance(final ChronologyauthoritiesCommon commonPartObject) {
+        ChronologyauthoritiesCommon result = new ChronologyauthoritiesCommon();
+
+        result.setDisplayName("updated-" + commonPartObject.getDisplayName());
+        result.setVocabType("updated-" + commonPartObject.getVocabType());
+
+        return result;
+    }
+
+    @Override
+    protected void compareUpdatedInstances(final ChronologyauthoritiesCommon original,
+                                           final ChronologyauthoritiesCommon updated) {
+        assertEquals(updated.getDisplayName(), original.getDisplayName(),
+                            "Display name in updated object did not match submitted data.");
+    }
+
+    @Override
+    protected void compareReadInstances(final ChronologyauthoritiesCommon original,
+                                        final ChronologyauthoritiesCommon fromRead) {
+        assertNotNull(fromRead.getDisplayName());
+        assertNotNull(fromRead.getShortIdentifier());
+        assertNotNull(fromRead.getRefName());
+    }
+
+    @Override
+    protected CollectionSpaceClient getClientInstance() throws Exception {
+        return new ChronologyAuthorityClient();
+    }
+
+    @Override
+    protected CollectionSpaceClient getClientInstance(String clientPropertiesFilename) throws Exception {
+        return new ChronologyAuthorityClient(clientPropertiesFilename);
+    }
+
+    @Override
+    protected String getServicePathComponent() {
+        return ChronologyAuthorityClient.SERVICE_PATH_COMPONENT;
+    }
+
+    @Override
+    protected String getServiceName() {
+        return ChronologyAuthorityClient.SERVICE_NAME;
+    }
+
+    @Override
+    protected String getItemServiceRootURL(String parentResourceIdentifier) {
+        return getResourceURL(parentResourceIdentifier) + "/" + getServicePathComponent();
+    }
+
+    @Override
+    protected String getItemResourceURL(String parentResourceIdentifier, String resourceIdentifier) {
+        return getItemServiceRootURL(parentResourceIdentifier) + "/" + resourceIdentifier;
+    }
+}

--- a/services/chronology/jaxb/pom.xml
+++ b/services/chronology/jaxb/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <artifactId>org.collectionspace.services.chronology</artifactId>
+    <groupId>org.collectionspace.services</groupId>
+    <version>${revision}</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>org.collectionspace.services.chronology.jaxb</artifactId>
+  <name>services.chronology.jaxb</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.jaxb</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.authority.jaxb</artifactId>
+      <optional>true</optional>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>collectionspace-services-chronology-jaxb</finalName>
+    <defaultGoal>install</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>org.jvnet.jaxb2.maven2</groupId>
+        <artifactId>maven-jaxb2-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/services/chronology/jaxb/src/main/java/org/collectionspace/services/ChronologyJAXBSchema.java
+++ b/services/chronology/jaxb/src/main/java/org/collectionspace/services/ChronologyJAXBSchema.java
@@ -1,0 +1,21 @@
+/**
+ * This document is a part of the source code and related artifacts
+ * for CollectionSpace, an open source collections management system
+ * for museums and related institutions:
+ *
+ * http://www.collectionspace.org
+ * http://wiki.collectionspace.org
+ *
+ * Licensed under the Educational Community License (ECL), Version 2.0.
+ * You may not use this file except in compliance with this License.
+ *
+ * You may obtain a copy of the ECL 2.0 License at
+ * https://source.collectionspace.org/collection-space/LICENSE.txt
+ */
+package org.collectionspace.services;
+
+import org.collectionspace.services.common.vocabulary.AuthorityItemJAXBSchema;
+
+public interface ChronologyJAXBSchema extends AuthorityItemJAXBSchema {
+    String CHRONOLOGIES_COMMON = "chronologies_common";
+}

--- a/services/chronology/jaxb/src/main/java/org/collectionspace/services/ChronologyJAXBSchema.java
+++ b/services/chronology/jaxb/src/main/java/org/collectionspace/services/ChronologyJAXBSchema.java
@@ -18,4 +18,6 @@ import org.collectionspace.services.common.vocabulary.AuthorityItemJAXBSchema;
 
 public interface ChronologyJAXBSchema extends AuthorityItemJAXBSchema {
     String CHRONOLOGIES_COMMON = "chronologies_common";
+    String CHRONOLOGY_DESCRIPTION = "description";
+
 }

--- a/services/chronology/jaxb/src/main/resources/chronology_common.xsd
+++ b/services/chronology/jaxb/src/main/resources/chronology_common.xsd
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+<!--
+    Chronology schema (XSD)
+
+    Entity  : Chronology
+    Part    : Common
+    Used for: JAXB binding between XML and Java objects
+-->
+
+<xs:schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+  jaxb:version="1.0" elementFormDefault="unqualified"
+  xmlns="http://collectionspace.org/services/chronology"
+  targetNamespace="http://collectionspace.org/services/chronology"
+  version="0.1"
+>
+  <!--  Chronology Information Group -->
+  <xs:element name="chronologies_common">
+    <xs:complexType>
+      <xs:sequence>
+        <!--  Common identifier -->
+        <xs:element name="csid" type="xs:string" />
+
+        <!-- Revision number -->
+        <xs:element name="rev" type="xs:integer" />
+
+        <!--  Common Authority Information Group -->
+        <!--  inAuthority is the csid of the owning ConceptAuthority -->
+        <xs:element name="inAuthority" type="xs:string" />
+        <xs:element name="shortIdentifier" type="xs:string" />
+        <xs:element name="refName" type="xs:string" />
+
+        <xs:element name="chronologyTermGroupList" type="chronologyTermGroupList" />
+        <xs:element name="chronologyStructuredDateGroup" type="structuredDateGroup" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:complexType name="chronologyTermGroupList">
+    <xs:sequence>
+      <xs:element name="chronologyTermGroup" type="chronologyTermGroup" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="chronologyTermGroup">
+    <xs:sequence>
+      <!-- Common across all authority item terms -->
+      <xs:element name="termDisplayName" type="xs:string" />
+      <xs:element name="termFormattedDisplayName" type="xs:string" />
+      <xs:element name="termName" type="xs:string" />
+      <xs:element name="termType" type="xs:string" />
+      <xs:element name="termStatus" type="xs:string" />
+      <xs:element name="termQualifier" type="xs:string" />
+      <xs:element name="termLanguage" type="xs:string" />
+      <xs:element name="termPrefForLang" type="xs:boolean" />
+      <xs:element name="termSource" type="xs:string" />
+      <xs:element name="termSourceDetail" type="xs:string" />
+      <xs:element name="termSourceID" type="xs:string" />
+      <xs:element name="termSourceNote" type="xs:string" />
+      <!-- Specific to chronology authority -->
+      <xs:element name="historicalStatus" type="xs:string" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="structuredDateGroup">
+    <xs:sequence>
+      <xs:element name="dateDisplayDate" type="xs:string" />
+      <xs:element name="dateAssociation" type="xs:string" />
+      <xs:element name="dateEarliestSingleYear" type="xs:integer" />
+      <xs:element name="dateEarliestSingleMonth" type="xs:integer" />
+      <xs:element name="dateEarliestSingleDay" type="xs:integer" />
+      <xs:element name="dateEarliestSingleEra" type="xs:string" />
+      <xs:element name="dateEarliestSingleCertainty" type="xs:string" />
+      <xs:element name="dateEarliestSingleQualifier" type="xs:string" />
+      <xs:element name="dateEarliestSingleQualifierValue" type="xs:integer" />
+      <xs:element name="dateEarliestSingleQualifierUnit" type="xs:string" />
+      <xs:element name="dateLatestYear" type="xs:integer" />
+      <xs:element name="dateLatestMonth" type="xs:integer" />
+      <xs:element name="dateLatestDay" type="xs:integer" />
+      <xs:element name="dateLatestEra" type="xs:string" />
+      <xs:element name="dateLatestCertainty" type="xs:string" />
+      <xs:element name="dateLatestQualifier" type="xs:string" />
+      <xs:element name="dateLatestQualifierValue" type="xs:integer" />
+      <xs:element name="dateLatestQualifierUnit" type="xs:string" />
+      <xs:element name="datePeriod" type="xs:string" />
+      <xs:element name="dateNote" type="xs:string" />
+      <xs:element name="dateEarliestScalarValue" type="xs:date" />
+      <xs:element name="dateLatestScalarValue" type="xs:date" />
+      <xs:element name="scalarValuesComputed" type="xs:boolean" />
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/services/chronology/jaxb/src/main/resources/chronologyauthority_common.xsd
+++ b/services/chronology/jaxb/src/main/resources/chronologyauthority_common.xsd
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+<!--
+    ChronologyAuthority schema (XSD)
+
+    Entity  : ChronologyAuthority
+    Part    : Common
+    Used for: JAXB binding between XML and Java objects
+-->
+
+<xs:schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+  jaxb:version="1.0" elementFormDefault="unqualified"
+  xmlns="http://collectionspace.org/services/chronology"
+  targetNamespace="http://collectionspace.org/services/chronology"
+  version="0.1"
+>
+
+  <!--  Chronology Information Group -->
+  <xs:element name="chronologyauthorities_common">
+    <xs:complexType>
+      <xs:sequence>
+        <!--  Common identifier -->
+        <xs:element name="csid" type="xs:string" />
+
+        <xs:element name="displayName" type="xs:string" />
+        <xs:element name="shortIdentifier" type="xs:string" />
+        <xs:element name="refName" type="xs:string" />
+        <xs:element name="vocabType" type="xs:string" />
+        <xs:element name="source" type="xs:string" />
+        <xs:element name="description" type="xs:string" />
+
+        <!-- The revision number of the authority.  Increments with each change including changes to its terms. -->
+        <xs:element name="rev" type="xs:integer" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/services/chronology/pom.xml
+++ b/services/chronology/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <groupId>org.collectionspace.services</groupId>
+    <artifactId>org.collectionspace.services.main</artifactId>
+    <version>${revision}</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>org.collectionspace.services.chronology</artifactId>
+  <name>services.chronology</name>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>jaxb</module>
+    <module>service</module>
+    <module>client</module>
+  </modules>
+
+</project>

--- a/services/chronology/service/pom.xml
+++ b/services/chronology/service/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <parent>
+    <groupId>org.collectionspace.services</groupId>
+    <artifactId>org.collectionspace.services.chronology</artifactId>
+    <version>${revision}</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>org.collectionspace.services.chronology.service</artifactId>
+  <name>services.chronology.service</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.authority.service</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.chronology.jaxb</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.chronology.client</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- External dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!--
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <scope>test</scope>
+    </dependency>
+    -->
+
+    <!-- javax -->
+    <dependency>
+      <groupId>javax.security</groupId>
+      <artifactId>jaas</artifactId>
+      <version>1.0.01</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- jboss -->
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxrs</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>tjws</groupId>
+          <artifactId>webserver</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxb-provider</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-multipart-provider</artifactId>
+    </dependency>
+
+    <!-- nuxeo -->
+
+    <dependency>
+      <groupId>org.nuxeo.ecm.core</groupId>
+      <artifactId>nuxeo-core-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <artifactId>jboss-remoting</artifactId>
+          <groupId>jboss</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <finalName>collectionspace-services-chronology</finalName>
+  </build>
+</project>

--- a/services/chronology/service/src/main/java/org/collectionspace/services/chronology/ChronologyAuthorityResource.java
+++ b/services/chronology/service/src/main/java/org/collectionspace/services/chronology/ChronologyAuthorityResource.java
@@ -1,0 +1,68 @@
+/**
+ * This document is a part of the source code and related artifacts
+ * for CollectionSpace, an open source collections management system
+ * for museums and related institutions:
+ *
+ * http://www.collectionspace.org
+ * http://wiki.collectionspace.org
+ *
+ * Licensed under the Educational Community License (ECL), Version 2.0.
+ * You may not use this file except in compliance with this License.
+ *
+ * You may obtain a copy of the ECL 2.0 License at
+ *
+ * https://source.collectionspace.org/collection-space/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.collectionspace.services.chronology;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+import org.collectionspace.services.chronology.nuxeo.ChronologyDocumentModelHandler;
+import org.collectionspace.services.client.ChronologyAuthorityClient;
+import org.collectionspace.services.common.vocabulary.AuthorityResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Path(ChronologyAuthorityClient.SERVICE_PATH)
+@Consumes("application/xml")
+@Produces("application/xml")
+public class ChronologyAuthorityResource
+    extends AuthorityResource<ChronologyauthoritiesCommon, ChronologyDocumentModelHandler> {
+    final Logger logger = LoggerFactory.getLogger(ChronologyAuthorityResource.class);
+
+    /**
+     * Instantiates a new Authority resource.
+     *
+     */
+    public ChronologyAuthorityResource() {
+        super(ChronologyauthoritiesCommon.class,
+              ChronologyAuthorityResource.class,
+              ChronologyAuthorityClient.SERVICE_COMMON_PART_NAME,
+              ChronologyAuthorityClient.SERVICE_ITEM_NAME_COMMON_PART_NAME);
+    }
+
+    @Override
+    public String getItemServiceName() {
+        return ChronologyAuthorityClient.SERVICE_ITEM_NAME;
+    }
+
+    @Override
+    public String getItemTermInfoGroupXPathBase() {
+        return ChronologyAuthorityClient.TERM_INFO_GROUP_XPATH_BASE;
+    }
+
+    @Override
+    public String getServiceName() {
+        return ChronologyAuthorityClient.SERVICE_NAME;
+    }
+
+}
+

--- a/services/chronology/service/src/main/java/org/collectionspace/services/chronology/nuxeo/ChronologyAuthorityConstants.java
+++ b/services/chronology/service/src/main/java/org/collectionspace/services/chronology/nuxeo/ChronologyAuthorityConstants.java
@@ -1,0 +1,11 @@
+package org.collectionspace.services.chronology.nuxeo;
+
+/**
+ * Constants for Chronology Authority
+ */
+public class ChronologyAuthorityConstants {
+
+    public final static String NUXEO_DOCTYPE = "ChronologyAuthority";
+    public final static String NUXEO_SCHEMA_NAME = "chronologyauthority";
+    public final static String NUXEO_DC_TITLE = "CollectionSpace-ChronologyAuthority";
+}

--- a/services/chronology/service/src/main/java/org/collectionspace/services/chronology/nuxeo/ChronologyAuthorityDocumentModelHandler.java
+++ b/services/chronology/service/src/main/java/org/collectionspace/services/chronology/nuxeo/ChronologyAuthorityDocumentModelHandler.java
@@ -1,0 +1,26 @@
+package org.collectionspace.services.chronology.nuxeo;
+
+import org.collectionspace.services.chronology.ChronologyauthoritiesCommon;
+import org.collectionspace.services.client.ChronologyAuthorityClient;
+import org.collectionspace.services.common.vocabulary.nuxeo.AuthorityDocumentModelHandler;
+
+/**
+ * ChronologyAuthorityDocumentModelHandler
+ */
+public class ChronologyAuthorityDocumentModelHandler
+    extends AuthorityDocumentModelHandler<ChronologyauthoritiesCommon> {
+    public ChronologyAuthorityDocumentModelHandler() {
+        super(ChronologyAuthorityClient.SERVICE_COMMON_PART_NAME,
+              ChronologyAuthorityClient.SERVICE_ITEM_NAME_COMMON_PART_NAME);
+    }
+
+    /**
+     * getQProperty converts the given property to qualified schema property
+     * @param prop
+     * @return
+     */
+    @Override
+    public String getQProperty(final String prop) {
+        return ChronologyAuthorityConstants.NUXEO_SCHEMA_NAME + ":" + prop;
+    }
+}

--- a/services/chronology/service/src/main/java/org/collectionspace/services/chronology/nuxeo/ChronologyConstants.java
+++ b/services/chronology/service/src/main/java/org/collectionspace/services/chronology/nuxeo/ChronologyConstants.java
@@ -1,0 +1,33 @@
+/**
+ * This document is a part of the source code and related artifacts
+ * for CollectionSpace, an open source collections management system
+ * for museums and related institutions:
+ *
+ * http://www.collectionspace.org
+ * http://wiki.collectionspace.org
+ *
+ * Licensed under the Educational Community License (ECL), Version 2.0.
+ * You may not use this file except in compliance with this License.
+ *
+ * You may obtain a copy of the ECL 2.0 License at
+ *
+ * https://source.collectionspace.org/collection-space/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.collectionspace.services.chronology.nuxeo;
+
+/**
+ * ChronologyConstants specifies constants for the Chronology service
+ *
+ */
+public class ChronologyConstants {
+    public final static String NUXEO_DOCTYPE = "Chronology";
+    public final static String NUXEO_SCHEMA_NAME = "chronology";
+    public final static String NUXEO_DC_TITLE = "CollectionSpace-Chronology";
+
+}

--- a/services/chronology/service/src/main/java/org/collectionspace/services/chronology/nuxeo/ChronologyDocumentModelHandler.java
+++ b/services/chronology/service/src/main/java/org/collectionspace/services/chronology/nuxeo/ChronologyDocumentModelHandler.java
@@ -1,0 +1,51 @@
+/**
+ *  This document is a part of the source code and related artifacts
+ *  for CollectionSpace, an open source collections management system
+ *  for museums and related institutions:
+ *
+ *  http://www.collectionspace.org
+ *  http://wiki.collectionspace.org
+ *
+ *  Licensed under the Educational Community License (ECL), Version 2.0.
+ *  You may not use this file except in compliance with this License.
+ *
+ *  You may obtain a copy of the ECL 2.0 License at
+ *
+ *  https://source.collectionspace.org/collection-space/LICENSE.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.collectionspace.services.chronology.nuxeo;
+
+import org.collectionspace.services.chronology.ChronologiesCommon;
+import org.collectionspace.services.client.ChronologyAuthorityClient;
+import org.collectionspace.services.common.vocabulary.nuxeo.AuthorityItemDocumentModelHandler;
+
+/**
+ * ChronologyDocumentModelHandler
+ */
+public class ChronologyDocumentModelHandler extends AuthorityItemDocumentModelHandler<ChronologiesCommon> {
+    public ChronologyDocumentModelHandler() {
+        super(ChronologyAuthorityClient.SERVICE_COMMON_PART_NAME,
+              ChronologyAuthorityClient.SERVICE_ITEM_NAME_COMMON_PART_NAME);
+    }
+
+    @Override
+    public String getAuthorityServicePath() {
+        return ChronologyAuthorityClient.SERVICE_PATH_COMPONENT;
+    }
+
+    @Override
+    public String getQProperty(String prop) {
+        return ChronologyConstants.NUXEO_SCHEMA_NAME + ":" + prop;
+    }
+
+    @Override
+    public String getParentCommonSchemaName() {
+        return ChronologyAuthorityClient.SERVICE_COMMON_PART_NAME;
+    }
+}

--- a/services/chronology/service/src/main/java/org/collectionspace/services/chronology/nuxeo/ChronologyValidatorHandler.java
+++ b/services/chronology/service/src/main/java/org/collectionspace/services/chronology/nuxeo/ChronologyValidatorHandler.java
@@ -1,0 +1,128 @@
+/**
+ * This document is a part of the source code and related artifacts
+ * for CollectionSpace, an open source collections management system
+ * for museums and related institutions:
+ *
+ * http://www.collectionspace.org
+ * http://wiki.collectionspace.org
+ *
+ * Licensed under the Educational Community License (ECL), Version 2.0.
+ * You may not use this file except in compliance with this License.
+ *
+ * You may obtain a copy of the ECL 2.0 License at
+ * https://source.collectionspace.org/collection-space/LICENSE.txt
+ */
+package org.collectionspace.services.chronology.nuxeo;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.collectionspace.services.chronology.ChronologiesCommon;
+import org.collectionspace.services.chronology.ChronologyTermGroup;
+import org.collectionspace.services.chronology.ChronologyTermGroupList;
+import org.collectionspace.services.common.api.Tools;
+import org.collectionspace.services.common.document.InvalidDocumentException;
+import org.collectionspace.services.common.document.ValidatorHandlerImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * ChronologyValidatorHandler
+ */
+public class ChronologyValidatorHandler<IT, OT> extends ValidatorHandlerImpl<IT, OT> {
+
+    final Logger logger = LoggerFactory.getLogger(ChronologyValidatorHandler.class);
+
+    /**
+     * 'Bad pattern' for shortIdentifiers matches any non-word characters
+     */
+    private static final Pattern SHORT_ID_BAD_PATTERN = Pattern.compile("[\\W]");
+    private static final String SHORT_ID_BAD_CHARS_ERROR =
+        "shortIdentifier must only contain standard word characters";
+    private static final String HAS_NO_TERMS_ERROR =
+        "Authority items must contain at least one term.";
+    private static final String TERM_HAS_EMPTY_DISPLAYNAME_ERROR =
+        "Each term group in an authority item must contain "
+        + "a non-empty display name.";
+
+
+    @Override
+    protected Class<?> getCommonPartClass() {
+        return null;
+    }
+
+    @Override
+    protected void handleCreate() throws InvalidDocumentException {
+        final ChronologiesCommon chronology = (ChronologiesCommon) getCommonPart();
+        // No guarantee that there is a common part in every post/update.
+        if (chronology != null) {
+            try {
+                final String shortId = chronology.getShortIdentifier();
+                if (shortId != null) {
+                    CS_ASSERT(shortIdentifierContainsOnlyValidChars(shortId), SHORT_ID_BAD_CHARS_ERROR);
+                }
+                CS_ASSERT(containsAtLeastOneTerm(chronology), HAS_NO_TERMS_ERROR);
+                CS_ASSERT(allTermsContainDisplayName(chronology), TERM_HAS_EMPTY_DISPLAYNAME_ERROR);
+            } catch (AssertionError e) {
+                logger.error(e.getMessage(), e);
+                throw new InvalidDocumentException(e.getMessage(), e);
+            }
+        }
+    }
+
+    @Override
+    protected void handleGet() throws InvalidDocumentException {
+    }
+
+    @Override
+    protected void handleGetAll() throws InvalidDocumentException {
+    }
+
+    @Override
+    protected void handleUpdate() throws InvalidDocumentException {
+        final ChronologiesCommon chronology = (ChronologiesCommon) getCommonPart();
+        // No guarantee that there is a common part in every post/update.
+        if (chronology != null) {
+            try {
+                // shortIdentifier is among a set of fields that are
+                // prevented from being changed on an update, and thus
+                // we don't need to check its value here.
+                CS_ASSERT(containsAtLeastOneTerm(chronology), HAS_NO_TERMS_ERROR);
+                CS_ASSERT(allTermsContainDisplayName(chronology), TERM_HAS_EMPTY_DISPLAYNAME_ERROR);
+            } catch (AssertionError e) {
+                logger.error(e.getMessage(), e);
+                throw new InvalidDocumentException(e.getMessage(), e);
+            }
+        }
+    }
+
+    @Override
+    protected void handleDelete() throws InvalidDocumentException {
+    }
+
+
+    private boolean shortIdentifierContainsOnlyValidChars(final String shortId) {
+        // Check whether any characters match the 'bad' pattern
+        return !SHORT_ID_BAD_PATTERN.matcher(shortId).find();
+    }
+
+    private boolean containsAtLeastOneTerm(final ChronologiesCommon chronology) {
+        final ChronologyTermGroupList termGroupList = chronology.getChronologyTermGroupList();
+        if (termGroupList == null) {
+            return false;
+        }
+        final List<ChronologyTermGroup> termGroups = termGroupList.getChronologyTermGroup();
+        return termGroups != null && !termGroups.isEmpty();
+    }
+
+    private boolean allTermsContainDisplayName(final ChronologiesCommon chronology) {
+        final ChronologyTermGroupList termGroupList = chronology.getChronologyTermGroupList();
+        final List<ChronologyTermGroup> termGroups = termGroupList.getChronologyTermGroup();
+        for (ChronologyTermGroup termGroup : termGroups) {
+            if (Tools.isBlank(termGroup.getTermDisplayName())) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -96,6 +96,7 @@
 		<module>uoc</module>
 		<module>publicitem</module>
 		<module>iterationreport</module>
+		<module>chronology</module>
 		<module>IntegrationTests</module>
 		<module>PerformanceTests</module>
 		<module>security</module>


### PR DESCRIPTION
**What does this do?**
Creates a new Chronology Authority

**Why are we doing this? (with JIRA link)**
https://collectionspace.atlassian.net/browse/DRYD-1133

This new authority allows records to reference eras (e.g. archaeological, geological, historical, etc) and events (e.g. presidential terms, wars, olympic games, etc).

**How should this be tested? Do these changes have associated tests?**

With Application PR:
* Verify that cspace is able to build and deploy;
* Once the server is running check that the authority and vocabularies are able to be queried, e.g.
  * curl -u 'admin@core.collectionspace.org:Administrator' http://localhost:8180/cspace-services/chronologyauthorities
  * curl -u 'admin@core.collectionspace.org:Administrator' 'http://localhost:8180/cspace-services/vocabularies/urn:cspace:name(chronologytermstatus)'
* Testing of adding, retrieving, and searching authorities can be done with cspace-ui

**Dependencies for merging? Releasing to production?**

Related prs for adding Chronology to the application and cspace-ui layers

One small thing I noticed - `RefNameUtils#getRelativeUri` logs a warning about chronology and citation being unrecognized authorities. This is the result of a hard coded list of authorities that it's checking against. There's an old jira link at this spot but we might need a new ticket for it.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter ran and tested against a local instance
