### PR TITLE
Optionally build UI packages from source.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 dev-master.xml
 .metadata/
 *tenant-bindings.merged.xml
+build
 target
 .settings
 .classpath

--- a/build.properties
+++ b/build.properties
@@ -20,8 +20,11 @@ cspace.services.war=${cspace.services.context}.war
 domain.nuxeo=nuxeo-server
 
 # UI settings
+cspace.ui.package.name=cspace-ui
 cspace.ui.library.name=cspaceUI
 cspace.ui.version=7.0.0
+cspace.ui.build.branch=master
+cspace.ui.build.node.ver=14
 
 #nuxeo
 nuxeo.release=9.10-HF30

--- a/cspace-ui/anthro/build.properties
+++ b/cspace-ui/anthro/build.properties
@@ -4,3 +4,4 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-anthro
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileAnthro
 tenant.ui.profile.plugin.version=6.0.5
+tenant.ui.profile.plugin.build.branch=master

--- a/cspace-ui/bonsai/build.properties
+++ b/cspace-ui/bonsai/build.properties
@@ -4,3 +4,4 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-bonsai
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileBonsai
 tenant.ui.profile.plugin.version=5.0.2
+tenant.ui.profile.plugin.build.branch=master

--- a/cspace-ui/botgarden/build.properties
+++ b/cspace-ui/botgarden/build.properties
@@ -4,3 +4,4 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-botgarden
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileBotGarden
 tenant.ui.profile.plugin.version=3.0.2
+tenant.ui.profile.plugin.build.branch=master

--- a/cspace-ui/build.xml
+++ b/cspace-ui/build.xml
@@ -19,29 +19,73 @@
 	</scriptdef>
 
 	<!-- set global properties for this build -->
-	<property name="services.trunk" value=".."/>
+	<property name="services.trunk" value=".." />
+	<property name="build.dir.name" value="build" />
+	<property name="build.dir" value="./${build.dir.name}" />
+	<property name="source.dir" value="${build.dir}/source" />
+	<property name="staging.dir" value="${build.dir}/staging" />
 
 	<!-- Environment should be declared before reading build.properties -->
 	<property environment="env" />
 	<property file="${services.trunk}/build.properties" />
+	<propertycopy name="cspace.ui.build" from="env.CSPACE_UI_BUILD" />
 
-	<property name="cspace.ui.filename" value="${cspace.ui.library.name}@${cspace.ui.version}.min.js" />
-
-	<target name="deploy_cspace_ui_js">
-		<exec executable="curl" failonerror="true">
-			<arg line="-o ${cspace.ui.filename} --fail --insecure --remote-name --location https://unpkg.com/cspace-ui@${cspace.ui.version}/dist/${cspace.ui.library.name}.min.js"/>
-		</exec>
-
-		<move file="${cspace.ui.filename}" todir="${jee.deploy.cspace.ui.shared}"></move>
+	<target name="clean">
+		<delete includeEmptyDirs="true">
+			<fileset dir="." includes="**/${build.dir.name}/" defaultexcludes="no" />
+		</delete>
 	</target>
 
-	<target name="undeploy_cspace_ui_js" description="undeploy collectionspace ui common components from ${jee.server.cspace}">
-		<delete file="${jee.deploy.cspace.ui.shared}/${cspace.ui.filename}" />
+	<target name="ensure_source_dir" if="${cspace.ui.build}">
+		<mkdir dir="${source.dir}" />
+	</target>
+
+	<target name="ensure_staging_dir">
+		<mkdir dir="${staging.dir}" />
+	</target>
+
+	<target name="install_nvm" if="${cspace.ui.build}">
+		<exec executable="bash" failonerror="true">
+			<arg value="-c" />
+			<arg line='"curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash"' />
+		</exec>
+	</target>
+
+	<target name="install_node" depends="install_nvm" if="${cspace.ui.build}">
+		<exec executable="bash" failonerror="true">
+			<arg value="-c" />
+			<arg value='source "$HOME/.nvm/nvm.sh" &amp;&amp; nvm install ${cspace.ui.build.node.ver} &amp;&amp; nvm use ${cspace.ui.build.node.ver} &amp;&amp; nvm install-latest-npm' />
+		</exec>
+	</target>
+
+	<target name="build_cspace_ui_js" depends="ensure_staging_dir,ensure_source_dir,install_node" if="${cspace.ui.build}">
+		<exec executable="bash" failonerror="true">
+			<arg value="-c" />
+			<arg value="./build_js.sh ${cspace.ui.package.name} ${cspace.ui.build.branch} ${source.dir} ${staging.dir} ${cspace.ui.library.name}"/>
+		</exec>
+	</target>
+
+	<target name="download_cspace_ui_js" depends="ensure_staging_dir" unless="${cspace.ui.build}">
+		<exec executable="curl" failonerror="true">
+			<arg line="-o ${staging.dir}/${cspace.ui.library.name}@${cspace.ui.version}.min.js --fail --insecure --location https://cdn.jsdelivr.net/npm/cspace-ui@${cspace.ui.version}/dist/${cspace.ui.library.name}.min.js"/>
+		</exec>
+	</target>
+
+	<target name="deploy_cspace_ui_js" depends="build_cspace_ui_js,download_cspace_ui_js">
+		<pathconvert property="cspace.ui.install.filename" targetos="unix">
+			<first>
+				<fileset dir="${staging.dir}" includes="${cspace.ui.library.name}@*.min.js" />
+			</first>
+
+			<mapper type="flatten" />
+		</pathconvert>
+
+		<copy file="${staging.dir}/${cspace.ui.install.filename}" todir="${jee.deploy.cspace.ui.shared}" />
 	</target>
 
 	<target name="deploy_tenants" depends="deploy_cspace_ui_js">
 		<subant target="deploy_tenant" genericantfile="${ant.file}" inheritall="true">
-			<dirset dir="." includes="*" />
+			<dirset dir="." includes="*" excludes="${build.dir.name}" />
 		</subant>
 	</target>
 
@@ -51,11 +95,12 @@
 		<propertycopy name="tenant.create.disabled" from="env.CSPACE_${tenant.shortname.upper}_CREATE_DISABLED_OPT" />
 
 		<property file="${basedir}/build.properties" />
-		<property name="tenant.ui.profile.plugin.filename" value="${tenant.ui.profile.plugin.library.name}@${tenant.ui.profile.plugin.version}.min.js" />
 
 		<!-- Default values, in case these weren't set in the tenant's build.properties. -->
 		<property name="tenant.ui.webapp.dir" value="cspace#${tenant.shortname}" />
 		<property name="tenant.ui.basename" value="/cspace/${tenant.shortname}" />
+
+		<echo message="Deploying tenant ${tenant.shortname}" />
 
 		<!-- Get the configured tenant ID from tenant bindings. This will be in the property tenant:tenantBinding.id. -->
 		<xmlproperty keepRoot="false" collapseAttributes="true" file="../../services/common/src/main/cspace/config/services/tenants/${tenant.shortname}/${tenant.shortname}-tenant-bindings.delta.xml" />
@@ -78,27 +123,74 @@
 			<isset property="tenant:tenantBinding.id"/>
 		</condition>
 
-		<antcall target="deploy_tenant_js" />
 		<antcall target="deploy_tenant_webapp" />
 	</target>
 
-	<target name="deploy_tenant_js" if="tenant.ui.profile.plugin.package.name" unless="${tenant.create.disabled}">
-		<exec executable="curl" failonerror="true">
-			<arg line="-o ${tenant.ui.profile.plugin.filename} --fail --insecure --remote-name --location https://unpkg.com/${tenant.ui.profile.plugin.package.name}@${tenant.ui.profile.plugin.version}/dist/${tenant.ui.profile.plugin.library.name}.min.js"/>
-		</exec>
-
-		<move file="${tenant.ui.profile.plugin.filename}" todir="${jee.deploy.cspace.ui.shared}"></move>
+	<target name="check_build_tenant_js">
+		<condition property="should.build.tenant.js">
+			<and>
+				<isset property="tenant.ui.profile.plugin.package.name" />
+				<isfalse value="${tenant.create.disabled}" />
+				<istrue value="${cspace.ui.build}" />
+			</and>
+		</condition>
 	</target>
 
-	<target name="deploy_tenant_webapp" unless="${tenant.create.disabled}">
-		<filter token="UI_FILENAME" value="${cspace.ui.filename}" />
-		<filter token="UI_PROFILE_PLUGIN_FILENAME" value="${tenant.ui.profile.plugin.filename}" />
+	<target name="build_tenant_js" depends="check_build_tenant_js,ensure_staging_dir,ensure_source_dir,install_node" if="should.build.tenant.js">
+		<fail message="Build branch not found for ${tenant.shortname}. Set the tenant.ui.profile.plugin.build.branch property in ${basedir}/build.properties.">
+			<condition>
+				<not>
+					<isset property="tenant.ui.profile.plugin.build.branch"/>
+				</not>
+			</condition>
+		</fail>
+
+		<exec executable="bash" failonerror="true">
+			<arg value="-c" />
+			<arg value="../build_js.sh ${tenant.ui.profile.plugin.package.name} ${tenant.ui.profile.plugin.build.branch} ${source.dir} ${staging.dir} ${tenant.ui.profile.plugin.library.name}"/>
+		</exec>
+	</target>
+
+	<target name="check_download_tenant_js">
+		<condition property="should.download.tenant.js">
+			<and>
+				<isset property="tenant.ui.profile.plugin.package.name" />
+				<isfalse value="${tenant.create.disabled}" />
+				<isfalse value="${cspace.ui.build}" />
+			</and>
+		</condition>
+	</target>
+
+	<target name="download_tenant_js" depends="check_download_tenant_js,ensure_staging_dir" if="should.download.tenant.js">
+		<exec executable="curl" failonerror="true">
+			<arg line="-o ${staging.dir}/${tenant.ui.profile.plugin.library.name}@${tenant.ui.profile.plugin.version}.min.js --fail --insecure --location https://cdn.jsdelivr.net/npm/${tenant.ui.profile.plugin.package.name}@${tenant.ui.profile.plugin.version}/dist/${tenant.ui.profile.plugin.library.name}.min.js"/>
+		</exec>
+	</target>
+
+	<target name="deploy_tenant_js" depends="build_tenant_js,download_tenant_js" if="tenant.ui.profile.plugin.package.name" unless="${tenant.create.disabled}">
+		<pathconvert property="tenant.ui.profile.plugin.install.filename" targetos="unix">
+			<first>
+				<fileset dir="${staging.dir}" includes="${tenant.ui.profile.plugin.library.name}@*.min.js" />
+			</first>
+
+			<mapper type="flatten" />
+		</pathconvert>
+
+		<copy file="${staging.dir}/${tenant.ui.profile.plugin.install.filename}" todir="${jee.deploy.cspace.ui.shared}" />
+	</target>
+
+	<target name="deploy_tenant_webapp" depends="deploy_tenant_js" unless="${tenant.create.disabled}">
+		<filter token="UI_FILENAME" value="${cspace.ui.install.filename}" />
+		<filter token="UI_PROFILE_PLUGIN_FILENAME" value="${tenant.ui.profile.plugin.install.filename}" />
 		<filter token="UI_PROFILE_PLUGIN_LIBRARY_NAME" value="${tenant.ui.profile.plugin.library.name}" />
 		<filter token="BASENAME" value="${tenant.ui.basename}" />
 		<filter token="TENANT_ID" value="${resolved.tenant.id}" />
 
 		<copy todir="${jee.deploy.cspace}/${tenant.ui.webapp.dir}" failonerror="false" filtering="true" overwrite="true">
-			<fileset dir="${basedir}" excludes="build.properties" />
+			<fileset dir="${basedir}">
+				<exclude name="build.properties" />
+				<exclude name="${build.dir.name}/" />
+			</fileset>
 		</copy>
 	</target>
 
@@ -124,7 +216,7 @@
 		<delete dir="${jee.deploy.cspace.ui.shared}" />
 	</target>
 
-	<target name="deploy" depends="deploy_tenants" description="deploy cspace ui to ${jee.server.cspace}" />
+	<target name="deploy" depends="clean,deploy_tenants" description="deploy cspace ui to ${jee.server.cspace}" />
 
-	<target name="undeploy" depends="undeploy_tenants, undeploy_js" description="undeploy collectionspace ui components from ${jee.server.cspace}" />
+	<target name="undeploy" depends="undeploy_tenants,undeploy_js" description="undeploy collectionspace ui components from ${jee.server.cspace}" />
 </project>

--- a/cspace-ui/build_js.sh
+++ b/cspace-ui/build_js.sh
@@ -1,0 +1,21 @@
+#/bin/bash
+
+PACKAGE_NAME=$1
+BRANCH_NAME=$2
+CHECKOUT_DIR=$3
+OUTPUT_DIR=$4
+LIBRARY_NAME=$5
+
+CODE_DIR=$CHECKOUT_DIR/$PACKAGE_NAME.js
+
+. "$HOME/.nvm/nvm.sh"
+
+rm -r $CODE_DIR
+git clone --branch $BRANCH_NAME --depth 1 https://github.com/collectionspace/$PACKAGE_NAME.js.git $CODE_DIR
+
+pushd $CODE_DIR
+COMMIT_HASH=`git rev-parse --short HEAD`
+npm install
+popd
+
+cp $CODE_DIR/dist/*.min.js "$OUTPUT_DIR/$LIBRARY_NAME@$COMMIT_HASH.min.js"

--- a/cspace-ui/fcart/build.properties
+++ b/cspace-ui/fcart/build.properties
@@ -4,3 +4,4 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-fcart
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileFCart
 tenant.ui.profile.plugin.version=5.0.3
+tenant.ui.profile.plugin.build.branch=master

--- a/cspace-ui/herbarium/build.properties
+++ b/cspace-ui/herbarium/build.properties
@@ -4,3 +4,4 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-herbarium
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileHerbarium
 tenant.ui.profile.plugin.version=2.0.2
+tenant.ui.profile.plugin.build.branch=master

--- a/cspace-ui/lhmc/build.properties
+++ b/cspace-ui/lhmc/build.properties
@@ -4,3 +4,4 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-lhmc
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileLHMC
 tenant.ui.profile.plugin.version=5.0.3
+tenant.ui.profile.plugin.build.branch=master

--- a/cspace-ui/materials/build.properties
+++ b/cspace-ui/materials/build.properties
@@ -4,3 +4,4 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-materials
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileMaterials
 tenant.ui.profile.plugin.version=3.0.3
+tenant.ui.profile.plugin.build.branch=master

--- a/cspace-ui/publicart/build.properties
+++ b/cspace-ui/publicart/build.properties
@@ -4,3 +4,4 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-publicart
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfilePublicArt
 tenant.ui.profile.plugin.version=4.0.3
+tenant.ui.profile.plugin.build.branch=master


### PR DESCRIPTION
**What does this do?**

This adds the ability to optionally locally check out and build UI packages from source, instead of downloading pre-built distributions that were published to npm.

If the environment variable `CSPACE_UI_BUILD` is set to `true`, the cspace-ui package and all enabled tenant plugins are cloned from github and built from source. The branches to build from are specified in build.properties files.

**Why are we doing this? (with JIRA link)**

This allows the nightly build to use the latest in-development UI packages, without the need to publish possibly untested work to npm. This makes it easier to evaluate in-progress work, without sharing it with the rest of the world.

**How should this be tested? Do these changes have associated tests?**

If `CSPACE_UI_BUILD` is not set to `true`, the build and deploy should work as it did before. If `CSPACE_UI_BUILD` is set to `true`, the latest cspace-ui and plugin code should be deployed. This can be verified by checking the build numbers (git commit hashes) displayed in the footer.

**Dependencies for merging? Releasing to production?**

None

**Has the application documentation been updated for these changes?**

For now, I'm considering this a non-public feature for us to use during development, but I'll update the installation docs if this changes.

**Did someone actually run this code to verify it works?**

@ray-lee tested a build/deploy with and without `CSPACE_UI_BUILD` set to `true`.