### PR TITLE
Upgrade dom4j to 2.1.4.

### DIFF
--- a/3rdparty/nuxeo/nuxeo-platform-elasticsearch/pom.xml
+++ b/3rdparty/nuxeo/nuxeo-platform-elasticsearch/pom.xml
@@ -25,6 +25,11 @@
             <groupId>org.nuxeo.ecm.automation</groupId>
             <artifactId>nuxeo-automation-io</artifactId>
         </dependency>
+        <!-- Needed by nuxeo-automation-io, since we excluded dom4j:dom4j in order to upgrade to org.dom4j:dom4j -->
+        <dependency>
+            <groupId>org.dom4j</groupId>
+            <artifactId>dom4j</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.collectionspace.services</groupId>
             <artifactId>org.collectionspace.services.common</artifactId>

--- a/3rdparty/nuxeo/nuxeo-platform-thumbnail/pom.xml
+++ b/3rdparty/nuxeo/nuxeo-platform-thumbnail/pom.xml
@@ -32,7 +32,11 @@
         <dependency>
           <groupId>org.nuxeo.ecm.platform</groupId>
           <artifactId>nuxeo-platform-imaging-core</artifactId>
-          <scope>provided</scope>
+        </dependency>
+        <!-- Needed by nuxeo-platform-imaging-core, since we excluded dom4j:dom4j in order to upgrade to org.dom4j:dom4j -->
+        <dependency>
+            <groupId>org.dom4j</groupId>
+            <artifactId>dom4j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.collectionspace.services</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -512,6 +512,12 @@
 				<scope>provided</scope>
 			</dependency>
 
+			<dependency>
+				<groupId>org.dom4j</groupId>
+				<artifactId>dom4j</artifactId>
+				<version>2.1.4</version>
+			</dependency>
+
 			<!-- Start of Nuxeo dependencies -->
 
 			<dependency>
@@ -535,6 +541,11 @@
 						<groupId>org.slf4j</groupId>
 						<artifactId>slf4j-log4j12</artifactId>
 					</exclusion>
+					<exclusion>
+						<!-- Exclude dom4j:dom4j so we can upgrade to org.dom4j:dom4j. -->
+						<groupId>dom4j</groupId>
+						<artifactId>dom4j</artifactId>
+					</exclusion>
 				</exclusions>
 			</dependency>
 			<dependency>
@@ -549,6 +560,11 @@
 					<exclusion>
 						<groupId>xerces</groupId>
 						<artifactId>xercesImpl</artifactId>
+					</exclusion>
+					<!-- Exclude dom4j:dom4j so we can upgrade to org.dom4j:dom4j. -->
+					<exclusion>
+						<groupId>dom4j</groupId>
+						<artifactId>dom4j</artifactId>
 					</exclusion>
 				</exclusions>
 			</dependency>
@@ -586,6 +602,11 @@
 						<groupId>com.sun.jersey</groupId>
 						<artifactId>jersey-servlet</artifactId>
 					</exclusion>
+					<!-- Exclude dom4j:dom4j so we can upgrade to org.dom4j:dom4j. -->
+					<exclusion>
+						<groupId>dom4j</groupId>
+						<artifactId>dom4j</artifactId>
+					</exclusion>
 				</exclusions>
 			</dependency>
 			<dependency>
@@ -618,6 +639,13 @@
 				<groupId>org.nuxeo.ecm.core</groupId>
 				<artifactId>nuxeo-core-io</artifactId>
 				<version>${nuxeo.core.version}</version>
+				<exclusions>
+					<!-- Exclude dom4j:dom4j so we can upgrade to org.dom4j:dom4j. -->
+					<exclusion>
+						<groupId>dom4j</groupId>
+						<artifactId>dom4j</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.nuxeo.ecm.core</groupId>
@@ -651,6 +679,11 @@
 						<groupId>org.slf4j</groupId>
 						<artifactId>slf4j-log4j12</artifactId>
 					</exclusion>
+					<!-- Exclude dom4j:dom4j so we can upgrade to org.dom4j:dom4j. -->
+					<exclusion>
+						<groupId>dom4j</groupId>
+						<artifactId>dom4j</artifactId>
+					</exclusion>
 				</exclusions>
 			</dependency>
 			<dependency>
@@ -661,6 +694,11 @@
 					<exclusion>
 						<groupId>com.sun.jersey</groupId>
 						<artifactId>jersey-core</artifactId>
+					</exclusion>
+					<!-- Exclude dom4j:dom4j so we can upgrade to org.dom4j:dom4j. -->
+					<exclusion>
+						<groupId>dom4j</groupId>
+						<artifactId>dom4j</artifactId>
 					</exclusion>
 				</exclusions>
 			</dependency>

--- a/services/JaxRsServiceProvider/pom.xml
+++ b/services/JaxRsServiceProvider/pom.xml
@@ -678,7 +678,6 @@
 			<groupId>org.nuxeo.ecm.platform</groupId>
 			<artifactId>nuxeo-platform-imaging-core</artifactId>
 			<version>${nuxeo.platform.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
 			<groupId>org.nuxeo.ecm.platform</groupId>
@@ -689,6 +688,11 @@
             <groupId>org.nuxeo.runtime</groupId>
             <artifactId>nuxeo-runtime-osgi</artifactId>
 			<version>${nuxeo.core.version}</version>
+        </dependency>
+        <!-- Needed by nuxeo-core and nuxeo-platform-imaging-core, since we excluded dom4j:dom4j in order to upgrade to org.dom4j:dom4j -->
+        <dependency>
+            <groupId>org.dom4j</groupId>
+            <artifactId>dom4j</artifactId>
         </dependency>
 
         <dependency>

--- a/services/account/jaxb/pom.xml
+++ b/services/account/jaxb/pom.xml
@@ -30,6 +30,11 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-entitymanager</artifactId>
         </dependency>
+        <!-- Needed by hibernate-entitymanager, since we excluded dom4j:dom4j in order to upgrade to org.dom4j:dom4j -->
+        <dependency>
+            <groupId>org.dom4j</groupId>
+            <artifactId>dom4j</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.jvnet.hyperjaxb3</groupId>
             <artifactId>hyperjaxb3-ejb-runtime</artifactId>
@@ -43,7 +48,7 @@
 			<groupId>org.collectionspace.services</groupId>
 			<artifactId>org.collectionspace.services.hyperjaxb</artifactId>
 			<version>${project.version}</version>
-        </dependency>        
+        </dependency>
     </dependencies>
 
     <build>

--- a/services/authentication/jaxb/pom.xml
+++ b/services/authentication/jaxb/pom.xml
@@ -12,12 +12,12 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.collectionspace.services.authentication.jaxb</artifactId>
     <name>services.authentication.jaxb</name>
-    
+
     <properties>
         <sql.file>authentication.sql</sql.file>
         <sql.dir>src/main/resources/db/mysql</sql.dir>
     </properties>
-    
+
     <dependencies>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
@@ -34,6 +34,11 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-entitymanager</artifactId>
+        </dependency>
+        <!-- Needed by hibernate-entitymanager, since we excluded dom4j:dom4j in order to upgrade to org.dom4j:dom4j -->
+        <dependency>
+            <groupId>org.dom4j</groupId>
+            <artifactId>dom4j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jvnet.hyperjaxb3</groupId>

--- a/services/authority/pom.xml
+++ b/services/authority/pom.xml
@@ -76,6 +76,11 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-entitymanager</artifactId>
         </dependency>
+        <!-- Needed by hibernate-entitymanager, since we excluded dom4j:dom4j in order to upgrade to org.dom4j:dom4j -->
+        <dependency>
+            <groupId>org.dom4j</groupId>
+            <artifactId>dom4j</artifactId>
+        </dependency>
         <!-- jboss -->
         <dependency>
             <groupId>jboss</groupId>

--- a/services/authority/service/pom.xml
+++ b/services/authority/service/pom.xml
@@ -176,6 +176,11 @@
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-entitymanager</artifactId>
 		</dependency>
+		<!-- Needed by hibernate-entitymanager and nuxeo-platform-imaging-core, since we excluded dom4j:dom4j in order to upgrade to org.dom4j:dom4j -->
+		<dependency>
+			<groupId>org.dom4j</groupId>
+			<artifactId>dom4j</artifactId>
+		</dependency>
 		<!-- jboss -->
 		<dependency>
 			<groupId>jboss</groupId>
@@ -194,7 +199,6 @@
 			<groupId>org.nuxeo.ecm.platform</groupId>
 			<artifactId>nuxeo-platform-imaging-core</artifactId>
 			<version>${nuxeo.platform.version}</version>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.nuxeo.ecm.platform</groupId>

--- a/services/authorization-mgt/jaxb/pom.xml
+++ b/services/authorization-mgt/jaxb/pom.xml
@@ -30,6 +30,11 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-entitymanager</artifactId>
         </dependency>
+        <!-- Needed by hibernate-entitymanager, since we excluded dom4j:dom4j in order to upgrade to org.dom4j:dom4j -->
+        <dependency>
+            <groupId>org.dom4j</groupId>
+            <artifactId>dom4j</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.jvnet.hyperjaxb3</groupId>
             <artifactId>hyperjaxb3-ejb-runtime</artifactId>
@@ -43,7 +48,7 @@
 			<groupId>org.collectionspace.services</groupId>
 			<artifactId>org.collectionspace.services.hyperjaxb</artifactId>
 			<version>${project.version}</version>
-        </dependency>        
+        </dependency>
     </dependencies>
 
     <build>

--- a/services/authorization/jaxb/pom.xml
+++ b/services/authorization/jaxb/pom.xml
@@ -33,6 +33,11 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-entitymanager</artifactId>
         </dependency>
+        <!-- Needed by hibernate-entitymanager, since we excluded dom4j:dom4j in order to upgrade to org.dom4j:dom4j -->
+        <dependency>
+            <groupId>org.dom4j</groupId>
+            <artifactId>dom4j</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-c3p0</artifactId>
@@ -45,8 +50,8 @@
 			<groupId>org.collectionspace.services</groupId>
 			<artifactId>org.collectionspace.services.hyperjaxb</artifactId>
 			<version>${project.version}</version>
-        </dependency>        
-<!--     
+        </dependency>
+<!--
         <dependency>
             <groupId>javax.persistence</groupId>
             <artifactId>persistence-api</artifactId>

--- a/services/common/pom.xml
+++ b/services/common/pom.xml
@@ -208,6 +208,11 @@
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-entitymanager</artifactId>
 		</dependency>
+		<!-- Needed by hibernate-entitymanager, nuxeo-opencmis-bindings, nuxeo-opencmis-impl, and nuxeo-platform-imaging-core, since we excluded dom4j:dom4j in order to upgrade to org.dom4j:dom4j -->
+		<dependency>
+			<groupId>org.dom4j</groupId>
+			<artifactId>dom4j</artifactId>
+		</dependency>
 		<!-- jboss -->
 		<dependency>
 			<groupId>org.jboss.security</groupId>
@@ -235,7 +240,6 @@
 			<groupId>org.nuxeo.ecm.platform</groupId>
 			<artifactId>nuxeo-platform-imaging-core</artifactId>
 			<version>${nuxeo.platform.version}</version>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.nuxeo.ecm.platform</groupId>

--- a/services/hyperjaxb/pom.xml
+++ b/services/hyperjaxb/pom.xml
@@ -2,16 +2,16 @@
 
 <!--
  pom.xml
- 
+
  A Maven 2 project file for the 'jaxb' module of the ID Service project.
 
  This document is a part of the source code and related artifacts
  for CollectionSpace, an open source collections management system
  for museums and related institutions:
- 
+
  http://www.collectionspace.org
  http://wiki.collectionspace.org
- 
+
  Based on work by Sanjay Dalal and Richard Millet.
 
  $LastChangedBy: aron $
@@ -28,21 +28,21 @@
     <artifactId>org.collectionspace.services.main</artifactId>
     <version>${revision}</version>
   </parent>
-  
+
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.collectionspace.services.hyperjaxb</artifactId>
   <name>services.hyperjaxb</name>
-  
+
   <dependencies>
-  <!-- 
+  <!--
 		<dependency>
 		  <groupId>com.sun.xml.bind</groupId>
 		  <artifactId>jaxb-impl</artifactId>
-		</dependency>    
+		</dependency>
 		<dependency>
 		  <groupId>org.jvnet.jaxb2-commons</groupId>
 		  <artifactId>property-listener-injector</artifactId>
-		</dependency>   
+		</dependency>
 		<dependency>
 			<groupId>org.jvnet.jaxb2_commons</groupId>
 			<artifactId>jaxb2-basics-runtime</artifactId>
@@ -57,12 +57,17 @@
 		    <groupId>org.hibernate</groupId>
 		    <artifactId>hibernate-entitymanager</artifactId>
 		</dependency>
+		<!-- Needed by hibernate-entitymanager, since we excluded dom4j:dom4j in order to upgrade to org.dom4j:dom4j -->
+		<dependency>
+			<groupId>org.dom4j</groupId>
+			<artifactId>dom4j</artifactId>
+		</dependency>
 		<dependency>
 		    <groupId>org.jvnet.hyperjaxb3</groupId>
 		    <artifactId>hyperjaxb3-ejb-runtime</artifactId>
-		</dependency>    
+		</dependency>
   </dependencies>
-  
+
   <build>
     <finalName>collectionspace-services-hyperjaxb</finalName>
     <defaultGoal>install</defaultGoal>

--- a/services/imports/service/pom.xml
+++ b/services/imports/service/pom.xml
@@ -100,12 +100,22 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>dom4j</groupId>
+                    <artifactId>dom4j</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
         	<groupId>org.nuxeo.ecm.platform</groupId>
 	  		<artifactId>nuxeo-importer-xml-parser</artifactId>
 	  		<version>${nuxeo.platform.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>dom4j</groupId>
+                    <artifactId>dom4j</artifactId>
+                </exclusion>
+            </exclusions>
   		</dependency>
 
         <dependency>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -420,6 +420,13 @@
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-entitymanager</artifactId>
 				<version>3.4.0.GA</version>
+				<exclusions>
+					<!-- Exclude dom4j:dom4j so we can upgrade to org.dom4j:dom4j. -->
+					<exclusion>
+						<groupId>dom4j</groupId>
+						<artifactId>dom4j</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.hibernate</groupId>
@@ -441,18 +448,6 @@
 				<groupId>org.postgresql</groupId>
 				<artifactId>postgresql</artifactId>
 				<version>${postgres.driver.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.dom4j</groupId>
-				<artifactId>dom4j</artifactId>
-				<version>2.1.4</version>
-				<scope>compile</scope>
-			</dependency>
-			<dependency>
-				<groupId>xml-apis</groupId>
-				<artifactId>xml-apis</artifactId>
-				<version>1.4.01</version>
-				<scope>compile</scope>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
**What does this do?**

This upgrades dom4j to 2.1.4. It's more complicated than it should be, because the group id of dom4j changed from `dom4j` to `org.dom4j` after 1.6. Normally, we could do an upgrade by setting the desired version number of the artifact in a `dependencyManagement` block, which would cause that version to be used by all transitive dependencies. However, since the group id changed, setting the version number of `org.dom4j:dom4j` to 2.1.4 won't affect transitive dependencies on `dom4j:dom4j`, since it's a different group id. So we need to find all our dependencies that have a transitive dependency on `dom4j:dom4j`, and exclude it from those dependencies. Then, in all the modules that use those dependencies, we need to add a dependency on `org.dom4j:dom4j:2.1.4`, to replace the excluded `dom4j:dom4j`.

**Why are we doing this? (with JIRA link)**

This resolves dependabot alerts on dom4j.

JIRA: https://collectionspace.atlassian.net/browse/DRYD-1201

**How should this be tested? Do these changes have associated tests?**

The unit tests should succeed. It's hard to pinpoint anything specific to test -- all functionality should continue to work the same.

**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

No, this is not user-facing.

**Did someone actually run this code to verify it works?**

@ray-lee ran the unit tests and tried a few functions through the UI.