### PR TITLE
DRYD-1130: Add deaccession report

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/deaccessions.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/deaccessions.jrxml
@@ -1,0 +1,1026 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 6.20.1.final using JasperReports Library version 6.20.1-7584acb244139816654f64e2fd57a00d3e31921e  -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="deaccessions" pageWidth="4600" pageHeight="595" orientation="Landscape" columnWidth="802" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isIgnorePagination="true" uuid="fc9debd5-bb8b-4232-8df2-554977cc56f1">
+	<property name="com.jaspersoft.studio.data.sql.tables" value=""/>
+	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="nuxeo"/>
+	<property name="com.jaspersoft.studio.data.sql.SQLQueryDesigner.sash.w1" value="193"/>
+	<property name="com.jaspersoft.studio.data.sql.SQLQueryDesigner.sash.w2" value="800"/>
+	<property name="com.jaspersoft.studio.property.dataset.dialog.DatasetDialog.sash.w1" value="625"/>
+	<property name="com.jaspersoft.studio.property.dataset.dialog.DatasetDialog.sash.w2" value="361"/>
+	<style name="Column header" fontName="SansSerif" fontSize="12" isBold="true"/>
+	<style name="Detail" fontName="SansSerif" fontSize="12"/>
+	<parameter name="deurnfields" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA["deaccessionapprovalgroup,deaccessionapprovalindividual,deaccessionapprovalstatus,disposalmethod"]]></defaultValueExpression>
+	</parameter>
+	<parameter name="tenantid" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA["1"]]></defaultValueExpression>
+	</parameter>
+	<parameter name="csid" class="java.lang.String" isForPrompting="false"/>
+	<parameter name="whereclause" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA[$P{csid} != null ?  "WHERE hier.name = '" + $P{csid} + "'"  : ""]]></defaultValueExpression>
+	</parameter>
+	<queryString language="SQL">
+		<![CDATA[WITH objectexits AS (
+  SELECT
+    hier.name AS csid,
+    exit.id AS id,
+    exit.exitnote,
+    exit.exitnumber,
+    exit.exitquantity,
+    exit.exitreason,
+    exit.packingnote,
+    exit.deaccessiondate,
+    exit.disposaldate,
+    exit.disposalmethod,
+    exit.disposalproposedrecipient,
+    exit.disposalrecipient,
+    exit.displosalnote AS disposalnote,
+    exit.displosalvalue AS disposalvalue,
+    exit.displosalprovisos AS disposalprovisos,
+    exitmethod.item AS exitmethod,
+    sdg.datedisplaydate AS exitdate
+  FROM objectexit_common exit
+  INNER JOIN hierarchy hier ON exit.id = hier.id
+  INNER JOIN misc ON misc.id = exit.id AND misc.lifecyclestate != 'deleted'
+  INNER JOIN collectionspace_core core ON misc.id = core.id AND core.tenantid = $P{tenantid}
+  LEFT JOIN objectexit_common_exitmethods exitmethod ON exitmethod.id = exit.id AND exitmethod.pos = 0
+  LEFT JOIN hierarchy date_hier ON date_hier.parentid = exit.id AND date_hier.name = 'objectexit_common:exitDateGroup'
+  LEFT JOIN structureddategroup sdg ON sdg.id = date_hier.id
+	$P!{whereclause}
+), proposed_recipients AS (
+  SELECT
+    ag.*,
+    ptg.termdisplayname AS primarydisplayname,
+    secondaryterm.termdisplayname AS secondarydisplayname,
+    exit.csid AS exitcsid
+  FROM objectexits exit
+  INNER JOIN persons_common person on person.refname = exit.disposalproposedrecipient
+  INNER JOIN hierarchy hier on hier.id = person.id
+  INNER JOIN hierarchy ptg_hier on ptg_hier.parentid = person.id and ptg_hier.primarytype = 'personTermGroup' and ptg_hier.pos = 0
+  INNER JOIN persontermgroup ptg on ptg.id = ptg_hier.id
+  LEFT JOIN hierarchy secterm_hier ON secterm_hier.parentid = person.id AND secterm_hier.primarytype = 'personTermGroup' AND secterm_hier.pos = 1
+  LEFT JOIN persontermgroup secondaryterm ON secondaryterm.id = secterm_hier.id
+  LEFT JOIN contacts_common contact on contact.initem = hier.name
+  LEFT JOIN hierarchy addr_hier on addr_hier.parentid = contact.id and addr_hier.primarytype = 'addressGroup' and addr_hier.pos = 0
+  LEFT JOIN addressgroup ag on ag.id = addr_hier.id
+), recipients AS (
+  SELECT
+    ag.*,
+    ptg.termdisplayname AS primarydisplayname,
+    secondaryterm.termdisplayname AS secondarydisplayname,
+    exit.csid AS exitcsid
+  FROM objectexits exit
+  INNER JOIN persons_common person on person.refname = exit.disposalrecipient
+  INNER JOIN hierarchy hier on hier.id = person.id
+  INNER JOIN hierarchy ptg_hier on ptg_hier.parentid = person.id and ptg_hier.primarytype = 'personTermGroup' and ptg_hier.pos = 0
+  INNER JOIN persontermgroup ptg on ptg.id = ptg_hier.id
+  LEFT JOIN hierarchy secterm_hier ON secterm_hier.parentid = person.id AND secterm_hier.primarytype = 'personTermGroup' AND secterm_hier.pos = 1
+  LEFT JOIN persontermgroup secondaryterm ON secondaryterm.id = secterm_hier.id
+  LEFT JOIN contacts_common contact on contact.initem = hier.name
+  LEFT JOIN hierarchy addr_hier on addr_hier.parentid = contact.id and addr_hier.primarytype = 'addressGroup' and addr_hier.pos = 0
+  LEFT JOIN addressgroup ag on ag.id = addr_hier.id
+), approvals AS (
+  SELECT
+    exit.csid as exitcsid,
+    approval.deaccessionapprovalgroup,
+    approval.deaccessionapprovalindividual,
+    approval.deaccessionapprovalstatus,
+    approval.deaccessionapprovaldate,
+    approval.deaccessionapprovalnote
+  FROM objectexits exit
+  INNER JOIN hierarchy hier on hier.parentid = exit.id AND hier.primarytype = 'deacApprovalGroup'
+  INNER JOIN deacapprovalgroup approval on approval.id = hier.id
+), related_objects AS (
+  SELECT
+    object.collection,
+    object.objectnumber,
+    object.objecthistorynote,
+    ong.objectname,
+    bd.item as briefdescription,
+    sdg.datedisplaydate as productiondate,
+    media.objectcsid as mediacsid,
+    exit.csid as exitcsid
+  FROM objectexits exit
+  INNER JOIN relations_common rels ON rels.subjectcsid = exit.csid AND rels.objectdocumenttype = 'CollectionObject'
+  INNER JOIN hierarchy hier ON hier.name = rels.objectcsid
+  INNER JOIN collectionobjects_common object ON object.id = hier.id
+  LEFT JOIN relations_common media ON media.subjectcsid = hier.name AND media.objectdocumenttype = 'Media'
+  LEFT JOIN collectionobjects_common_briefdescriptions bd ON bd.id = object.id AND bd.pos = 0
+  LEFT JOIN hierarchy ong_hier ON ong_hier.parentid = object.id AND ong_hier.primarytype = 'objectNameGroup' AND ong_hier.pos = 0
+  LEFT JOIN objectnamegroup ong ON ong.id = ong_hier.id
+  LEFT JOIN hierarchy opdg_hier ON opdg_hier.parentid = object.id AND opdg_hier.name = 'collectionobjects_common:objectProductionDateGroupList' AND opdg_hier.pos = 0
+  LEFT JOIN structureddategroup sdg ON sdg.id = opdg_hier.id
+), related_procedures AS (
+  SELECT
+    acq.acquisitionreferencenumber AS acquisition,
+    intake.entrynumber AS intake,
+    exit.csid as exitcsid
+  FROM objectexits exit
+  LEFT JOIN relations_common acq_rels ON acq_rels.subjectcsid = exit.csid AND acq_rels.objectdocumenttype = 'Acquisition'
+  LEFT JOIN hierarchy acq_hier ON acq_hier.name = acq_rels.objectcsid
+  LEFT JOIN acquisitions_common acq ON acq.id = acq_hier.id
+  LEFT JOIN relations_common intake_rels ON intake_rels.subjectcsid = exit.csid AND intake_rels.objectdocumenttype = 'Intake'
+  LEFT JOIN hierarchy intake_hier ON intake_hier.name = intake_rels.objectcsid
+  LEFT JOIN intakes_common intake ON intake.id = intake_hier.id
+)
+SELECT
+  exit.exitnumber,
+  exit.exitquantity,
+  exit.exitdate,
+  exit.exitmethod,
+  exit.exitreason,
+  approval.deaccessionapprovalgroup,
+  approval.deaccessionapprovalindividual,
+  approval.deaccessionapprovalstatus,
+  approval.deaccessionapprovaldate,
+  approval.deaccessionapprovalnote,
+  exit.exitnote,
+  exit.packingnote,
+  obj.objectnumber,
+  obj.objectname,
+  obj.productiondate,
+  obj.collection,
+  obj.briefdescription,
+  obj.objecthistorynote,
+  proposed_recip.primarydisplayname AS proposed_primaryname,
+  proposed_recip.secondarydisplayname AS proposed_secondaryname,
+  proposed_recip.addressplace1 AS proposed_addressplace1,
+  proposed_recip.addressplace2 AS proposed_addressplace2,
+  proposed_recip.addresstype AS proposed_addresstype,
+  proposed_recip.addresscountry AS proposed_addresscountry,
+  proposed_recip.addressmunicipality AS proposed_addressmunicipality,
+  proposed_recip.addresspostcode AS proposed_addresspostcode,
+  proposed_recip.addressstateorprovince AS proposed_addressstateorprovince,
+  recip.primarydisplayname AS recip_primaryname,
+  recip.secondarydisplayname AS recip_secondaryname,
+  recip.addressplace1 AS recip_addressplace1,
+  recip.addressplace2 AS recip_addressplace2,
+  recip.addresstype AS recip_addresstype,
+  recip.addresscountry AS recip_addresscountry,
+  recip.addressmunicipality AS recip_addressmunicipality,
+  recip.addresspostcode AS recip_addresspostcode,
+  recip.addressstateorprovince AS recip_addressstateorprovince,
+  exit.disposalprovisos,
+  exit.disposalnote,
+  exit.deaccessiondate,
+  exit.disposaldate,
+  exit.disposalmethod,
+  exit.disposalvalue,
+  procedures.acquisition,
+  procedures.intake,
+  obj.mediacsid
+FROM objectexits exit
+LEFT JOIN approvals approval ON approval.exitcsid = exit.csid
+LEFT JOIN related_objects obj ON obj.exitcsid = exit.csid
+LEFT JOIN proposed_recipients proposed_recip ON proposed_recip.exitcsid = exit.csid
+LEFT JOIN recipients recip ON recip.exitcsid = exit.csid
+LEFT JOIN related_procedures procedures ON procedures.exitcsid = exit.csid]]>
+	</queryString>
+	<field name="exitnumber" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="exitnumber"/>
+		<property name="com.jaspersoft.studio.field.label" value="exitnumber"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="objectexit_common"/>
+	</field>
+	<field name="exitquantity" class="java.lang.Long">
+		<property name="com.jaspersoft.studio.field.name" value="exitquantity"/>
+		<property name="com.jaspersoft.studio.field.label" value="exitquantity"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="objectexit_common"/>
+	</field>
+	<field name="exitdate" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="exitdate"/>
+		<property name="com.jaspersoft.studio.field.label" value="exitdate"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="structureddategroup"/>
+	</field>
+	<field name="exitmethod" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="exitmethod"/>
+		<property name="com.jaspersoft.studio.field.label" value="exitmethod"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="objectexit_common_exitmethods"/>
+	</field>
+	<field name="exitreason" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="exitreason"/>
+		<property name="com.jaspersoft.studio.field.label" value="exitreason"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="objectexit_common"/>
+	</field>
+	<field name="deaccessionapprovalgroup" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="deaccessionapprovalgroup"/>
+		<property name="com.jaspersoft.studio.field.label" value="deaccessionapprovalgroup"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="deacapprovalgroup"/>
+	</field>
+	<field name="deaccessionapprovalindividual" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="deaccessionapprovalindividual"/>
+		<property name="com.jaspersoft.studio.field.label" value="deaccessionapprovalindividual"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="deacapprovalgroup"/>
+	</field>
+	<field name="deaccessionapprovalstatus" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="deaccessionapprovalstatus"/>
+		<property name="com.jaspersoft.studio.field.label" value="deaccessionapprovalstatus"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="deacapprovalgroup"/>
+	</field>
+	<field name="deaccessionapprovaldate" class="java.sql.Timestamp">
+		<property name="com.jaspersoft.studio.field.name" value="deaccessionapprovaldate"/>
+		<property name="com.jaspersoft.studio.field.label" value="deaccessionapprovaldate"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="deacapprovalgroup"/>
+	</field>
+	<field name="deaccessionapprovalnote" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="deaccessionapprovalnote"/>
+		<property name="com.jaspersoft.studio.field.label" value="deaccessionapprovalnote"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="deacapprovalgroup"/>
+	</field>
+	<field name="exitnote" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="exitnote"/>
+		<property name="com.jaspersoft.studio.field.label" value="exitnote"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="objectexit_common"/>
+	</field>
+	<field name="packingnote" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="packingnote"/>
+		<property name="com.jaspersoft.studio.field.label" value="packingnote"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="objectexit_common"/>
+	</field>
+	<field name="objectnumber" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="objectnumber"/>
+		<property name="com.jaspersoft.studio.field.label" value="objectnumber"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="collectionobjects_common"/>
+	</field>
+	<field name="objectname" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="objectname"/>
+		<property name="com.jaspersoft.studio.field.label" value="objectname"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="objectnamegroup"/>
+	</field>
+	<field name="productiondate" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="productiondate"/>
+		<property name="com.jaspersoft.studio.field.label" value="productiondate"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="structureddategroup"/>
+	</field>
+	<field name="collection" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="collection"/>
+		<property name="com.jaspersoft.studio.field.label" value="collection"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="collectionobjects_common"/>
+	</field>
+	<field name="briefdescription" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="briefdescription"/>
+		<property name="com.jaspersoft.studio.field.label" value="briefdescription"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="collectionobjects_common_briefdescriptions"/>
+	</field>
+	<field name="objecthistorynote" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="objecthistorynote"/>
+		<property name="com.jaspersoft.studio.field.label" value="objecthistorynote"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="collectionobjects_common"/>
+	</field>
+	<field name="proposed_primaryname" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="proposed_primaryname"/>
+		<property name="com.jaspersoft.studio.field.label" value="proposed_primaryname"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="persontermgroup"/>
+	</field>
+	<field name="proposed_secondaryname" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="proposed_secondaryname"/>
+		<property name="com.jaspersoft.studio.field.label" value="proposed_secondaryname"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="persontermgroup"/>
+	</field>
+	<field name="proposed_addressplace1" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="proposed_addressplace1"/>
+		<property name="com.jaspersoft.studio.field.label" value="proposed_addressplace1"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="addressgroup"/>
+	</field>
+	<field name="proposed_addressplace2" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="proposed_addressplace2"/>
+		<property name="com.jaspersoft.studio.field.label" value="proposed_addressplace2"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="addressgroup"/>
+	</field>
+	<field name="proposed_addresstype" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="proposed_addresstype"/>
+		<property name="com.jaspersoft.studio.field.label" value="proposed_addresstype"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="addressgroup"/>
+	</field>
+	<field name="proposed_addresscountry" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="proposed_addresscountry"/>
+		<property name="com.jaspersoft.studio.field.label" value="proposed_addresscountry"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="addressgroup"/>
+	</field>
+	<field name="proposed_addressmunicipality" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="proposed_addressmunicipality"/>
+		<property name="com.jaspersoft.studio.field.label" value="proposed_addressmunicipality"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="addressgroup"/>
+	</field>
+	<field name="proposed_addresspostcode" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="proposed_addresspostcode"/>
+		<property name="com.jaspersoft.studio.field.label" value="proposed_addresspostcode"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="addressgroup"/>
+	</field>
+	<field name="proposed_addressstateorprovince" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="proposed_addressstateorprovince"/>
+		<property name="com.jaspersoft.studio.field.label" value="proposed_addressstateorprovince"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="addressgroup"/>
+	</field>
+	<field name="recip_primaryname" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="recip_primaryname"/>
+		<property name="com.jaspersoft.studio.field.label" value="recip_primaryname"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="persontermgroup"/>
+	</field>
+	<field name="recip_secondaryname" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="recip_secondaryname"/>
+		<property name="com.jaspersoft.studio.field.label" value="recip_secondaryname"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="persontermgroup"/>
+	</field>
+	<field name="recip_addressplace1" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="recip_addressplace1"/>
+		<property name="com.jaspersoft.studio.field.label" value="recip_addressplace1"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="addressgroup"/>
+	</field>
+	<field name="recip_addressplace2" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="recip_addressplace2"/>
+		<property name="com.jaspersoft.studio.field.label" value="recip_addressplace2"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="addressgroup"/>
+	</field>
+	<field name="recip_addresstype" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="recip_addresstype"/>
+		<property name="com.jaspersoft.studio.field.label" value="recip_addresstype"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="addressgroup"/>
+	</field>
+	<field name="recip_addresscountry" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="recip_addresscountry"/>
+		<property name="com.jaspersoft.studio.field.label" value="recip_addresscountry"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="addressgroup"/>
+	</field>
+	<field name="recip_addressmunicipality" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="recip_addressmunicipality"/>
+		<property name="com.jaspersoft.studio.field.label" value="recip_addressmunicipality"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="addressgroup"/>
+	</field>
+	<field name="recip_addresspostcode" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="recip_addresspostcode"/>
+		<property name="com.jaspersoft.studio.field.label" value="recip_addresspostcode"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="addressgroup"/>
+	</field>
+	<field name="recip_addressstateorprovince" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="recip_addressstateorprovince"/>
+		<property name="com.jaspersoft.studio.field.label" value="recip_addressstateorprovince"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="addressgroup"/>
+	</field>
+	<field name="disposalprovisos" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="disposalprovisos"/>
+		<property name="com.jaspersoft.studio.field.label" value="disposalprovisos"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="objectexit_common"/>
+	</field>
+	<field name="disposalnote" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="disposalnote"/>
+		<property name="com.jaspersoft.studio.field.label" value="disposalnote"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="objectexit_common"/>
+	</field>
+	<field name="deaccessiondate" class="java.sql.Timestamp">
+		<property name="com.jaspersoft.studio.field.name" value="deaccessiondate"/>
+		<property name="com.jaspersoft.studio.field.label" value="deaccessiondate"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="objectexit_common"/>
+	</field>
+	<field name="disposaldate" class="java.sql.Timestamp">
+		<property name="com.jaspersoft.studio.field.name" value="disposaldate"/>
+		<property name="com.jaspersoft.studio.field.label" value="disposaldate"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="objectexit_common"/>
+	</field>
+	<field name="disposalmethod" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="disposalmethod"/>
+		<property name="com.jaspersoft.studio.field.label" value="disposalmethod"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="objectexit_common"/>
+	</field>
+	<field name="disposalvalue" class="java.lang.Double">
+		<property name="com.jaspersoft.studio.field.name" value="disposalvalue"/>
+		<property name="com.jaspersoft.studio.field.label" value="disposalvalue"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="objectexit_common"/>
+	</field>
+	<field name="acquisition" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="acquisition"/>
+		<property name="com.jaspersoft.studio.field.label" value="acquisition"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="acquisitions_common"/>
+	</field>
+	<field name="intake" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="intake"/>
+		<property name="com.jaspersoft.studio.field.label" value="intake"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="intakes_common"/>
+	</field>
+	<field name="mediacsid" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="mediacsid"/>
+		<property name="com.jaspersoft.studio.field.label" value="mediacsid"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="relations_common"/>
+	</field>
+	<background>
+		<band splitType="Stretch"/>
+	</background>
+	<title>
+		<band>
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+		</band>
+	</title>
+	<pageHeader>
+		<band splitType="Stretch">
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+		</band>
+	</pageHeader>
+	<columnHeader>
+		<band height="44" splitType="Stretch">
+			<property name="com.jaspersoft.studio.layout" value="com.jaspersoft.studio.editor.layout.FreeLayout"/>
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+			<staticText>
+				<reportElement style="Column header" x="0" y="0" width="100" height="44" uuid="f809accd-fe24-4e42-904a-9c5ddb7d5170">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Exit number]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="100" y="0" width="100" height="44" uuid="df0dab5e-6620-4d94-a2e8-aa0e57ce83e2">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Exit quantity]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="200" y="0" width="100" height="44" uuid="d8c568a2-c8bf-4385-968b-ebd7e7b2b027">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Exit date]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="300" y="0" width="100" height="44" uuid="c9c7042a-5de0-4780-9475-4edc7aa99066">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Exit method]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="400" y="0" width="100" height="44" uuid="7f22ccd2-2633-4b12-9a69-a2ba3468d66e">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Exit reason]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="500" y="0" width="100" height="44" uuid="7731969b-6e12-42dd-a4a7-8cd70670f394">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Deaccession group]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="600" y="0" width="100" height="44" uuid="2733a9de-4ff6-40b2-9a58-bc26e2344b70">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Deaccession individual]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="700" y="0" width="100" height="44" uuid="455b0b82-d5f9-4c0e-8e23-d9202e710166">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Deaccession status]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="800" y="0" width="100" height="44" uuid="d4f0fe26-8760-441a-a6c7-6d187ad507fd">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Deaccession date]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="900" y="0" width="100" height="44" uuid="6f6be086-9951-4ea1-a051-9c37ea68bd80">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Deaccession note]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="1000" y="0" width="100" height="44" uuid="7a865f30-03c8-4cca-9f4a-00c9cdb634c7">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Exit note]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="1100" y="0" width="100" height="44" uuid="a5e37502-996c-483e-bdb7-abe30cafb16b">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Packing note]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="1200" y="0" width="100" height="44" uuid="30549c2c-b81c-4508-96b2-1a882fda44b5">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Object number]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="1300" y="0" width="100" height="44" uuid="f0e8795a-9621-4887-9390-8ca2fac97309">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Object name]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="1400" y="0" width="100" height="44" uuid="542800ab-8b92-4e91-ab38-96f07a21f11c">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Object prod date]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="1500" y="0" width="100" height="44" uuid="230e1f74-dbdf-4426-8cfb-68c01ffe678b">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Obj collection]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="1600" y="0" width="100" height="44" uuid="6f4daf54-06fc-43ea-9c2c-6f30cde79c20">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Obj brief desc]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="1700" y="0" width="100" height="44" uuid="1dc8f32f-dc35-44cf-93da-945de643100f">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Obj history note]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="1800" y="0" width="100" height="44" uuid="b7723ca7-30de-4f07-b8d8-f992da5fa4a9">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Disposal Proposed Recipient Name 1]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="1900" y="0" width="100" height="44" uuid="007384f1-6266-46d3-8cda-9984d957868d">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Disposal Proposed Recipient Name 2]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="2000" y="0" width="100" height="44" uuid="bfb9be47-d2d1-435a-832f-2f98bb7a8502">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Disposal Proposed Recipient Addr Type]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="2100" y="0" width="100" height="44" uuid="672caeb6-bf39-4238-98b6-a4feac38f918">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Disposal Proposed Recipient Addr Line 1]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="2200" y="0" width="100" height="44" uuid="42f07533-80a6-4117-b995-5bcf26f0debe">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Disposal Proposed Recipient Addr Line 2]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="2300" y="0" width="100" height="44" uuid="dd2b4d65-3cc3-4319-b02e-9fec7c77b262">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Disposal Proposed Recipient Municipality]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="2400" y="0" width="100" height="44" uuid="88c77fdb-83ff-4503-8d92-ae63828b59b6">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Disposal Proposed Recipient State/Province]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="2500" y="0" width="100" height="44" uuid="0eb2a4c3-4c35-4b5e-82ba-09db339fd2ad">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Disposal Proposed Recipient Postal Code]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="2600" y="0" width="100" height="44" uuid="31e06d48-bf69-4916-a800-354ea33c2a3f">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Disposal Proposed Recipient Country]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="2700" y="0" width="100" height="44" uuid="90a78145-071d-45f1-98b4-1d0ab8b05d26">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Disposal Recipient Name 1]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="2800" y="0" width="100" height="44" uuid="dbbba120-1610-4189-a9a2-4c54228b26bb">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Disposal Recipient Name 2]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="2900" y="0" width="100" height="44" uuid="25568da7-628b-4cb8-9bc5-82190ee44390">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Disposal Recipient Addr Type]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="3000" y="0" width="100" height="44" uuid="b46a51ec-e390-4b25-8043-06e2b3cd0024">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Disposal Recipient Addr Line 1]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="3100" y="0" width="100" height="44" uuid="90632fe1-ea17-4142-9f3e-d457b16e670d">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Disposal Recipient Addr Line 2]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="3200" y="0" width="100" height="44" uuid="bc0ed9d3-883a-482c-b04a-2305aad732a3">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Disposal Recipient Municipality]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="3300" y="0" width="100" height="44" uuid="38792d6e-225e-48cc-b38d-485edf5d8dc5">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Disposal Recipient State/Province]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="3400" y="0" width="100" height="44" uuid="fcfef552-f9c3-4542-bd61-9b8bf2883a27">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Disposal Recipient Postal Code]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="3500" y="0" width="100" height="44" uuid="b45aee43-0cab-4b0e-95e9-edfdc7641992">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Disposal Recipient Country]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="3600" y="0" width="100" height="44" uuid="a4f8f6c4-0bf6-4d83-ade1-5dc289ce8e03">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Disposal provisos]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="3700" y="0" width="100" height="44" uuid="1a6cb6e4-71f5-4cf1-a40b-e2948706f2f3">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Disposal note]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="3800" y="0" width="100" height="44" uuid="4bf915f7-efed-4a43-89c1-6b058dae0bf7">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Deaccession date]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="3900" y="0" width="100" height="44" uuid="1fc9d0c3-3081-42ed-8097-e68d323765d1">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Disposal date]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="4000" y="0" width="100" height="44" uuid="9951fbb5-a174-4c45-9341-9424315fea7e">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Disposal method]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="4100" y="0" width="100" height="44" uuid="a32a0b13-e56d-4ada-a8aa-dde01dae48ae">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Disposal value]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="4200" y="0" width="100" height="44" uuid="2d33ea33-de5d-4e94-8e63-a5dd71e3ab24">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Accesssion number]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="4300" y="0" width="100" height="44" uuid="ff6b0674-b07f-4429-afbb-24b2c1a5fada">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Intake number]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="4400" y="0" width="100" height="44" uuid="35da18f4-135b-4a59-8f36-d90375c1f1f1">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Thumbnail]]></text>
+			</staticText>
+		</band>
+	</columnHeader>
+	<detail>
+		<band height="66" splitType="Stretch">
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+			<textField>
+				<reportElement style="Detail" x="0" y="0" width="100" height="30" uuid="56afbd1a-4861-43a3-9e26-9b6755882991">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{exitnumber}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="100" y="0" width="100" height="30" uuid="6c9fc572-62c9-4591-bf13-9b50a671addc">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{exitquantity}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="200" y="0" width="100" height="30" uuid="198b574c-8492-4ea4-ab68-17b18f412c3f">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{exitdate}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="300" y="0" width="100" height="30" uuid="8a166167-cbb1-4e06-a8c9-0da3f1978c8b">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{exitmethod}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="400" y="0" width="100" height="30" uuid="f9b9d5f4-2b5f-4f5b-99bf-957c84aeead9">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{exitreason}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="500" y="0" width="100" height="30" uuid="8567f1d2-a36c-4be5-ad52-31d84937445d">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{deaccessionapprovalgroup}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="600" y="0" width="100" height="30" uuid="1e377b18-993c-4d7c-9c5f-794bcc292e2f">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{deaccessionapprovalindividual}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="700" y="0" width="100" height="30" uuid="cf58a4c8-7a81-45fd-98d2-1665cf086fe7">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{deaccessionapprovalstatus}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="800" y="0" width="100" height="30" uuid="7080720c-f950-472a-86a7-59bf70dd17a0">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{deaccessionapprovaldate}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="900" y="0" width="100" height="30" uuid="7f3c6b34-7d67-40a9-941d-9ab1bac2c0e6">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{deaccessionapprovaldate}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="1000" y="0" width="100" height="30" uuid="427c6ba1-a7b7-4053-91f8-a968e2578786">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{exitnote}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="1100" y="0" width="100" height="30" uuid="fe9cd903-d44a-4929-b3b8-646292d7b665">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{packingnote}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="1200" y="0" width="100" height="30" uuid="7484898e-b56c-48e4-9240-d0335437038a">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{objectnumber}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="1300" y="0" width="100" height="30" uuid="23044237-4704-4781-8d11-9b6a986deb6f">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{objectname}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="1400" y="0" width="100" height="30" uuid="f11f0936-4d53-4ebe-9479-70e9b63da7b1">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{productiondate}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="1500" y="0" width="100" height="30" uuid="ce3c8a6c-0cec-45aa-b6b5-a46f4afcbdfc">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{collection}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="1600" y="0" width="100" height="30" uuid="5cbb37f2-63bc-4c94-b895-520ddefc9dea">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{briefdescription}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="1700" y="0" width="100" height="30" uuid="400f3d73-058e-4485-a2cf-ccf6222688cb">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{objecthistorynote}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="1800" y="0" width="100" height="30" uuid="a74806df-eeb0-4251-8f91-9d0e3d6aed22">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{proposed_primaryname}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="1900" y="0" width="100" height="30" uuid="7c20f6cf-9100-4faf-b844-f0f2540a90fe">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{proposed_secondaryname}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="2000" y="0" width="100" height="30" uuid="cbf4ed81-59bb-4446-a665-26a77da6b3c5">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{proposed_addresstype}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="2100" y="0" width="100" height="30" uuid="9ec2d144-7d38-4742-b01d-4480a90b1049">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{proposed_addressplace1}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="2200" y="0" width="100" height="30" uuid="dac21fe6-179b-4acf-8028-a45b8423b66d">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{proposed_addressplace2}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="2300" y="0" width="100" height="30" uuid="2baf5e12-c474-4a7a-a3b7-f67a32445bc3">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{proposed_addressmunicipality}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="2400" y="0" width="100" height="30" uuid="21266cb8-c3e8-4286-9560-d067a80c493f">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{proposed_addressstateorprovince}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="2500" y="0" width="100" height="30" uuid="b5edfdb4-9f0b-4f98-9fd7-44ed3b04844c">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{proposed_addresspostcode}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="2600" y="0" width="100" height="30" uuid="670bcf02-0320-45fb-b93d-34794c1544d0">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{proposed_addresscountry}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="2700" y="0" width="100" height="30" uuid="06c0ea34-3c7b-4130-b28d-5ee7d35d8b55">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{recip_primaryname}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="2800" y="0" width="100" height="30" uuid="a85ada24-3a62-4e93-93de-0b4cb8463137">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{recip_secondaryname}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="2900" y="0" width="100" height="30" uuid="44e0bd3a-c6bd-48da-a78c-1f14a942d0d7">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{recip_addresstype}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="3000" y="0" width="100" height="30" uuid="f739a888-540f-4158-a5b8-d8a08a423225">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{recip_addressplace1}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="3100" y="0" width="100" height="30" uuid="9cf7c268-94fc-4732-b770-e894ece870b3">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{recip_addressplace2}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="3200" y="0" width="100" height="30" uuid="82b22f93-b85f-4cb9-896d-0ef14de27096">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{recip_addressmunicipality}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="3300" y="0" width="100" height="30" uuid="ccbb5a34-1a9a-4597-9fdd-bf6adfa8de77">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{recip_addressstateorprovince}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="3400" y="0" width="100" height="30" uuid="36bc8c12-2fbc-4d16-8610-53b5f0bbb7ed">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{recip_addresspostcode}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="3500" y="0" width="100" height="30" uuid="f192af1c-8269-4d91-a8f9-845d01703352">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{recip_addresscountry}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="3600" y="0" width="100" height="30" uuid="d32be13e-9677-49ca-bd91-5406bcbf1d7d">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{disposalprovisos}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="3700" y="0" width="100" height="30" uuid="71decb7b-184a-4f82-951f-9ac3d0318c01">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{disposalnote}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="3800" y="0" width="100" height="30" uuid="baf5031d-afb9-45b9-b1f0-897c10dc2ece">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{deaccessiondate}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="3900" y="0" width="100" height="30" uuid="07f966c0-343e-4b5e-a133-d4dfe1343c2f">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{disposaldate}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="4000" y="0" width="100" height="30" uuid="f0612414-22e0-4882-99fb-91b6f2c74100">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{disposalmethod}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="4100" y="0" width="100" height="30" uuid="c29d0b1c-3e58-4058-9c6e-9c5c6027f034">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{disposalvalue}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="4200" y="0" width="100" height="30" uuid="1cfa324e-e689-47d5-8538-cdca3b18619a">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{acquisition}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement style="Detail" x="4300" y="0" width="100" height="30" uuid="1d2a375e-394e-472d-8414-34f07977c18e">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{intake}]]></textFieldExpression>
+			</textField>
+			<image onErrorType="Blank">
+				<reportElement x="4400" y="0" width="50" height="50" uuid="9b74cc9a-57b5-48b7-92a2-bbb4bd26165e"/>
+				<imageExpression><![CDATA["cspace://media/" + $F{mediacsid} + "/blob/derivatives/Thumbnail/content"]]></imageExpression>
+			</image>
+		</band>
+	</detail>
+	<columnFooter>
+		<band splitType="Stretch">
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+		</band>
+	</columnFooter>
+	<pageFooter>
+		<band splitType="Stretch">
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+		</band>
+	</pageFooter>
+	<summary>
+		<band splitType="Stretch">
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+		</band>
+	</summary>
+</jasperReport>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/deaccessions.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/deaccessions.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<document name="report">
+  <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
+    <name>Deaccessions</name>
+    <notes>Deaccession</notes>
+    <forDocTypes>
+      <forDocType>ObjectExit</forDocType>
+    </forDocTypes>
+    <supportsSingleDoc>true</supportsSingleDoc>
+    <supportsDocList>false</supportsDocList>
+    <supportsGroup>false</supportsGroup>
+    <supportsNoContext>true</supportsNoContext>
+    <filename>deaccessions.jrxml</filename>
+    <outputMIME>application/pdf</outputMIME>
+  </ns2:reports_common>
+</document>


### PR DESCRIPTION
**What does this do?**
* Add deaccession report
* Add xml for registering deaccession report with cspace

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1130
Report requested by OHC

**How should this be tested? Do these changes have associated tests?**
* Register the report with collectionspace
* Create an ObjectExit procedure with most (all? ) fields filled out
* Create a CollectionObject with media + relate to the ObjectExit
* Create an Acquisition + relate to the ObjectExit
* Crete an Intake + relate to the ObjectExit

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested w/ all fields present