### PR TITLE
Update relation queries for reports

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/accessions.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/accessions.jrxml
@@ -56,24 +56,31 @@
 	$P!{whereclause}
 ), related_objects AS (
   SELECT
+    hier.name AS csid,
     object.collection,
     object.objecthistorynote,
     object.objectnumber,
     ong.objectname,
     bd.item AS briefdescription,
     sdg.datedisplaydate AS objectproductiondate,
-    media.objectcsid AS mediacsid,
     acq.csid AS acquisitioncsid
   FROM acquisitions acq
   INNER JOIN relations_common rels ON rels.subjectcsid = acq.csid AND rels.objectdocumenttype = 'CollectionObject'
+  INNER JOIN misc on misc.id = rels.id AND misc.lifecyclestate != 'deleted'
   INNER JOIN hierarchy hier ON hier.name = rels.objectcsid AND hier.primarytype = 'CollectionObject'
   INNER JOIN collectionobjects_common object ON object.id = hier.id
-  LEFT JOIN relations_common media ON media.subjectcsid = hier.name AND media.objectdocumenttype = 'Media'
   LEFT JOIN collectionobjects_common_briefdescriptions bd ON bd.id = object.id AND bd.pos = 0
   LEFT JOIN hierarchy ong_hier ON ong_hier.parentid = object.id AND ong_hier.primarytype = 'objectNameGroup' AND ong_hier.pos = 0
   LEFT JOIN objectnamegroup ong ON ong.id = ong_hier.id
   LEFT JOIN hierarchy opdg_hier ON opdg_hier.parentid = object.id AND opdg_hier.name = 'collectionobjects_common:objectProductionDateGroupList' AND opdg_hier.pos = 0
   LEFT JOIN structureddategroup sdg ON sdg.id = opdg_hier.id
+), related_media AS (
+  SELECT
+    object.csid AS objcsid,
+    media.objectcsid AS mediacsid
+  FROM related_objects object
+  INNER JOIN relations_common media ON media.subjectcsid = object.csid AND media.objectdocumenttype = 'Media'
+  INNER JOIN misc ON misc.id = media.id AND misc.lifecyclestate != 'deleted'
 )
 SELECT
   acq.acquisitionreferencenumber,
@@ -94,9 +101,10 @@ SELECT
   obj.collection,
   obj.briefdescription,
   obj.objecthistorynote,
-  obj.mediacsid
+  media.mediacsid
 FROM acquisitions acq
-LEFT JOIN related_objects obj ON obj.acquisitioncsid = acq.csid]]>
+LEFT JOIN related_objects obj ON obj.acquisitioncsid = acq.csid
+LEFT JOIN related_media media ON media.objcsid = obj.csid]]>
 	</queryString>
 	<field name="acquisitionreferencenumber" class="java.lang.String">
 		<property name="com.jaspersoft.studio.field.name" value="acquisitionreferencenumber"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/accessions.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/accessions.xml
@@ -11,6 +11,6 @@
     <supportsGroup>false</supportsGroup>
     <supportsNoContext>true</supportsNoContext>
     <filename>accessions.jrxml</filename>
-    <outputMIME>application/pdf</outputMIME>
+    <outputMIME>text/csv</outputMIME>
   </ns2:reports_common>
 </document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/box_list.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/box_list.jrxml
@@ -34,6 +34,7 @@
   SELECT co.id, co.objectnumber, hier.name AS csid, lmi.csid AS movementcsid
   FROM lmis lmi
   INNER JOIN relations_common rels ON rels.subjectcsid = lmi.csid AND rels.objectdocumenttype = 'CollectionObject'
+  INNER JOIN misc ON misc.id = rels.id AND misc.lifecyclestate != 'deleted'
   INNER JOIN hierarchy hier ON hier.name = rels.objectcsid AND hier.primarytype = 'CollectionObject'
   INNER JOIN collectionobjects_common co ON co.id = hier.id
 ), objectnames AS (
@@ -45,6 +46,7 @@
   SELECT relations.objectcsid as mediacsid, co.csid AS objectcsid
   FROM collectionobjects co
   INNER JOIN relations_common relations ON relations.subjectcsid = co.csid AND relations.objectdocumenttype = 'Media'
+  INNER JOIN misc ON misc.id = relations.id AND misc.lifecyclestate != 'deleted'
 )
 SELECT lmi.movementreferencenumber, terms.termdisplayname, terms.termname, co.objectnumber, objectnames.objectname, thumbnails.mediacsid
 FROM lmis lmi

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/box_list.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/box_list.xml
@@ -11,6 +11,6 @@
     <supportsGroup>false</supportsGroup>
     <supportsNoContext>true</supportsNoContext>
     <filename>box_list.jrxml</filename>
-    <outputMIME>application/pdf</outputMIME>
+    <outputMIME>text/csv</outputMIME>
   </ns2:reports_common>
 </document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/deaccessions.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/deaccessions.jrxml
@@ -46,7 +46,7 @@
   LEFT JOIN objectexit_common_exitmethods exitmethod ON exitmethod.id = exit.id AND exitmethod.pos = 0
   LEFT JOIN hierarchy date_hier ON date_hier.parentid = exit.id AND date_hier.name = 'objectexit_common:exitDateGroup'
   LEFT JOIN structureddategroup sdg ON sdg.id = date_hier.id
-	$P!{whereclause}
+  $P!{whereclause}
 ), proposed_recipients AS (
   SELECT
     ag.*,
@@ -92,36 +92,49 @@
   INNER JOIN deacapprovalgroup approval on approval.id = hier.id
 ), related_objects AS (
   SELECT
+    hier.name AS csid,
     object.collection,
     object.objectnumber,
     object.objecthistorynote,
     ong.objectname,
     bd.item as briefdescription,
     sdg.datedisplaydate as productiondate,
-    media.objectcsid as mediacsid,
     exit.csid as exitcsid
   FROM objectexits exit
   INNER JOIN relations_common rels ON rels.subjectcsid = exit.csid AND rels.objectdocumenttype = 'CollectionObject'
+  INNER JOIN misc ON misc.id = rels.id AND misc.lifecyclestate != 'deleted'
   INNER JOIN hierarchy hier ON hier.name = rels.objectcsid
   INNER JOIN collectionobjects_common object ON object.id = hier.id
-  LEFT JOIN relations_common media ON media.subjectcsid = hier.name AND media.objectdocumenttype = 'Media'
   LEFT JOIN collectionobjects_common_briefdescriptions bd ON bd.id = object.id AND bd.pos = 0
   LEFT JOIN hierarchy ong_hier ON ong_hier.parentid = object.id AND ong_hier.primarytype = 'objectNameGroup' AND ong_hier.pos = 0
   LEFT JOIN objectnamegroup ong ON ong.id = ong_hier.id
   LEFT JOIN hierarchy opdg_hier ON opdg_hier.parentid = object.id AND opdg_hier.name = 'collectionobjects_common:objectProductionDateGroupList' AND opdg_hier.pos = 0
   LEFT JOIN structureddategroup sdg ON sdg.id = opdg_hier.id
-), related_procedures AS (
+), related_object_media AS (
+  SELECT
+    object.csid AS objcsid,
+    media.objectcsid as mediacsid
+  FROM related_objects object
+  INNER JOIN relations_common media ON media.subjectcsid = object.csid AND media.objectdocumenttype = 'Media'
+  INNER JOIN misc ON misc.id = media.id AND misc.lifecyclestate != 'deleted'
+), related_acquisitions AS (
   SELECT
     acq.acquisitionreferencenumber AS acquisition,
+    exit.csid as exitcsid
+  FROM objectexits exit
+  INNER JOIN relations_common relation ON relation.subjectcsid = exit.csid AND relation.objectdocumenttype = 'Acquisition'
+  INNER JOIN misc ON misc.id = relation.id AND misc.lifecyclestate != 'deleted'
+  INNER JOIN hierarchy hier ON hier.name = relation.objectcsid
+  INNER JOIN acquisitions_common acq ON acq.id = hier.id
+), related_intakes AS (
+  SELECT
     intake.entrynumber AS intake,
     exit.csid as exitcsid
   FROM objectexits exit
-  LEFT JOIN relations_common acq_rels ON acq_rels.subjectcsid = exit.csid AND acq_rels.objectdocumenttype = 'Acquisition'
-  LEFT JOIN hierarchy acq_hier ON acq_hier.name = acq_rels.objectcsid
-  LEFT JOIN acquisitions_common acq ON acq.id = acq_hier.id
-  LEFT JOIN relations_common intake_rels ON intake_rels.subjectcsid = exit.csid AND intake_rels.objectdocumenttype = 'Intake'
-  LEFT JOIN hierarchy intake_hier ON intake_hier.name = intake_rels.objectcsid
-  LEFT JOIN intakes_common intake ON intake.id = intake_hier.id
+  INNER JOIN relations_common relation ON relation.subjectcsid = exit.csid AND relation.objectdocumenttype = 'Intake'
+  INNER JOIN misc ON misc.id = relation.id AND misc.lifecyclestate != 'deleted'
+  INNER JOIN hierarchy hier ON hier.name = relation.objectcsid
+  INNER JOIN intakes_common intake ON intake.id = hier.id
 )
 SELECT
   exit.exitnumber,
@@ -166,15 +179,17 @@ SELECT
   exit.disposaldate,
   exit.disposalmethod,
   exit.disposalvalue,
-  procedures.acquisition,
-  procedures.intake,
-  obj.mediacsid
+  acquisition.acquisition,
+  intake.intake,
+  media.mediacsid
 FROM objectexits exit
 LEFT JOIN approvals approval ON approval.exitcsid = exit.csid
 LEFT JOIN related_objects obj ON obj.exitcsid = exit.csid
+LEFT JOIN related_object_media media ON media.objcsid = obj.csid
 LEFT JOIN proposed_recipients proposed_recip ON proposed_recip.exitcsid = exit.csid
 LEFT JOIN recipients recip ON recip.exitcsid = exit.csid
-LEFT JOIN related_procedures procedures ON procedures.exitcsid = exit.csid]]>
+LEFT JOIN related_acquisitions acquisition ON acquisition.exitcsid = exit.csid
+LEFT JOIN related_intakes intake ON intake.exitcsid = exit.csid]]>
 	</queryString>
 	<field name="exitnumber" class="java.lang.String">
 		<property name="com.jaspersoft.studio.field.name" value="exitnumber"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/deaccessions.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/deaccessions.xml
@@ -11,6 +11,6 @@
     <supportsGroup>false</supportsGroup>
     <supportsNoContext>true</supportsNoContext>
     <filename>deaccessions.jrxml</filename>
-    <outputMIME>application/pdf</outputMIME>
+    <outputMIME>text/csv</outputMIME>
   </ns2:reports_common>
 </document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/deed_of_gift.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/deed_of_gift.jrxml
@@ -56,19 +56,26 @@
   SELECT object.collection,
     ong.objectname,
     bd.item as briefdescription,
-    media.objectcsid as mediacsid,
     sdg.datedisplaydate as productiondate,
-    intake.csid as intakecsid
+    intake.csid as intakecsid,
+    hier.name as csid
   FROM intakes intake
   INNER JOIN relations_common rels ON rels.subjectcsid = intake.csid AND rels.objectdocumenttype = 'CollectionObject'
+  INNER JOIN misc on misc.id = rels.id AND misc.lifecyclestate != 'deleted'
   INNER JOIN hierarchy hier ON hier.name = rels.objectcsid AND hier.primarytype = 'CollectionObject'
   INNER JOIN collectionobjects_common object ON object.id = hier.id
   LEFT JOIN collectionobjects_common_briefdescriptions bd ON bd.id = object.id AND bd.pos = 0
-  LEFT JOIN relations_common media ON media.subjectcsid = hier.name AND media.objectdocumenttype = 'Media'
   LEFT JOIN hierarchy ong_hier ON ong_hier.parentid = object.id AND ong_hier.primarytype = 'objectNameGroup' AND ong_hier.pos = 0
   LEFT JOIN objectnamegroup ong ON ong.id = ong_hier.id
   LEFT JOIN hierarchy opdg_hier ON opdg_hier.parentid = object.id AND opdg_hier.name = 'collectionobjects_common:objectProductionDateGroupList' AND opdg_hier.pos = 0
   LEFT JOIN structureddategroup sdg ON sdg.id = opdg_hier.id
+), related_object_media AS (
+  SELECT
+    object.csid AS objcsid,
+    media.objectcsid as mediacsid
+  FROM related_objects object
+  INNER JOIN relations_common media ON media.subjectcsid = object.csid AND media.objectdocumenttype = 'Media'
+  INNER JOIN misc on misc.id = media.id AND misc.lifecyclestate != 'deleted'
 )
 select owner.primarydisplayname as primarydisplayname,
   owner.secondarydisplayname as secondarydisplayname,
@@ -83,10 +90,11 @@ select owner.primarydisplayname as primarydisplayname,
   obj.objectname,
   obj.briefdescription,
   obj.productiondate,
-  obj.mediacsid
+  media.mediacsid
 from intakes intake
 left join person_owners as owner on intake.csid = owner.intakecsid
-left join related_objects obj on intake.csid = obj.intakecsid]]>
+left join related_objects obj on intake.csid = obj.intakecsid
+left join related_object_media media on media.objcsid = obj.csid]]>
 	</queryString>
 	<field name="primarydisplayname" class="java.lang.String">
 		<property name="com.jaspersoft.studio.field.name" value="primarydisplayname"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/deed_of_gift.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/deed_of_gift.xml
@@ -11,6 +11,6 @@
     <supportsGroup>false</supportsGroup>
     <supportsNoContext>true</supportsNoContext>
     <filename>deed_of_gift.jrxml</filename>
-    <outputMIME>application/pdf</outputMIME>
+    <outputMIME>text/csv</outputMIME>
   </ns2:reports_common>
 </document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/incoming_loan_letter.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/incoming_loan_letter.xml
@@ -11,6 +11,6 @@
     <supportsGroup>false</supportsGroup>
     <supportsNoContext>true</supportsNoContext>
     <filename>incoming_loan_letter.jrxml</filename>
-    <outputMIME>application/pdf</outputMIME>
+    <outputMIME>text/csv</outputMIME>
   </ns2:reports_common>
 </document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/obj_computed_location.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/obj_computed_location.jrxml
@@ -35,7 +35,7 @@
   object.computedcurrentlocation,
   COALESCE(loc_term.termname, org_term.termname) AS locationname,
   bd.item AS description,
-  media.objectcsid AS mediacsid
+  related_media.objectcsid AS mediacsid
 FROM collectionobjects_common object
 INNER JOIN misc ON misc.id = object.id AND misc.lifecyclestate != 'deleted'
 INNER JOIN collectionspace_core core ON misc.id = core.id AND core.tenantid = $P{tenantid}
@@ -55,7 +55,13 @@ LEFT JOIN loctermgroup loc_term ON loc_term.id = loc_hier.id
 LEFT JOIN organizations_common org ON org.refname = object.computedcurrentlocation
 LEFT JOIN hierarchy org_hier ON org_hier.parentid = org.id AND org_hier.primarytype = 'orgTermGroup' AND org_hier.pos = 0
 LEFT JOIN orgtermgroup org_term ON org_term.id = org_hier.id
-LEFT JOIN relations_common media ON media.subjectcsid = hier.name AND media.objectdocumenttype = 'Media'
+-- related media
+LEFT JOIN (
+  SELECT relation.*
+  FROM relations_common relation
+  INNER JOIN misc ON misc.id = relation.id AND misc.lifecyclestate != 'deleted'
+  WHERE relation.objectdocumenttype = 'Media' AND relation.subjectdocumenttype = 'CollectionObject'
+) related_media ON related_media.subjectcsid = hier.name
 $P!{whereclause}]]>
 	</queryString>
 	<field name="objectnumber" class="java.lang.String">

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/obj_computed_location.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/obj_computed_location.xml
@@ -11,6 +11,6 @@
     <supportsGroup>false</supportsGroup>
     <supportsNoContext>true</supportsNoContext>
     <filename>obj_computed_location.jrxml</filename>
-    <outputMIME>application/pdf</outputMIME>
+    <outputMIME>text/csv</outputMIME>
   </ns2:reports_common>
 </document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/outgoing_loan_letter.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/outgoing_loan_letter.xml
@@ -11,6 +11,6 @@
     <supportsGroup>false</supportsGroup>
     <supportsNoContext>true</supportsNoContext>
     <filename>outgoing_loan_letter.jrxml</filename>
-    <outputMIME>application/pdf</outputMIME>
+    <outputMIME>text/csv</outputMIME>
   </ns2:reports_common>
 </document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tombstone_with_budget.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tombstone_with_budget.jrxml
@@ -397,7 +397,7 @@ $P!{whereclause}]]>
 				<textFieldExpression><![CDATA[$F{acquisitionfundingcurrency}]]></textFieldExpression>
 			</textField>
 			<image onErrorType="Blank">
-				<reportElement x="500" y="0" width="50" height="50" uuid="1ad42717-39a1-42dd-be1c-e4b125a5df3e"/>
+				<reportElement x="1500" y="0" width="50" height="50" uuid="1ad42717-39a1-42dd-be1c-e4b125a5df3e"/>
 				<imageExpression><![CDATA["cspace://media/" + $F{mediacsid} + "/blob/derivatives/Thumbnail/content"]]></imageExpression>
 			</image>
 		</band>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tombstone_with_budget.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tombstone_with_budget.jrxml
@@ -49,8 +49,8 @@ SELECT
   dimension.measurementunit AS dimensionunit,
   sd.datedisplaydate AS artworkdate,
   media.objectcsid AS mediacsid,
-  funding.acquisitionfundingcurrency,
-  funding.acquisitionfundingvalue
+  acquisition.acquisitionfundingcurrency,
+  acquisition.acquisitionfundingvalue
 FROM collectionobjects_common obj
 INNER JOIN hierarchy hier ON hier.id = obj.id
 INNER JOIN misc ON misc.id = hier.id AND misc.lifecyclestate != 'deleted'

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tombstone_with_budget.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tombstone_with_budget.jrxml
@@ -72,11 +72,24 @@ LEFT JOIN dimensionsubgroup dimension ON dimension.id = dimension_hier.id
 LEFT JOIN hierarchy pdg_hier ON pdg_hier.parentid = obj.id AND pdg_hier.primarytype = 'publicartProductionDateGroup' AND pdg_hier.pos = 0
 LEFT JOIN hierarchy sdg_hier ON sdg_hier.parentid = pdg_hier.id AND sdg_hier.primarytype = 'structuredDateGroup'
 LEFT JOIN structureddategroup sd ON sd.id = sdg_hier.id
-LEFT JOIN relations_common media ON media.subjectcsid = hier.name AND media.objectdocumenttype = 'Media'
-LEFT JOIN relations_common acq_rels ON acq_rels.subjectcsid = hier.name AND acq_rels.objectdocumenttype = 'Acquisition'
-LEFT JOIN hierarchy acquisition_hier ON acquisition_hier.name = acq_rels.objectcsid
-LEFT JOIN hierarchy funding_hier ON funding_hier.parentid = acquisition_hier.id AND funding_hier.primarytype = 'acquisitionFunding' AND funding_hier.pos = 0
-LEFT JOIN acquisitionfunding funding ON funding.id = funding_hier.id
+LEFT JOIN (
+  SELECT relation.*
+  FROM relations_common relation
+  INNER JOIN misc ON misc.id = relation.id AND misc.lifecyclestate != 'deleted'
+  WHERE relation.objectdocumenttype = 'Media' AND relation.subjectdocumenttype = 'CollectionObject'
+) media ON media.subjectcsid = hier.name
+LEFT JOIN (
+  SELECT
+    relation.subjectcsid,
+    funding.acquisitionfundingcurrency,
+    funding.acquisitionfundingvalue
+  FROM relations_common relation
+  INNER JOIN misc ON misc.id = relation.id AND misc.lifecyclestate != 'deleted'
+  INNER JOIN hierarchy hier ON hier.name = relation.objectcsid
+  LEFT JOIN hierarchy funding_hier ON funding_hier.parentid = hier.id AND funding_hier.primarytype = 'acquisitionFunding' AND funding_hier.pos = 0
+  LEFT JOIN acquisitionfunding funding ON funding.id = funding_hier.id
+  WHERE relation.objectdocumenttype = 'Acquisition' AND relation.subjectdocumenttype = 'CollectionObject'
+) acquisition ON acquisition.subjectcsid = hier.name
 $P!{whereclause}]]>
 	</queryString>
 	<field name="objectnumber" class="java.lang.String">


### PR DESCRIPTION
**What does this do?**
This PR updates many of the queries for the new csv reports in order to ignore relations on objects/procedures which have been deleted. 

**Why are we doing this? (with JIRA link)**
When testing on dev we saw some reports generating many more rows than expected and when looking into the cause I found that there were deleted relations being retrieved in the report. This work is being done in order to remove those rows from the reports.

I also updated the default output to be `text/csv`.

**How should this be tested? Do these changes have associated tests?**

Most of the reports only query for related objects and media on said objects, what I have is:
* A single base collectionobject and 2 media handling procedures
* Relate the collectionobject with the media
* Delete on of the media procedures

Then for run reports which query related collectionobjects/media
* Accessions
  * Acquisition -> CollectionObject -> Media
*  Box List
    * LMI -> CollectionObject -> Media
* Deaccessions
  * ObjectExit -> CollectionObject -> Media
  * Also needs test on related acquisitions and intake
* Deed of Gift
  * Intake -> CollectionObject -> Media
* Object w/ Computed location
  * CollectionObject -> Media
* Tombstone w/ budget
  * CollectionObject -> Media
  * Also needs test on related acqusition

**Dependencies for merging? Releasing to production?**
I updated each query to be consistent with how I had previously done them. So if the report already used  CTEs I went that route, otherwise I found I could use subqueries and join on them. I'm not really sure about performance implications for them, but both allow an easy way to make sure we 1) get a row back if no relation exists and 2) avoid any records which have been deleted. 

I also only updated the sql in the jasper reports, and if needed I can reimport the reports into jasper to regenerate the `<field>` tags. It didn't seem like this impacted the ability of the server to run the reports but I'm still going through them.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested the accessions and object w/ computed location reports. Other queries have been ran but I reset my database the other day so I have no test data; still going through the rest of the reports to verify.