### PR TITLE
DRYD-1230: Automatically add/update reports on startup.

### DIFF
--- a/services/JaxRsServiceProvider/src/main/java/org/collectionspace/services/jaxrs/CSpaceResteasyBootstrap.java
+++ b/services/JaxRsServiceProvider/src/main/java/org/collectionspace/services/jaxrs/CSpaceResteasyBootstrap.java
@@ -191,7 +191,11 @@ public class CSpaceResteasyBootstrap extends ResteasyBootstrap {
 			if (list.getTotalItems() == 0) {
 				logger.info("Adding report " + reportName);
 
-				reportResource.create(resourceMap, null, payload);
+				try {
+					reportResource.create(resourceMap, null, payload);
+				} catch(Exception e) {
+					logger.error(e.getMessage(), e);
+				}
 			} else {
 				for (ListItem item : list.getListItem()) {
 					String csid = AbstractCommonListUtils.ListItemGetCSID(item);
@@ -215,7 +219,11 @@ public class CSpaceResteasyBootstrap extends ResteasyBootstrap {
 					) {
 						logger.info("Updating report {} with csid {}", reportName, csid);
 
-						reportResource.update(resourceMap, null, csid, payload);
+						try {
+							reportResource.update(resourceMap, null, csid, payload);
+						} catch (Exception e) {
+							logger.error(e.getMessage(), e);
+						}
 					} else {
 						logger.info(
 							"Not updating report {} with csid {} - it was not auto-created, or was updated or soft-deleted",

--- a/services/batch/service/src/main/java/org/collectionspace/services/batch/BatchResource.java
+++ b/services/batch/service/src/main/java/org/collectionspace/services/batch/BatchResource.java
@@ -96,6 +96,7 @@ public class BatchResource extends NuxeoBasedResource {
             MultivaluedMap<String, String> queryParams = ctx.getQueryParams();
             DocumentHandler handler = createDocumentHandler(ctx);
             String docType = queryParams.getFirst(IQueryManager.SEARCH_TYPE_DOCTYPE);
+            String filename = queryParams.getFirst(IQueryManager.SEARCH_TYPE_FILENAME);
             List<String> modes = queryParams.get(IQueryManager.SEARCH_TYPE_INVOCATION_MODE);
             String whereClause = null;
             DocumentFilter documentFilter = null;
@@ -104,6 +105,13 @@ public class BatchResource extends NuxeoBasedResource {
             if (docType != null && !docType.isEmpty()) {
                 whereClause = QueryManager.createWhereClauseForInvocableByDocType(
                 		common_part, docType);
+                documentFilter = handler.getDocumentFilter();
+                documentFilter.appendWhereClause(whereClause, IQueryManager.SEARCH_QUALIFIER_AND);
+            }
+
+            if (filename != null && !filename.isEmpty()) {
+                whereClause = QueryManager.createWhereClauseForInvocableByFilename(
+                        common_part, filename);
                 documentFilter = handler.getDocumentFilter();
                 documentFilter.appendWhereClause(whereClause, IQueryManager.SEARCH_QUALIFIER_AND);
             }

--- a/services/client/src/main/java/org/collectionspace/services/client/IQueryManager.java
+++ b/services/client/src/main/java/org/collectionspace/services/client/IQueryManager.java
@@ -35,17 +35,18 @@ public interface IQueryManager {
 	final static String SEARCH_TERM_SEPARATOR = " ";
 	final static String SEARCH_LIKE = " LIKE ";
 	final static String SEARCH_ILIKE = " ILIKE ";
-    final static String SEARCH_TYPE_KEYWORDS = "keywords";
-    final static String SEARCH_TYPE_KEYWORDS_KW = "kw";
-    final static String SEARCH_TYPE_KEYWORDS_AS = "as";
-    final static String SEARCH_TYPE_PARTIALTERM = "pt";
-    final static String SEARCH_TYPE_DOCTYPE = "doctype";
-    final static String SEARCH_TYPE_INVOCATION_MODE = "mode";
-    final static String SEARCH_TYPE_INVOCATION = "inv";
+	final static String SEARCH_TYPE_KEYWORDS = "keywords";
+	final static String SEARCH_TYPE_KEYWORDS_KW = "kw";
+	final static String SEARCH_TYPE_KEYWORDS_AS = "as";
+	final static String SEARCH_TYPE_PARTIALTERM = "pt";
+	final static String SEARCH_TYPE_DOCTYPE = "doctype";
+	final static String SEARCH_TYPE_FILENAME = "filename";
+	final static String SEARCH_TYPE_INVOCATION_MODE = "mode";
+	final static String SEARCH_TYPE_INVOCATION = "inv";
 	final static String SEARCH_QUALIFIER_AND = SEARCH_TERM_SEPARATOR + "AND" + SEARCH_TERM_SEPARATOR;
 	final static String SEARCH_QUALIFIER_OR = SEARCH_TERM_SEPARATOR + "OR" + SEARCH_TERM_SEPARATOR;
-    final static String DEFAULT_SELECT_CLAUSE = "SELECT * FROM ";
-    final static String CSID_QUERY_PARAM = "csid";
+	final static String DEFAULT_SELECT_CLAUSE = "SELECT * FROM ";
+	final static String CSID_QUERY_PARAM = "csid";
 
 
 	//
@@ -160,6 +161,16 @@ public interface IQueryManager {
 	 * @return the string
 	 */
 	public String createWhereClauseForInvocableByDocType(String schema, String docType);
+
+
+	/**
+	 * Creates a filtering where clause from filename, for invocables.
+	 *
+	 * @param schema  the schema name for this invocable
+	 * @param docType the filename
+	 * @return        the where clause
+	 */
+	public String createWhereClauseForInvocableByFilename(String schema, String filename);
 
 	/**
 	 * Creates a filtering where clause from invocation mode, for invocables.

--- a/services/common/src/main/cspace/config/services/tenants/publicart/publicart-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/publicart/publicart-tenant-bindings.delta.xml
@@ -1,13 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <tenant:TenantBindingConfig
-        xmlns:merge="http://xmlmerge.el4j.elca.ch"
-        xmlns:tenant="http://collectionspace.org/services/config/tenant">
+		xmlns:merge="http://xmlmerge.el4j.elca.ch"
+		xmlns:tenant="http://collectionspace.org/services/config/tenant">
 
-    <!-- Add your changes, if any, within the following tag pair. -->
-    <!-- The value of the 'id' attribute, below, should match the corresponding -->
-    <!-- value in cspace/config/services/tenants/publicart-tenant-bindings-proto.xml -->
+	<!-- Add your changes, if any, within the following tag pair. -->
+	<!-- The value of the 'id' attribute, below, should match the corresponding -->
+	<!-- value in cspace/config/services/tenants/publicart-tenant-bindings-proto.xml -->
 
-    <tenant:tenantBinding id="5000">
-    </tenant:tenantBinding>
+	<tenant:tenantBinding id="5000">
+		<tenant:serviceBindings merge:matcher="id" id="Reports">
+			<service:properties xmlns:service="http://collectionspace.org/services/config/service" xmlns:types="http://collectionspace.org/services/config/types">
+				<types:item merge:matcher="skip" merge:action="insert">
+					<types:key>report</types:key>
+					<types:value>obj_current_place_details</types:value>
+				</types:item>
+				<types:item merge:matcher="skip" merge:action="insert">
+					<types:key>report</types:key>
+					<types:value>tombstone_with_budget</types:value>
+				</types:item>
+			</service:properties>
+		</tenant:serviceBindings>
+	</tenant:tenantBinding>
 
 </tenant:TenantBindingConfig>

--- a/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
+++ b/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
@@ -528,61 +528,66 @@
 			<service:initHandler xmlns:service="http://collectionspace.org/services/config/service">
 				<service:classname>org.collectionspace.services.report.nuxeo.ReportPostInitHandler</service:classname>
 				<service:params>
-                   <service:property>
-                           <service:key>readerRoleName</service:key>
-                           <service:value>reader</service:value>
-                   </service:property>
+					<service:property>
+						<service:key>readerRoleName</service:key>
+						<service:value>reader</service:value>
+					</service:property>
 				</service:params>
 			</service:initHandler>
-			<service:properties xmlns:service="http://collectionspace.org/services/config/service">
-		        <types:item xmlns:types="http://collectionspace.org/services/config/types">
-		          <types:key>outputMIME</types:key>
-		          <types:displayName>XML</types:displayName>
-		          <types:value>application/xml</types:value>
-		        </types:item>
-		        <types:item xmlns:types="http://collectionspace.org/services/config/types">
-		          <types:key>outputMIME</types:key>
-		          <types:displayName>HTML</types:displayName>
-		          <types:value>text/html</types:value>
-		        </types:item>
-		        <types:item xmlns:types="http://collectionspace.org/services/config/types">
-		          <types:key>outputMIME</types:key>
-		          <types:displayName>PDF</types:displayName>
-		          <types:value>application/pdf</types:value>
-		        </types:item>
-		        <types:item xmlns:types="http://collectionspace.org/services/config/types">
-		          <types:key>outputMIME</types:key>
-		          <types:value>text/csv</types:value>
-		        </types:item>
-		        <types:item xmlns:types="http://collectionspace.org/services/config/types">
-		          <types:key>outputMIME</types:key>
-		          <types:value>text/tab-separated-values</types:value>
-		        </types:item>
-		        <types:item xmlns:types="http://collectionspace.org/services/config/types">
-		          <types:key>outputMIME</types:key>
-		          <types:value>application/msword</types:value>
-		        </types:item>
-		        <types:item xmlns:types="http://collectionspace.org/services/config/types">
-		          <types:key>outputMIME</types:key>
-		          <types:value>application/vnd.openxmlformats-officedocument.wordprocessingml.document</types:value>
-		        </types:item>
-		        <types:item xmlns:types="http://collectionspace.org/services/config/types">
-		          <types:key>outputMIME</types:key>
-		          <types:value>application/vnd.ms-excel</types:value>
-		        </types:item>
-		        <types:item xmlns:types="http://collectionspace.org/services/config/types">
-		          <types:key>outputMIME</types:key>
-		          <types:value>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</types:value>
-		        </types:item>
-		        <types:item xmlns:types="http://collectionspace.org/services/config/types">
-		          <types:key>outputMIME</types:key>
-		          <types:value>application/vnd.ms-powerpoint</types:value>
-		        </types:item>
-		        <types:item xmlns:types="http://collectionspace.org/services/config/types">
-		          <types:key>outputMIME</types:key>
-		          <types:value>application/vnd.openxmlformats-officedocument.presentationml.presentation</types:value>
-		        </types:item>
-	      	</service:properties>
+			<service:properties xmlns:service="http://collectionspace.org/services/config/service" xmlns:types="http://collectionspace.org/services/config/types">
+				<types:item>
+					<types:key>outputMIME</types:key>
+					<types:displayName>XML</types:displayName>
+					<types:value>application/xml</types:value>
+				</types:item>
+				<types:item>
+					<types:key>outputMIME</types:key>
+					<types:displayName>HTML</types:displayName>
+					<types:value>text/html</types:value>
+				</types:item>
+				<types:item>
+					<types:key>outputMIME</types:key>
+					<types:displayName>PDF</types:displayName>
+					<types:value>application/pdf</types:value>
+				</types:item>
+				<types:item>
+					<types:key>outputMIME</types:key>
+					<types:value>text/csv</types:value>
+				</types:item>
+				<types:item>
+					<types:key>outputMIME</types:key>
+					<types:value>text/tab-separated-values</types:value>
+				</types:item>
+				<types:item>
+					<types:key>outputMIME</types:key>
+					<types:value>application/msword</types:value>
+				</types:item>
+				<types:item>
+					<types:key>outputMIME</types:key>
+					<types:value>application/vnd.openxmlformats-officedocument.wordprocessingml.document</types:value>
+				</types:item>
+				<types:item>
+					<types:key>outputMIME</types:key>
+					<types:value>application/vnd.ms-excel</types:value>
+				</types:item>
+				<types:item>
+					<types:key>outputMIME</types:key>
+					<types:value>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</types:value>
+				</types:item>
+				<types:item>
+					<types:key>outputMIME</types:key>
+					<types:value>application/vnd.ms-powerpoint</types:value>
+				</types:item>
+				<types:item>
+					<types:key>outputMIME</types:key>
+					<types:value>application/vnd.openxmlformats-officedocument.presentationml.presentation</types:value>
+				</types:item>
+
+				<types:item>
+					<types:key>report</types:key>
+					<types:value>deed_of_gift</types:value>
+				</types:item>
+			</service:properties>
 			<service:object xmlns:service="http://collectionspace.org/services/config/service" name="Report"
 				version="1.0">
 				<service:part id="0" control_group="Managed" versionable="true" auditable="false" label="reports-system"

--- a/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
+++ b/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
@@ -585,7 +585,31 @@
 
 				<types:item>
 					<types:key>report</types:key>
+					<types:value>accessions</types:value>
+				</types:item>
+				<types:item>
+					<types:key>report</types:key>
+					<types:value>box_list</types:value>
+				</types:item>
+				<types:item>
+					<types:key>report</types:key>
+					<types:value>deaccessions</types:value>
+				</types:item>
+				<types:item>
+					<types:key>report</types:key>
 					<types:value>deed_of_gift</types:value>
+				</types:item>
+				<types:item>
+					<types:key>report</types:key>
+					<types:value>incoming_loan_letter</types:value>
+				</types:item>
+				<types:item>
+					<types:key>report</types:key>
+					<types:value>obj_computed_location</types:value>
+				</types:item>
+				<types:item>
+					<types:key>report</types:key>
+					<types:value>outgoing_loan_letter</types:value>
 				</types:item>
 			</service:properties>
 			<service:object xmlns:service="http://collectionspace.org/services/config/service" name="Report"

--- a/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
+++ b/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
@@ -589,7 +589,43 @@
 				</types:item>
 				<types:item>
 					<types:key>report</types:key>
+					<types:value>acq_basic</types:value>
+				</types:item>
+				<types:item>
+					<types:key>report</types:key>
+					<types:value>Acq_List_Basic</types:value>
+				</types:item>
+				<types:item>
+					<types:key>report</types:key>
 					<types:value>box_list</types:value>
+				</types:item>
+				<types:item>
+					<types:key>report</types:key>
+					<types:value>CC_List_Basic</types:value>
+				</types:item>
+				<types:item>
+					<types:key>report</types:key>
+					<types:value>coreAcquisition</types:value>
+				</types:item>
+				<types:item>
+					<types:key>report</types:key>
+					<types:value>coreGroupObject</types:value>
+				</types:item>
+				<types:item>
+					<types:key>report</types:key>
+					<types:value>coreIntake</types:value>
+				</types:item>
+				<types:item>
+					<types:key>report</types:key>
+					<types:value>coreLoanIn</types:value>
+				</types:item>
+				<types:item>
+					<types:key>report</types:key>
+					<types:value>coreLoanOut</types:value>
+				</types:item>
+				<types:item>
+					<types:key>report</types:key>
+					<types:value>coreObjectExit</types:value>
 				</types:item>
 				<types:item>
 					<types:key>report</types:key>
@@ -601,7 +637,23 @@
 				</types:item>
 				<types:item>
 					<types:key>report</types:key>
+					<types:value>Exhibition_List_Basic</types:value>
+				</types:item>
+				<types:item>
+					<types:key>report</types:key>
+					<types:value>Group_List_Basic</types:value>
+				</types:item>
+				<types:item>
+					<types:key>report</types:key>
 					<types:value>incoming_loan_letter</types:value>
+				</types:item>
+				<types:item>
+					<types:key>report</types:key>
+					<types:value>LoansIn_List_Basic</types:value>
+				</types:item>
+				<types:item>
+					<types:key>report</types:key>
+					<types:value>LoansOut_List_Basic</types:value>
 				</types:item>
 				<types:item>
 					<types:key>report</types:key>
@@ -609,7 +661,15 @@
 				</types:item>
 				<types:item>
 					<types:key>report</types:key>
+					<types:value>object_valuation</types:value>
+				</types:item>
+				<types:item>
+					<types:key>report</types:key>
 					<types:value>outgoing_loan_letter</types:value>
+				</types:item>
+				<types:item>
+					<types:key>report</types:key>
+					<types:value>systematicInventory</types:value>
 				</types:item>
 			</service:properties>
 			<service:object xmlns:service="http://collectionspace.org/services/config/service" name="Report"

--- a/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
+++ b/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
@@ -645,6 +645,10 @@
 				</types:item>
 				<types:item>
 					<types:key>report</types:key>
+					<types:value>incoming_loan</types:value>
+				</types:item>
+				<types:item>
+					<types:key>report</types:key>
 					<types:value>incoming_loan_letter</types:value>
 				</types:item>
 				<types:item>
@@ -666,6 +670,10 @@
 				<types:item>
 					<types:key>report</types:key>
 					<types:value>outgoing_loan_letter</types:value>
+				</types:item>
+				<types:item>
+					<types:key>report</types:key>
+					<types:value>referral</types:value>
 				</types:item>
 				<types:item>
 					<types:key>report</types:key>

--- a/services/common/src/main/java/org/collectionspace/services/common/query/QueryManager.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/query/QueryManager.java
@@ -110,6 +110,17 @@ public class QueryManager {
 	}
 
 	/**
+	 * Creates a filtering where clause from filename, for invocables.
+	 *
+	 * @param schema  the schema name for this invocable
+	 * @param docType the filename
+	 * @return        the where clause
+	 */
+	static public String createWhereClauseForInvocableByFilename(String schema, String filename) {
+		return queryManager.createWhereClauseForInvocableByFilename(schema, filename);
+	}
+
+	/**
 	 * Creates a filtering where clause from invocation mode, for invocables.
 	 *
 	 * @param schema the schema name for this invocable type

--- a/services/common/src/main/java/org/collectionspace/services/common/query/nuxeo/QueryManagerNuxeoImpl.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/query/nuxeo/QueryManagerNuxeoImpl.java
@@ -280,18 +280,44 @@ public class QueryManagerNuxeoImpl implements IQueryManager {
 	 * @return the string
 	 */
 	@Override
-	public String createWhereClauseForInvocableByDocType(String schema,
-			String docType) {
-		String trimmed = (docType == null) ? "" : docType.trim();
+	public String createWhereClauseForInvocableByDocType(String schema, String docType) {
+		String trimmed = sanitizeNXQLString(docType);
+
 		if (trimmed.isEmpty()) {
 			throw new RuntimeException("No docType specified.");
 		}
+
 		if (schema == null || schema.isEmpty()) {
 			throw new RuntimeException("No match schema specified.");
 		}
-		String wClause = schema + ":" + InvocableJAXBSchema.FOR_DOC_TYPES
-				+ " = '" + trimmed + "'";
-		return wClause;
+
+		String whereClause = schema + ":" + InvocableJAXBSchema.FOR_DOC_TYPES + " = '" + trimmed + "'";
+
+		return whereClause;
+	}
+
+	/**
+	 * Creates a filtering where clause from filename, for invocables.
+	 *
+	 * @param schema  the schema name for this invocable
+	 * @param docType the filename
+	 * @return        the where clause
+	 */
+	@Override
+	public String createWhereClauseForInvocableByFilename(String schema, String filename) {
+		String trimmed = sanitizeNXQLString(filename);
+
+		if (trimmed.isEmpty()) {
+			throw new RuntimeException("No filename specified.");
+		}
+
+		if (schema == null || schema.isEmpty()) {
+			throw new RuntimeException("No match schema specified.");
+		}
+
+		String whereClause = schema + ":" + InvocableJAXBSchema.FILENAME + " = '" + trimmed + "'";
+
+		return whereClause;
 	}
 
 	/**
@@ -336,6 +362,13 @@ public class QueryManagerNuxeoImpl implements IQueryManager {
 		}
 
 		return "";
+	}
+
+	private String sanitizeNXQLString(String input) {
+		String trimmed = (input == null) ? "" : input.trim();
+		String escaped = unescapedSingleQuote.matcher(trimmed).replaceAll("\\\\'");
+
+		return escaped;
 	}
 
 	/**
@@ -389,5 +422,4 @@ public class QueryManagerNuxeoImpl implements IQueryManager {
 
 		return NuxeoUtils.getByNameWhereClause(csid);
 	}
-
 }

--- a/services/jaxb/src/main/java/org/collectionspace/services/jaxb/InvocableJAXBSchema.java
+++ b/services/jaxb/src/main/java/org/collectionspace/services/jaxb/InvocableJAXBSchema.java
@@ -1,9 +1,10 @@
 /**
- * 
+ *
  */
 package org.collectionspace.services.jaxb;
 
 public interface InvocableJAXBSchema {
+    final static String FILENAME = "filename";
     final static String FOR_DOC_TYPES = "forDocTypes";
     final static String SUPPORTS_SINGLE_DOC = "supportsSingleDoc";
     final static String SUPPORTS_DOC_LIST = "supportsDocList";

--- a/services/report/3rdparty/build.xml
+++ b/services/report/3rdparty/build.xml
@@ -73,7 +73,7 @@
             <arg value="${mvn.opts}" />
         </exec>
     </target>
-    
+
     <target name="clean" depends="clean-unix,clean-windows"
   description="Delete target directories" >
         <delete dir="${build}"/>
@@ -108,38 +108,38 @@
             <arg value="${mvn.opts}" />
         </exec>
     </target>
-    
-    <!-- 
+
+    <!--
          Preserve the legacy name for this target, while noting that
          legacy name is no longer descriptive of its purpose.
      -->
     <target name="deploy_jasper_samples" depends="deploy_report_files" />
 
     <target name="deploy_report_files"
-        description="Deploy report files">
+        description="Deploy report files and metadata files">
         <copy todir="${jee.server.cspace}/cspace/reports" overwrite="true">
             <fileset dir="${basedir}/jasper-cs-report/src/main/resources"
-                includes="*.jrxml"/>
+                includes="*.jrxml,*.xml"/>
         </copy>
     </target>
-    
+
     <target name="undeploy_report_files"
       depends="undeploy_source_report_files,undeploy_compiled_report_files"
       description="Undeploy report files">
     </target>
-    
+
 	<!-- Removes only the source reports that originated from the source directory.  Ones added
 		manually remain.
 	-->
     <target name="undeploy_source_report_files"
-      description="Undeploy source (.jrxml) report files">
+      description="Undeploy source (.jrxml) report files and metadata (.xml) files">
       <delete failonerror="false">
-        <fileset dir="${jee.server.cspace}/cspace/reports" includes="*.jrxml">
+        <fileset dir="${jee.server.cspace}/cspace/reports" includes="*.jrxml,*.xml">
 			<present targetdir="${basedir}/jasper-cs-report/src/main/resources" />
 		</fileset>
       </delete>
     </target>
-    
+
     <target name="undeploy_compiled_report_files"
       description="Undeploy compiled (.jasper) report files">
       <delete failonerror="false">
@@ -150,7 +150,7 @@
     <target name="deploy" depends="install,deploy_report_files"
       description="Deploy report-related artifacts">
       <!--
-        The following ant call is obsolete.  The Nuxeo artifacts are now created 
+        The following ant call is obsolete.  The Nuxeo artifacts are now created
         and deployed using the "csmake" tool.
         <ant antfile="nuxeo-platform-cs-report/build.xml" target="deploy" inheritall="false"/>
       -->

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/Acq_List_Basic.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/Acq_List_Basic.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<document name="report">
+  <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
+    <name>Acquisition Basic List</name>
+    <notes>Catalog info for objects related to an acquisition record. Runs on a single record only.</notes>
+    <forDocTypes>
+      <forDocType>Acquisition</forDocType>
+    </forDocTypes>
+    <supportsSingleDoc>true</supportsSingleDoc>
+    <supportsDocList>false</supportsDocList>
+    <supportsGroup>false</supportsGroup>
+    <supportsNoContext>false</supportsNoContext>
+    <outputMIME>application/pdf</outputMIME>
+    <filename>Acq_List_Basic.jrxml</filename>
+  </ns2:reports_common>
+</document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/CC_List_Basic.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/CC_List_Basic.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<document name="report">
+  <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
+    <name>Condition Check Basic List</name>
+    <notes>Catalog info for objects related to a condition check record. Runs on a single record only.</notes>
+    <forDocTypes>
+      <forDocType>Conditioncheck</forDocType>
+    </forDocTypes>
+    <supportsSingleDoc>true</supportsSingleDoc>
+    <supportsDocList>false</supportsDocList>
+    <supportsGroup>false</supportsGroup>
+    <supportsNoContext>false</supportsNoContext>
+    <outputMIME>application/pdf</outputMIME>
+    <filename>CC_List_Basic.jrxml</filename>
+  </ns2:reports_common>
+</document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/Exhibition_List_Basic.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/Exhibition_List_Basic.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<document name="report">
+  <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
+    <name>Exhibition Basic List</name>
+    <notes>Catalog info for objects related to a exhibition record. Runs on a single record only.</notes>
+    <forDocTypes>
+      <forDocType>Exhibition</forDocType>
+    </forDocTypes>
+    <supportsSingleDoc>true</supportsSingleDoc>
+    <supportsDocList>false</supportsDocList>
+    <supportsGroup>false</supportsGroup>
+    <supportsNoContext>false</supportsNoContext>
+    <outputMIME>application/pdf</outputMIME>
+    <filename>Exhibition_List_Basic.jrxml</filename>
+  </ns2:reports_common>
+</document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/Group_List_Basic.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/Group_List_Basic.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<document name="report">
+  <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
+    <name>Group Basic List</name>
+    <notes>Catalog info for objects related to a group record. Runs on a group of objects, a single object, or selected objects.</notes>
+    <forDocTypes>
+      <forDocType>CollectionObject</forDocType>
+    </forDocTypes>
+    <supportsSingleDoc>true</supportsSingleDoc>
+    <supportsDocList>true</supportsDocList>
+    <supportsGroup>true</supportsGroup>
+    <supportsNoContext>false</supportsNoContext>
+    <outputMIME>application/pdf</outputMIME>
+    <filename>Group_List_Basic.jrxml</filename>
+  </ns2:reports_common>
+</document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/LoansIn_List_Basic.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/LoansIn_List_Basic.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<document name="report">
+  <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
+    <name>Loan In Basic List</name>
+    <notes>Catalog info for objects related to a loan in record. Runs on a single record only.</notes>
+    <forDocTypes>
+      <forDocType>Loanin</forDocType>
+    </forDocTypes>
+    <supportsSingleDoc>true</supportsSingleDoc>
+    <supportsDocList>false</supportsDocList>
+    <supportsGroup>false</supportsGroup>
+    <supportsNoContext>false</supportsNoContext>
+    <outputMIME>application/pdf</outputMIME>
+    <filename>LoansIn_List_Basic.jrxml</filename>
+  </ns2:reports_common>
+</document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/LoansOut_List_Basic.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/LoansOut_List_Basic.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<document name="report">
+  <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
+    <name>Loan Out Basic List</name>
+    <notes>Catalog info for objects related to a loan out record. Runs on a single record only.</notes>
+    <forDocTypes>
+      <forDocType>Loanout</forDocType>
+    </forDocTypes>
+    <supportsSingleDoc>true</supportsSingleDoc>
+    <supportsDocList>false</supportsDocList>
+    <supportsGroup>false</supportsGroup>
+    <supportsNoContext>false</supportsNoContext>
+    <outputMIME>application/pdf</outputMIME>
+    <filename>LoansOut_List_Basic.jrxml</filename>
+  </ns2:reports_common>
+</document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/acq_basic.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/acq_basic.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<document name="report">
+  <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
+    <name>Acquisition Summary</name>
+    <notes>An acquisition summary report. Runs on a single record only.</notes>
+    <forDocTypes>
+      <forDocType>Acquisition</forDocType>
+    </forDocTypes>
+    <supportsSingleDoc>true</supportsSingleDoc>
+    <supportsDocList>false</supportsDocList>
+    <supportsGroup>false</supportsGroup>
+    <supportsNoContext>false</supportsNoContext>
+    <outputMIME>application/pdf</outputMIME>
+    <filename>acq_basic.jrxml</filename>
+  </ns2:reports_common>
+</document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/coreAcquisition.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/coreAcquisition.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<document name="report">
+  <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
+    <name>Acquisition Ethnographic Object List</name>
+    <notes>Core acquisition report. Runs on a single record only.</notes>
+    <forDocTypes>
+      <forDocType>Acquisition</forDocType>
+    </forDocTypes>
+    <supportsSingleDoc>true</supportsSingleDoc>
+    <supportsDocList>false</supportsDocList>
+    <supportsGroup>false</supportsGroup>
+    <supportsNoContext>false</supportsNoContext>
+    <outputMIME>application/pdf</outputMIME>
+    <filename>coreAcquisition.jrxml</filename>
+  </ns2:reports_common>
+</document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/coreGroupObject.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/coreGroupObject.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<document name="report">
+  <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
+    <name>Group Object Ethnographic Object List</name>
+    <notes>Core group object report. Runs on a single record only.</notes>
+    <forDocTypes>
+      <forDocType>Group</forDocType>
+    </forDocTypes>
+    <supportsSingleDoc>true</supportsSingleDoc>
+    <supportsDocList>false</supportsDocList>
+    <supportsGroup>false</supportsGroup>
+    <supportsNoContext>false</supportsNoContext>
+    <outputMIME>application/pdf</outputMIME>
+    <filename>coreGroupObject.jrxml</filename>
+  </ns2:reports_common>
+</document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/coreIntake.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/coreIntake.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<document name="report">
+  <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
+    <name>Intake Ethnographic Object List</name>
+    <notes>Core intake report. Runs on a single record only.</notes>
+    <forDocTypes>
+      <forDocType>Intake</forDocType>
+    </forDocTypes>
+    <supportsSingleDoc>true</supportsSingleDoc>
+    <supportsDocList>false</supportsDocList>
+    <supportsGroup>false</supportsGroup>
+    <supportsNoContext>false</supportsNoContext>
+    <outputMIME>application/pdf</outputMIME>
+    <filename>coreIntake.jrxml</filename>
+  </ns2:reports_common>
+</document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/coreLoanIn.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/coreLoanIn.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<document name="report">
+  <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
+    <name>Loan In Ethnographic Object List</name>
+    <notes>Core loan in report. Runs on a single record only.</notes>
+    <forDocTypes>
+      <forDocType>Loanin</forDocType>
+    </forDocTypes>
+    <supportsSingleDoc>true</supportsSingleDoc>
+    <supportsDocList>false</supportsDocList>
+    <supportsGroup>false</supportsGroup>
+    <supportsNoContext>false</supportsNoContext>
+    <outputMIME>application/pdf</outputMIME>
+    <filename>coreLoanIn.jrxml</filename>
+  </ns2:reports_common>
+</document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/coreLoanOut.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/coreLoanOut.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<document name="report">
+  <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
+    <name>Loan Out Ethnographic Object List</name>
+    <notes>Core loan out report. Runs on a single record only.</notes>
+    <forDocTypes>
+      <forDocType>Loanout</forDocType>
+    </forDocTypes>
+    <supportsSingleDoc>true</supportsSingleDoc>
+    <supportsDocList>false</supportsDocList>
+    <supportsGroup>false</supportsGroup>
+    <supportsNoContext>false</supportsNoContext>
+    <outputMIME>application/pdf</outputMIME>
+    <filename>coreLoanOut.jrxml</filename>
+  </ns2:reports_common>
+</document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/coreObjectExit.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/coreObjectExit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<document name="report">
+  <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
+    <name>Object Exit Ethnographic Object List</name>
+    <notes>Core object exit report. Runs on a single record only.</notes>
+    <forDocTypes>
+      <forDocType>ObjectExit</forDocType>
+    </forDocTypes>
+    <supportsSingleDoc>true</supportsSingleDoc>
+    <supportsDocList>false</supportsDocList>
+    <supportsGroup>false</supportsGroup>
+    <supportsNoContext>false</supportsNoContext>
+    <outputMIME>application/pdf</outputMIME>
+    <filename>coreObjectExit.jrxml</filename>
+  </ns2:reports_common>
+</document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/object_valuation.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/object_valuation.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<document name="report">
+  <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
+    <name>Object Valuation</name>
+    <notes>Returns latest valuation information for selected objects. Runs on selected objects, or all objects.</notes>
+    <forDocTypes>
+      <forDocType>CollectionObject</forDocType>
+    </forDocTypes>
+    <supportsSingleDoc>false</supportsSingleDoc>
+    <supportsDocList>true</supportsDocList>
+    <supportsGroup>false</supportsGroup>
+    <supportsNoContext>true</supportsNoContext>
+    <outputMIME>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</outputMIME>
+    <filename>object_valuation.jrxml</filename>
+  </ns2:reports_common>
+</document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/systematicInventory.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/systematicInventory.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<document name="report">
+  <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
+    <name>Systematic Inventory</name>
+    <notes>Generate a checklist for performing an inventory on a range of storage locations. Runs on all records, using the provided start and end locations.</notes>
+    <forDocTypes>
+      <forDocType>Locationitem</forDocType>
+    </forDocTypes>
+    <supportsSingleDoc>false</supportsSingleDoc>
+    <supportsDocList>false</supportsDocList>
+    <supportsGroup>false</supportsGroup>
+    <supportsNoContext>true</supportsNoContext>
+    <outputMIME>application/pdf</outputMIME>
+    <filename>systematicInventory.jrxml</filename>
+  </ns2:reports_common>
+</document>

--- a/services/report/client/src/main/java/org/collectionspace/services/client/ReportClient.java
+++ b/services/report/client/src/main/java/org/collectionspace/services/client/ReportClient.java
@@ -1,4 +1,4 @@
-/**	
+/**
  * ReportClient.java
  *
  * {Purpose of This Class}
@@ -38,63 +38,60 @@ import org.collectionspace.services.report.ReportsCommon;
  * FIXME: http://issues.collectionspace.org/browse/CSPACE-1684
  */
 public class ReportClient extends AbstractCommonListPoxServiceClientImpl<ReportProxy, ReportsCommon> {
-
-    public static final String SERVICE_NAME = "reports";
-    public static final String SERVICE_PATH_COMPONENT = SERVICE_NAME;
-    public static final String SERVICE_PATH = "/" + SERVICE_PATH_COMPONENT;
+	public static final String SERVICE_NAME = "reports";
+	public static final String SERVICE_PATH_COMPONENT = SERVICE_NAME;
+	public static final String SERVICE_PATH = "/" + SERVICE_PATH_COMPONENT;
 	public static final String SERVICE_COMMON_PART_NAME = SERVICE_NAME + PART_LABEL_SEPARATOR + PART_COMMON_LABEL;
-    public static final String PDF_MIME_TYPE = "application/pdf";
-    public static final String CSV_MIME_TYPE = "text/csv";
-    public static final String TSV_MIME_TYPE = "text/tab-separated-values";
-    public static final String MSWORD_MIME_TYPE = "application/msword";
-    public static final String OPEN_DOCX_MIME_TYPE = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
-    public static final String MSEXCEL_MIME_TYPE = "application/vnd.ms-excel";
-    public static final String OPEN_XLSX_MIME_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
-    public static final String MSPPT_MIME_TYPE = "application/vnd.ms-powerpoint";
-    public static final String OPEN_PPTX_MIME_TYPE = "application/vnd.openxmlformats-officedocument.presentationml.presentation";
-    public static final String DEFAULT_REPORT_OUTPUT_MIME = PDF_MIME_TYPE;
-    public static final String COMPILED_REPORT_EXTENSION = ".jasper";
-    public static final String REPORT_DECSRIPTION_EXTENSION = ".jrxml";
+	public static final String PDF_MIME_TYPE = "application/pdf";
+	public static final String CSV_MIME_TYPE = "text/csv";
+	public static final String TSV_MIME_TYPE = "text/tab-separated-values";
+	public static final String MSWORD_MIME_TYPE = "application/msword";
+	public static final String OPEN_DOCX_MIME_TYPE = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+	public static final String MSEXCEL_MIME_TYPE = "application/vnd.ms-excel";
+	public static final String OPEN_XLSX_MIME_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+	public static final String MSPPT_MIME_TYPE = "application/vnd.ms-powerpoint";
+	public static final String OPEN_PPTX_MIME_TYPE = "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+	public static final String DEFAULT_REPORT_OUTPUT_MIME = PDF_MIME_TYPE;
+	public static final String COMPILED_REPORT_EXTENSION = ".jasper";
+	public static final String REPORT_DECSRIPTION_EXTENSION = ".jrxml";
+	public static final String REPORT_METADATA_EXTENSION = ".xml";
 
-    public ReportClient() throws Exception {
+	public ReportClient() throws Exception {
 		super();
 	}
 
-    public ReportClient(String clientPropertiesFilename) throws Exception {
+	public ReportClient(String clientPropertiesFilename) throws Exception {
 		super(clientPropertiesFilename);
 	}
 
 	@Override
-    public String getServiceName() {
-        return SERVICE_NAME;
-    }
+	public String getServiceName() {
+		return SERVICE_NAME;
+	}
 
-    @Override
+	@Override
 	public String getServicePathComponent() {
-        return SERVICE_PATH_COMPONENT;
-    }
+		return SERVICE_PATH_COMPONENT;
+	}
 
 	@Override
 	public Class<ReportProxy> getProxyClass() {
 		return ReportProxy.class;
 	}
-	
+
 	/*
 	 * Proxied service calls
 	 */
-	
-    /**
-     * @return
-     * @see org.collectionspace.services.client.ReportProxy#getReport()
-     */
-    public Response readListFiltered(
-        		String docType, String mode) {
-        return getProxy().readListFiltered(docType, mode);
-    }
-    
-    public Response publishReport(String csid,
-    		InvocationContext invContext) {
-    	return getProxy().publishReport(csid, invContext);
-    }
-    
+
+	/**
+	 * @return
+	 * @see org.collectionspace.services.client.ReportProxy#getReport()
+	 */
+	public Response readListFiltered(String docType, String mode) {
+		return getProxy().readListFiltered(docType, mode);
+	}
+
+	public Response publishReport(String csid, InvocationContext invContext) {
+		return getProxy().publishReport(csid, invContext);
+	}
 }

--- a/services/report/service/src/main/java/org/collectionspace/services/report/ReportResource.java
+++ b/services/report/service/src/main/java/org/collectionspace/services/report/ReportResource.java
@@ -23,6 +23,7 @@
  */
 package org.collectionspace.services.report;
 
+import java.io.File;
 import java.io.InputStream;
 import java.util.List;
 
@@ -37,7 +38,9 @@ import org.collectionspace.services.client.ReportClient;
 import org.collectionspace.services.common.CSWebApplicationException;
 import org.collectionspace.services.common.NuxeoBasedResource;
 import org.collectionspace.services.common.ResourceMap;
+import org.collectionspace.services.common.ServiceMain;
 import org.collectionspace.services.common.ServiceMessages;
+import org.collectionspace.services.common.api.JEEServerDeployment;
 import org.collectionspace.services.common.context.ServiceContext;
 import org.collectionspace.services.common.document.DocumentFilter;
 import org.collectionspace.services.common.document.DocumentHandler;
@@ -68,6 +71,8 @@ import javax.ws.rs.core.Response.Status;
 public class ReportResource extends NuxeoBasedResource {
     final Logger logger = LoggerFactory.getLogger(ReportResource.class);
 
+    private static String REPORTS_FOLDER = "reports";
+
     @Override
     protected String getVersionString() {
     	final String lastChangeRevision = "$LastChangedRevision: 1982 $";
@@ -94,6 +99,7 @@ public class ReportResource extends NuxeoBasedResource {
             MultivaluedMap<String, String> queryParams = ctx.getQueryParams();
             DocumentHandler handler = createDocumentHandler(ctx);
             String docType = queryParams.getFirst(IQueryManager.SEARCH_TYPE_DOCTYPE);
+            String filename = queryParams.getFirst(IQueryManager.SEARCH_TYPE_FILENAME);
             List<String> modes = queryParams.get(IQueryManager.SEARCH_TYPE_INVOCATION_MODE);
             String whereClause = null;
             DocumentFilter documentFilter = null;
@@ -101,6 +107,12 @@ public class ReportResource extends NuxeoBasedResource {
             if (docType != null && !docType.isEmpty()) {
                 whereClause = QueryManager.createWhereClauseForInvocableByDocType(
                 		common_part, docType);
+                documentFilter = handler.getDocumentFilter();
+                documentFilter.appendWhereClause(whereClause, IQueryManager.SEARCH_QUALIFIER_AND);
+            }
+            if (filename != null && !filename.isEmpty()) {
+                whereClause = QueryManager.createWhereClauseForInvocableByFilename(
+                        common_part, filename);
                 documentFilter = handler.getDocumentFilter();
                 documentFilter.appendWhereClause(whereClause, IQueryManager.SEARCH_QUALIFIER_AND);
             }
@@ -329,4 +341,29 @@ public class ReportResource extends NuxeoBasedResource {
         return result;
     }
 
+    private static String getReportBasePath() {
+        return (
+            ServiceMain.getInstance().getServerRootDir() +
+            File.separator +
+            JEEServerDeployment.CSPACE_DIR_NAME +
+            File.separator +
+            REPORTS_FOLDER +
+            File.separator
+        );
+    }
+
+    public static File getReportSourceFile(String reportName) {
+        return new File(
+            getReportBasePath() + reportName + ReportClient.REPORT_DECSRIPTION_EXTENSION);
+    }
+
+    public static File getReportCompiledFile(String reportName) {
+        return new File(
+            getReportBasePath() + reportName + ReportClient.COMPILED_REPORT_EXTENSION);
+    }
+
+    public static File getReportMetadataFile(String reportName) {
+        return new File(
+            getReportBasePath() + reportName + ReportClient.REPORT_METADATA_EXTENSION);
+    }
 }


### PR DESCRIPTION
**What does this do?**

This automatically adds and updates reports on startup. Reports to add are configured in tenant bindings.

To add reports to all tenants, add the report name (the filename of the report, excluding the `.jrxml` extension) to tenant-bindings-proto-unified.xml. Follow the examples in this PR.

To add reports only to specific tenants, add the report name to the delta file for the tenant, e.g. publicart-tenant-bindings.delta.xml. Follow the examples in this PR.

If a report has already been installed, its metadata is updated from the installed xml file only if: the existing report metadata record was originally automatically created; it has not been updated by another user since it was created; and it has not been soft-deleted.

**Why are we doing this? (with JIRA link)**

This reduces the amount of work needed to install reports. JIRA: https://collectionspace.atlassian.net/browse/DRYD-1230

**How should this be tested? Do these changes have associated tests?**

When cspace is started, reports that have been added to the services/report/3rdparty/jasper-cs-report/src/main/resources directory, and configured in tenant-bindings-proto-unified.xml and publicart-tenant-bindings.delta.xml should be visible.

**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

@ray-lee will update the appropriate report installation documentation.

**Did someone actually run this code to verify it works?**

@ray-lee verified that reports were automatically installed.