### PR TITLE
DRYD-1176: Add xml payload for incomingloanletter

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/incoming_loan_letter.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/incoming_loan_letter.jrxml
@@ -38,7 +38,7 @@
   from persons_common person
   inner join local_person_authority local_auth on person.inauthority = local_auth.name
   inner join hierarchy hier on hier.id = person.id
-  inner join hierarchy ptg_hier on ptg_hier.parentid = person.id and ptg_hier.primarytype = 'personTermGroup'
+  inner join hierarchy ptg_hier on ptg_hier.parentid = person.id and ptg_hier.primarytype = 'personTermGroup' and ptg_hier.pos = 0
   inner join persontermgroup ptg on ptg.id = ptg_hier.id
   left outer join contacts_common contact on contact.initem = hier.name
   left outer join hierarchy addr_hier on addr_hier.parentid = contact.id and addr_hier.primarytype = 'addressGroup' and addr_hier.pos = 0
@@ -48,7 +48,7 @@
   from organizations_common org
   inner join local_org_authority local_auth on org.inauthority = local_auth.name
   inner join hierarchy hier on hier.id = org.id
-  inner join hierarchy otg_hier on otg_hier.parentid = org.id and otg_hier.primarytype = 'orgTermGroup'
+  inner join hierarchy otg_hier on otg_hier.parentid = org.id and otg_hier.primarytype = 'orgTermGroup' and otg_hier.pos = 0
   inner join orgtermgroup otg on otg.id = otg_hier.id
   left outer join contacts_common contact on contact.initem = hier.name
   left outer join hierarchy addr_hier on addr_hier.parentid = contact.id and addr_hier.primarytype = 'addressGroup' and addr_hier.pos = 0

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/incoming_loan_letter.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/incoming_loan_letter.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<document name="report">
+  <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
+    <name>Incoming Loan Letter</name>
+    <notes>Incoming Loan Letter</notes>
+    <forDocTypes>
+      <forDocType>Loanin</forDocType>
+    </forDocTypes>
+    <supportsSingleDoc>true</supportsSingleDoc>
+    <supportsDocList>false</supportsDocList>
+    <supportsGroup>false</supportsGroup>
+    <supportsNoContext>true</supportsNoContext>
+    <filename>incoming_loan_letter.jrxml</filename>
+    <outputMIME>application/pdf</outputMIME>
+  </ns2:reports_common>
+</document>


### PR DESCRIPTION
**What does this do?**
Adds xml for registering the incoming loan letter report with cspace
Small edit to the incoming loan letter report to only fetch the first term group for person/organizations

**Why are we doing this? (with JIRA link)**
To assist with registering reports

**How should this be tested? Do these changes have associated tests?**
Test that the xml can be used in the report API call, e.g.
```
curl -X POST http://localhost:8180/cspace-services/reports -i -u admin@core.collectionspace.org:Administrator -H "Content-Type: application/xml" -T incoming_loan_letter.xml
``` 

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@mikejritter previously used this for testing the incoming loan letter report