### PR TITLE
DRYD-1133: Update chronology tests

### DIFF
--- a/services/chronology/client/src/main/java/org/collectionspace/services/client/ChronologyAuthorityClientUtils.java
+++ b/services/chronology/client/src/main/java/org/collectionspace/services/client/ChronologyAuthorityClientUtils.java
@@ -64,14 +64,14 @@ public class ChronologyAuthorityClientUtils {
      *
      * @param vcsid the csid of the authority
      * @param authRefName the refname of the authority
-     * @param materialMap properties for the new chronology
+     * @param chronologyMap properties for the new chronology
      * @param terms terms for the new chronology
      * @param client the service client
      * @return the csid of the new item
      */
     public static String createItemInAuthority(final String vcsid,
                                                final String authRefName,
-                                               final Map<String, String> materialMap,
+                                               final Map<String, String> chronologyMap,
                                                final List<ChronologyTermGroup> terms,
                                                final ChronologyAuthorityClient client) {
         // Expected status code: 201 Created
@@ -84,24 +84,24 @@ public class ChronologyAuthorityClientUtils {
             displayName = terms.get(0).getTermDisplayName();
         }
         logger.debug("Creating item with display name: {} in chronologyAuthority: {}", displayName, vcsid);
-        PoxPayloadOut multipart = createChronologyInstance(materialMap, terms, client.getItemCommonPartName());
+        PoxPayloadOut multipart = createChronologyInstance(chronologyMap, terms, client.getItemCommonPartName());
         String newID;
 
         final Response res = client.createItem(vcsid, multipart);
         try {
             int statusCode = res.getStatus();
 
-            if(!REQUEST_TYPE.isValidStatusCode(statusCode)) {
+            if (!REQUEST_TYPE.isValidStatusCode(statusCode)) {
                 final String error = "Could not create Item: %s in chronologyAuthority: %s, %s";
                 throw new RuntimeException(String.format(error,
-                                                         materialMap.get(ChronologyJAXBSchema.SHORT_IDENTIFIER),
+                                                         chronologyMap.get(ChronologyJAXBSchema.SHORT_IDENTIFIER),
                                                          authRefName,
                                                          invalidStatusCodeMessage(REQUEST_TYPE, statusCode)));
             }
-            if(statusCode != EXPECTED_STATUS_CODE) {
+            if (statusCode != EXPECTED_STATUS_CODE) {
                 final String error = "Unexpected Status when creating Item: %s in chronologyAuthority %s, Status: %d";
                 throw new RuntimeException(String.format(error,
-                                                         materialMap.get(ChronologyJAXBSchema.SHORT_IDENTIFIER),
+                                                         chronologyMap.get(ChronologyJAXBSchema.SHORT_IDENTIFIER),
                                                          authRefName,
                                                          statusCode));
             }

--- a/services/chronology/client/src/test/java/org/collectionspace/services/client/test/ChronologyAuthorityServiceTest.java
+++ b/services/chronology/client/src/test/java/org/collectionspace/services/client/test/ChronologyAuthorityServiceTest.java
@@ -12,7 +12,7 @@
  * You may obtain a copy of the ECL 2.0 License at
  * https://source.collectionspace.org/collection-space/LICENSE.txt
  */
-package org.collectionspace.services.client;
+package org.collectionspace.services.client.test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -30,7 +30,12 @@ import org.collectionspace.services.chronology.ChronologiesCommon;
 import org.collectionspace.services.chronology.ChronologyTermGroup;
 import org.collectionspace.services.chronology.ChronologyTermGroupList;
 import org.collectionspace.services.chronology.ChronologyauthoritiesCommon;
-import org.collectionspace.services.client.test.AbstractAuthorityServiceTest;
+import org.collectionspace.services.client.AuthorityClient;
+import org.collectionspace.services.client.ChronologyAuthorityClient;
+import org.collectionspace.services.client.ChronologyAuthorityClientUtils;
+import org.collectionspace.services.client.CollectionSpaceClient;
+import org.collectionspace.services.client.PoxPayloadIn;
+import org.collectionspace.services.client.PoxPayloadOut;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
@@ -309,7 +314,7 @@ public class ChronologyAuthorityServiceTest
 
     @Override
     protected String getItemServiceRootURL(String parentResourceIdentifier) {
-        return getResourceURL(parentResourceIdentifier) + "/" + getServicePathComponent();
+        return getResourceURL(parentResourceIdentifier) + "/" + AuthorityClient.ITEMS;
     }
 
     @Override


### PR DESCRIPTION
**What does this do?**
Fixes failing test for chronology
Update variable name to be chronology in its util class 

**Why are we doing this? (with JIRA link)**
The cspace nightly build is failing because of two tests in chronology - `verifyIllegalItemDisplayName` and `testItemSubmitRequest`.

When running the tests, `testItemSubmitRequest` was failing because the url being created was incorrect and need to use the  `AuthorityClient.ITEMS` path. `verifyIllegalItemDisplayName` was giving a NPE which appears to have been resolved though it wasn't addressed directly. I did move the test class into the test package to be consistent with other authorities but nothing else was changed for it. 

**How should this be tested? Do these changes have associated tests?**

* Run `mvn test` and verify everything passes

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter ran tests on the chronology module