### PR TITLE
DRYD-1233: Automatically add/update batch jobs on startup.

### DIFF
--- a/services/batch/service/src/main/java/org/collectionspace/services/batch/BatchResource.java
+++ b/services/batch/service/src/main/java/org/collectionspace/services/batch/BatchResource.java
@@ -48,6 +48,7 @@ import org.collectionspace.services.authorization.PermissionException;
 import org.collectionspace.services.authorization.URIResourceImpl;
 import org.collectionspace.services.authorization.perms.ActionType;
 
+import java.io.InputStream;
 import java.util.List;
 
 import javax.ws.rs.Consumes;
@@ -96,7 +97,7 @@ public class BatchResource extends NuxeoBasedResource {
             MultivaluedMap<String, String> queryParams = ctx.getQueryParams();
             DocumentHandler handler = createDocumentHandler(ctx);
             String docType = queryParams.getFirst(IQueryManager.SEARCH_TYPE_DOCTYPE);
-            String filename = queryParams.getFirst(IQueryManager.SEARCH_TYPE_FILENAME);
+            String className = queryParams.getFirst(IQueryManager.SEARCH_TYPE_CLASS_NAME);
             List<String> modes = queryParams.get(IQueryManager.SEARCH_TYPE_INVOCATION_MODE);
             String whereClause = null;
             DocumentFilter documentFilter = null;
@@ -109,9 +110,9 @@ public class BatchResource extends NuxeoBasedResource {
                 documentFilter.appendWhereClause(whereClause, IQueryManager.SEARCH_QUALIFIER_AND);
             }
 
-            if (filename != null && !filename.isEmpty()) {
-                whereClause = QueryManager.createWhereClauseForInvocableByFilename(
-                        common_part, filename);
+            if (className != null && !className.isEmpty()) {
+                whereClause = QueryManager.createWhereClauseForInvocableByClassName(
+                        common_part, className);
                 documentFilter = handler.getDocumentFilter();
                 documentFilter.appendWhereClause(whereClause, IQueryManager.SEARCH_QUALIFIER_AND);
             }
@@ -289,6 +290,19 @@ public class BatchResource extends NuxeoBasedResource {
         	String msg = String.format("%s Could not invoke batch job with CSID='%s'.",
         			ServiceMessages.POST_FAILED, csid);
             throw bigReThrow(e, msg);
+        }
+    }
+
+    public static InputStream getBatchMetadataInputStream(String batchName) {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+
+        try {
+            Class<?> clazz = classLoader.loadClass(batchName);
+            String metadataFileName = clazz.getSimpleName() + ".xml";
+
+            return clazz.getResourceAsStream(metadataFileName);
+        } catch (Exception e) {
+            return null;
         }
     }
 }

--- a/services/batch/service/src/main/resources/org/collectionspace/services/batch/nuxeo/MergeAuthorityItemsBatchJob.xml
+++ b/services/batch/service/src/main/resources/org/collectionspace/services/batch/nuxeo/MergeAuthorityItemsBatchJob.xml
@@ -1,0 +1,22 @@
+<document name="batch">
+  <ns2:batch_common xmlns:ns2="http://collectionspace.org/services/batch" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <name>Merge Authority Items</name>
+    <notes>Merge an authority item into a target, and update all referencing records. Runs on a single record only.</notes>
+    <forDocTypes>
+      <forDocType>Chronology</forDocType>
+      <forDocType>Workitem</forDocType>
+      <forDocType>Person</forDocType>
+      <forDocType>Conceptitem</forDocType>
+      <forDocType>Placeitem</forDocType>
+      <forDocType>Citation</forDocType>
+      <forDocType>Organization</forDocType>
+      <forDocType>Locationitem</forDocType>
+    </forDocTypes>
+    <supportsSingleDoc>true</supportsSingleDoc>
+    <supportsDocList>false</supportsDocList>
+    <supportsGroup>false</supportsGroup>
+    <supportsNoContext>false</supportsNoContext>
+    <createsNewFocus>false</createsNewFocus>
+    <className>org.collectionspace.services.batch.nuxeo.MergeAuthorityItemsBatchJob</className>
+  </ns2:batch_common>
+</document>

--- a/services/batch/service/src/main/resources/org/collectionspace/services/batch/nuxeo/UpdateInventoryStatusBatchJob.xml
+++ b/services/batch/service/src/main/resources/org/collectionspace/services/batch/nuxeo/UpdateInventoryStatusBatchJob.xml
@@ -1,0 +1,15 @@
+<document name="batch">
+  <ns2:batch_common xmlns:ns2="http://collectionspace.org/services/batch" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <name>Update Inventory Status</name>
+    <notes>Set the inventory status of selected Object records. Runs on a record list only.</notes>
+    <forDocTypes>
+      <forDocType>CollectionObject</forDocType>
+    </forDocTypes>
+    <supportsSingleDoc>false</supportsSingleDoc>
+    <supportsDocList>true</supportsDocList>
+    <supportsGroup>false</supportsGroup>
+    <supportsNoContext>false</supportsNoContext>
+    <createsNewFocus>false</createsNewFocus>
+    <className>org.collectionspace.services.batch.nuxeo.UpdateInventoryStatusBatchJob</className>
+  </ns2:batch_common>
+</document>

--- a/services/batch/service/src/main/resources/org/collectionspace/services/batch/nuxeo/UpdateObjectLocationBatchJob.xml
+++ b/services/batch/service/src/main/resources/org/collectionspace/services/batch/nuxeo/UpdateObjectLocationBatchJob.xml
@@ -1,0 +1,15 @@
+<document name="batch">
+  <ns2:batch_common xmlns:ns2="http://collectionspace.org/services/batch" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <name>Update Current Location</name>
+    <notes>Recompute the current location of Object records, based on the related Location/Movement/Inventory records. Runs on a single record or all records.</notes>
+    <forDocTypes>
+      <forDocType>CollectionObject</forDocType>
+    </forDocTypes>
+    <supportsSingleDoc>true</supportsSingleDoc>
+    <supportsDocList>false</supportsDocList>
+    <supportsGroup>false</supportsGroup>
+    <supportsNoContext>true</supportsNoContext>
+    <createsNewFocus>false</createsNewFocus>
+    <className>org.collectionspace.services.batch.nuxeo.UpdateObjectLocationBatchJob</className>
+  </ns2:batch_common>
+</document>

--- a/services/client/src/main/java/org/collectionspace/services/client/IQueryManager.java
+++ b/services/client/src/main/java/org/collectionspace/services/client/IQueryManager.java
@@ -41,6 +41,7 @@ public interface IQueryManager {
 	final static String SEARCH_TYPE_PARTIALTERM = "pt";
 	final static String SEARCH_TYPE_DOCTYPE = "doctype";
 	final static String SEARCH_TYPE_FILENAME = "filename";
+	final static String SEARCH_TYPE_CLASS_NAME = "classname";
 	final static String SEARCH_TYPE_INVOCATION_MODE = "mode";
 	final static String SEARCH_TYPE_INVOCATION = "inv";
 	final static String SEARCH_QUALIFIER_AND = SEARCH_TERM_SEPARATOR + "AND" + SEARCH_TERM_SEPARATOR;
@@ -171,6 +172,15 @@ public interface IQueryManager {
 	 * @return        the where clause
 	 */
 	public String createWhereClauseForInvocableByFilename(String schema, String filename);
+
+	/**
+	 * Creates a filtering where clause from class name, for invocables.
+	 *
+	 * @param schema  the schema name for this invocable
+	 * @param docType the class name
+	 * @return        the where clause
+	 */
+	public String createWhereClauseForInvocableByClassName(String schema, String className);
 
 	/**
 	 * Creates a filtering where clause from invocation mode, for invocables.

--- a/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
+++ b/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
@@ -305,6 +305,20 @@
 			</service:DocHandlerParams>
 			<service:validatorHandler xmlns:service="http://collectionspace.org/services/config/service">org.collectionspace.services.batch.nuxeo.BatchValidatorHandler
 			</service:validatorHandler>
+			<service:properties xmlns:service="http://collectionspace.org/services/config/service" xmlns:types="http://collectionspace.org/services/config/types">
+				<types:item>
+					<types:key>batch</types:key>
+					<types:value>org.collectionspace.services.batch.nuxeo.MergeAuthorityItemsBatchJob</types:value>
+				</types:item>
+				<types:item>
+					<types:key>batch</types:key>
+					<types:value>org.collectionspace.services.batch.nuxeo.UpdateInventoryStatusBatchJob</types:value>
+				</types:item>
+				<types:item>
+					<types:key>batch</types:key>
+					<types:value>org.collectionspace.services.batch.nuxeo.UpdateObjectLocationBatchJob</types:value>
+				</types:item>
+			</service:properties>
 			<service:object xmlns:service="http://collectionspace.org/services/config/service" name="Batch"
 				version="1.0">
 				<service:part id="0" control_group="Managed" versionable="true" auditable="false" label="batch-system"

--- a/services/common/src/main/java/org/collectionspace/services/common/query/QueryManager.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/query/QueryManager.java
@@ -121,6 +121,17 @@ public class QueryManager {
 	}
 
 	/**
+	 * Creates a filtering where clause from class name, for invocables.
+	 *
+	 * @param schema  the schema name for this invocable
+	 * @param docType the class name
+	 * @return        the where clause
+	 */
+	static public String createWhereClauseForInvocableByClassName(String schema, String className) {
+		return queryManager.createWhereClauseForInvocableByClassName(schema, className);
+	}
+
+	/**
 	 * Creates a filtering where clause from invocation mode, for invocables.
 	 *
 	 * @param schema the schema name for this invocable type

--- a/services/common/src/main/java/org/collectionspace/services/common/query/nuxeo/QueryManagerNuxeoImpl.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/query/nuxeo/QueryManagerNuxeoImpl.java
@@ -321,6 +321,30 @@ public class QueryManagerNuxeoImpl implements IQueryManager {
 	}
 
 	/**
+	 * Creates a filtering where clause from class name, for invocables.
+	 *
+	 * @param schema  the schema name for this invocable
+	 * @param docType the class name
+	 * @return        the where clause
+	 */
+	@Override
+	public String createWhereClauseForInvocableByClassName(String schema, String className) {
+		String trimmed = sanitizeNXQLString(className);
+
+		if (trimmed.isEmpty()) {
+			throw new RuntimeException("No class name specified.");
+		}
+
+		if (schema == null || schema.isEmpty()) {
+			throw new RuntimeException("No match schema specified.");
+		}
+
+		String whereClause = schema + ":" + InvocableJAXBSchema.CLASS_NAME + " = '" + trimmed + "'";
+
+		return whereClause;
+	}
+
+	/**
 	 * Creates a filtering where clause from invocation mode, for invocables.
 	 *
 	 * @param mode

--- a/services/jaxb/src/main/java/org/collectionspace/services/jaxb/InvocableJAXBSchema.java
+++ b/services/jaxb/src/main/java/org/collectionspace/services/jaxb/InvocableJAXBSchema.java
@@ -5,6 +5,7 @@ package org.collectionspace.services.jaxb;
 
 public interface InvocableJAXBSchema {
     final static String FILENAME = "filename";
+    final static String CLASS_NAME = "className";
     final static String FOR_DOC_TYPES = "forDocTypes";
     final static String SUPPORTS_SINGLE_DOC = "supportsSingleDoc";
     final static String SUPPORTS_DOC_LIST = "supportsDocList";


### PR DESCRIPTION
**What does this do?**

This automatically adds and updates batch jobs on startup. Batch jobs to add are configured in tenant bindings.

To add batch jobs to all tenants, add the batch job name (the fully qualified class name of the Java implementation) to tenant-bindings-proto-unified.xml. Follow the examples in this PR: 

To add batch jobs only to specific tenants, add the batch job name to the delta file for the tenant, e.g. publicart-tenant-bindings.delta.xml. Follow the examples in this PR: 

The batch job metadata is expected to be a Java resource file accessible from the classloader of the batch job class, with the same name as the class, and the extension `.xml`. For example:

If a batch job has already been installed, its metadata is updated from the xml file on startup only if: the existing batch job metadata record was originally automatically created; it has not been updated by another user since it was created; and it has not been soft-deleted.

**Why are we doing this? (with JIRA link)**

This reduces the amount of work needed to install batch jobs. JIRA: https://collectionspace.atlassian.net/browse/DRYD-1233

**How should this be tested? Do these changes have associated tests?**

When cspace is started, batch jobs that are configured in tenant-bindings-proto-unified.xml should be visible.

- Start CSpace.
- On the Tools/Data Updates screen, verify that there are batch jobs. As of this writing, there should be 3 batch jobs on all profiles.
- Verify that no batch jobs are duplicated.

**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

I will update the relevant documentation, and add a README.

**Did someone actually run this code to verify it works?**

@ray-lee verified that batch jobs were automatically installed.
