### PR TITLE
DRYD-1221: Support media images in reports.

### DIFF
--- a/services/blob/service/src/main/java/org/collectionspace/services/blob/BlobResource.java
+++ b/services/blob/service/src/main/java/org/collectionspace/services/blob/BlobResource.java
@@ -121,7 +121,7 @@ public class BlobResource extends NuxeoBasedResource {
     	return result;
     }
     
-    private InputStream getBlobContent(ServiceContext<PoxPayloadIn, PoxPayloadOut> ctx,
+    public InputStream getBlobContent(ServiceContext<PoxPayloadIn, PoxPayloadOut> ctx,
     		String csid, 
     		String derivativeTerm, 
     		StringBuffer outMimeType) throws CSWebApplicationException {

--- a/services/report/service/pom.xml
+++ b/services/report/service/pom.xml
@@ -24,7 +24,7 @@
             <artifactId>org.collectionspace.services.account.service</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
-        </dependency>            
+        </dependency>
         <dependency>
             <groupId>org.collectionspace.services</groupId>
             <artifactId>org.collectionspace.services.config</artifactId>
@@ -53,6 +53,11 @@
         <dependency>
             <groupId>org.collectionspace.services</groupId>
             <artifactId>org.collectionspace.services.collectionobject.jaxb</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.collectionspace.services</groupId>
+            <artifactId>org.collectionspace.services.media.service</artifactId>
             <version>${project.version}</version>
         </dependency>
         <!-- External dependencies -->

--- a/services/report/service/src/main/java/org/collectionspace/services/report/jasperreports/CSpaceReportScriptlet.java
+++ b/services/report/service/src/main/java/org/collectionspace/services/report/jasperreports/CSpaceReportScriptlet.java
@@ -1,4 +1,4 @@
-package org.collectionspace.services.report.nuxeo;
+package org.collectionspace.services.report.jasperreports;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -18,8 +18,8 @@ import org.slf4j.LoggerFactory;
  * fields to de-urn are supplied in the deurnfields parameter, as a comma-delimited list. If "*" is
  * specified, all string-typed fields are de-urned.
  */
-public class DefaultReportScriptlet extends JRDefaultScriptlet {
-	private final Logger logger = LoggerFactory.getLogger(DefaultReportScriptlet.class);
+public class CSpaceReportScriptlet extends JRDefaultScriptlet {
+	private final Logger logger = LoggerFactory.getLogger(CSpaceReportScriptlet.class);
 
 	private static String DEURN_FIELDS_PARAM = "deurnfields";
 

--- a/services/report/service/src/main/java/org/collectionspace/services/report/jasperreports/CSpaceRepositoryExtensionsRegistryFactory.java
+++ b/services/report/service/src/main/java/org/collectionspace/services/report/jasperreports/CSpaceRepositoryExtensionsRegistryFactory.java
@@ -1,0 +1,30 @@
+package org.collectionspace.services.report.jasperreports;
+
+import java.util.Collections;
+import java.util.List;
+
+import net.sf.jasperreports.engine.JRPropertiesMap;
+import net.sf.jasperreports.extensions.ExtensionsRegistry;
+import net.sf.jasperreports.extensions.ExtensionsRegistryFactory;
+import net.sf.jasperreports.repo.RepositoryService;
+
+public class CSpaceRepositoryExtensionsRegistryFactory implements ExtensionsRegistryFactory {
+
+	private static final RepositoryService repositoryService = new CSpaceRepositoryService();
+
+	private static final ExtensionsRegistry extensionsRegistry = new ExtensionsRegistry() {
+		@Override
+		public <T> List<T> getExtensions(Class<T> extensionType) {
+			if (RepositoryService.class.equals(extensionType)) {
+				return (List<T>) Collections.singletonList(repositoryService);
+			}
+
+			return null;
+		}
+	};
+
+	@Override
+	public ExtensionsRegistry createRegistry(String registryId, JRPropertiesMap properties) {
+		return extensionsRegistry;
+	}
+}

--- a/services/report/service/src/main/java/org/collectionspace/services/report/jasperreports/CSpaceRepositoryService.java
+++ b/services/report/service/src/main/java/org/collectionspace/services/report/jasperreports/CSpaceRepositoryService.java
@@ -1,0 +1,83 @@
+package org.collectionspace.services.report.jasperreports;
+
+import java.io.InputStream;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang.StringUtils;
+import org.collectionspace.services.client.MediaClient;
+import org.collectionspace.services.common.ResourceMap;
+import org.collectionspace.services.media.MediaResource;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.sf.jasperreports.repo.InputStreamResource;
+import net.sf.jasperreports.repo.RepositoryService;
+import net.sf.jasperreports.repo.Resource;
+
+public class CSpaceRepositoryService implements RepositoryService {
+	final static Logger logger = LoggerFactory.getLogger(CSpaceRepositoryService.class);
+
+	public static final String CSPACE_PROTOCOL = "cspace://";
+	public static final Pattern MEDIA_CONTENT_PATH_PATTERN = Pattern.compile("^/?media/(.*?)/blob/derivatives/(.*?)/content$");
+
+	@Override
+	public Resource getResource(String uri) {
+		return getResource(uri, InputStreamResource.class);
+	}
+
+	@Override
+	public <K extends Resource> K getResource(String uri, Class<K> resourceType) {
+		if (
+			InputStreamResource.class.equals(resourceType)
+			&& uri.startsWith(CSPACE_PROTOCOL))
+		{
+			return ((K) getCSpaceResource(uri.substring(CSPACE_PROTOCOL.length())));
+		}
+
+		return null;
+	}
+
+	@Override
+	public void saveResource(String uri, Resource resource) {
+		// Not implemented
+	}
+
+	private InputStreamResource getCSpaceResource(String resourcePath) {
+		Matcher matcher = MEDIA_CONTENT_PATH_PATTERN.matcher(resourcePath);
+
+		if (matcher.matches()) {
+			String mediaCsid = matcher.group(1);
+			String derivative = matcher.group(2);
+
+			return getMediaContentResource(mediaCsid, derivative);
+		}
+
+		return null;
+	}
+
+	private InputStreamResource getMediaContentResource(String mediaCsid, String derivative) {
+		if (StringUtils.isNotEmpty(mediaCsid) && StringUtils.isNotEmpty(derivative)) {
+			ResourceMap resourceMap = ResteasyProviderFactory.getContextData(ResourceMap.class);
+			MediaResource mediaResource = (MediaResource) resourceMap.get(MediaClient.SERVICE_NAME);
+
+			InputStream contentStream = null;
+
+			try {
+				contentStream = mediaResource.getDerivativeContent(mediaCsid, derivative);
+			} catch (Exception e) {
+				logger.warn("Error getting {} derivative for media csid {}: {}", derivative, mediaCsid, e.getMessage());
+			}
+
+			if (contentStream != null) {
+				InputStreamResource inputStreamResource = new InputStreamResource();
+				inputStreamResource.setInputStream(contentStream);
+
+				return inputStreamResource;
+			}
+		}
+
+		return null;
+	}
+}

--- a/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
+++ b/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
@@ -380,7 +380,7 @@ public class ReportDocumentModelHandler extends NuxeoDocumentModelHandler<Report
 
 				JasperDesign design = JRXmlLoader.load(sourceFilePath);
 
-				design.setScriptletClass("org.collectionspace.services.report.nuxeo.DefaultReportScriptlet");
+				design.setScriptletClass("org.collectionspace.services.report.jasperreports.CSpaceReportScriptlet");
 
 				JasperCompileManager.compileReportToFile(design, compiledFilePath);
 			}

--- a/services/report/service/src/main/resources/jasperreports_extension.properties
+++ b/services/report/service/src/main/resources/jasperreports_extension.properties
@@ -1,0 +1,1 @@
+net.sf.jasperreports.extension.registry.factory.cspace.repository=org.collectionspace.services.report.jasperreports.CSpaceRepositoryExtensionsRegistryFactory


### PR DESCRIPTION
**What does this do?**

This adds a [JasperReports extension](https://jasperreports.sourceforge.net/api/net/sf/jasperreports/extensions/package-summary.html) that allows reports to include images from media record content. The extension registers a [RepositoryService](https://jasperreports.sourceforge.net/api/net/sf/jasperreports/repo/RepositoryService.html) that handles URLs with the `cspace` protocol.

To display media content, report authors can add images with expressions like `"cspace://media/" + $F{mediacsid} + "/blob/derivatives/Thumbnail/content"`. The reporting engine will retrieve the content for the specified media csid and derivative to display in the report. `Thumbnail` can be replaced with any valid derivative name.

This also moves the CSpace JasperReports scriptlet from #312 to a more appropriate package.

**Why are we doing this? (with JIRA link)**

This allows reports to include images from media records.

JIRA: https://collectionspace.atlassian.net/browse/DRYD-1221

**How should this be tested? Do these changes have associated tests?**

- Existing reports should continue to work as they do now.
- New reports that contain images loaded from the above expression should work, and display the expected images.
 
**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

I'm not sure where to put the documentation for this right now, given the state of our docs. For now I'm parking some draft documentation in the JIRA: https://collectionspace.atlassian.net/browse/DRYD-1221?focusedCommentId=57855

**Did someone actually run this code to verify it works?**

@ray-lee ran some existing reports and a new report that contains images from media records.