### PR TITLE
DRYD-1154: De-urn reports

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/Acq_List_Basic.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/Acq_List_Basic.jrxml
@@ -11,6 +11,9 @@
 	<style name="SubTitle" forecolor="#666666" fontName="SansSerif" fontSize="18"/>
 	<style name="Column header" forecolor="#666666" fontName="SansSerif" fontSize="12" isBold="true"/>
 	<style name="Detail" fontName="SansSerif" fontSize="12"/>
+	<parameter name="deurnfields" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA["objectname,objectproductionorganizationrole,objectproductionpersonrole,computedcurrentlocation"]]></defaultValueExpression>
+	</parameter>
 	<parameter name="tenantid" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA["101"]]></defaultValueExpression>
 	</parameter>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/CC_List_Basic.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/CC_List_Basic.jrxml
@@ -11,6 +11,9 @@
 	<style name="SubTitle" forecolor="#666666" fontName="SansSerif" fontSize="18"/>
 	<style name="Column header" forecolor="#666666" fontName="SansSerif" fontSize="12" isBold="true"/>
 	<style name="Detail" fontName="SansSerif" fontSize="12"/>
+	<parameter name="deurnfields" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA["objectname,objectproductionorganizationrole,objectproductionpersonrole,computedcurrentlocation"]]></defaultValueExpression>
+	</parameter>
 	<parameter name="tenantid" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA["101"]]></defaultValueExpression>
 	</parameter>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/Exhibition_List_Basic.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/Exhibition_List_Basic.jrxml
@@ -12,6 +12,9 @@
 	<style name="SubTitle" forecolor="#666666" fontName="SansSerif" fontSize="18"/>
 	<style name="Column header" forecolor="#666666" fontName="SansSerif" fontSize="12" isBold="true"/>
 	<style name="Detail" fontName="SansSerif" fontSize="12"/>
+	<parameter name="deurnfields" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA["objectname,objectproductionorganizationrole,objectproductionpersonrole,computedcurrentlocation"]]></defaultValueExpression>
+	</parameter>
 	<parameter name="tenantid" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA["101"]]></defaultValueExpression>
 	</parameter>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/LoansIn_List_Basic.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/LoansIn_List_Basic.jrxml
@@ -12,6 +12,9 @@
 	<style name="SubTitle" forecolor="#666666" fontName="SansSerif" fontSize="18"/>
 	<style name="Column header" forecolor="#666666" fontName="SansSerif" fontSize="12" isBold="true"/>
 	<style name="Detail" fontName="SansSerif" fontSize="12"/>
+	<parameter name="deurnfields" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA["objectname,objectproductionorganizationrole,objectproductionpersonrole,computedcurrentlocation"]]></defaultValueExpression>
+	</parameter>
 	<parameter name="tenantid" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA["101"]]></defaultValueExpression>
 	</parameter>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/LoansOut_List_Basic.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/LoansOut_List_Basic.jrxml
@@ -12,6 +12,9 @@
 	<style name="SubTitle" forecolor="#666666" fontName="SansSerif" fontSize="18"/>
 	<style name="Column header" forecolor="#666666" fontName="SansSerif" fontSize="12" isBold="true"/>
 	<style name="Detail" fontName="SansSerif" fontSize="12"/>
+	<parameter name="deurnfields" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA["objectname,objectproductionorganizationrole,objectproductionpersonrole,computedcurrentlocation"]]></defaultValueExpression>
+	</parameter>
 	<parameter name="tenantid" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA["101"]]></defaultValueExpression>
 	</parameter>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/coreAcquisition.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/coreAcquisition.jrxml
@@ -7,6 +7,9 @@
 	<style name="SubTitle" forecolor="#666666" fontName="SansSerif" fontSize="18"/>
 	<style name="Column header" forecolor="#666666" fontName="SansSerif" fontSize="12" isBold="true"/>
 	<style name="Detail" fontName="SansSerif" fontSize="12"/>
+	<parameter name="deurnfields" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA["objectname,productionpeople,productionperson,productionorg"]]></defaultValueExpression>
+	</parameter>
 	<parameter name="tenantid" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA[15]]></defaultValueExpression>
 	</parameter>
@@ -25,18 +28,9 @@ case when (bd.item is not null and bd.item <> '') then
  when co.objectnumber is null then 'No objects are related to this Acquisition.'
  else ''
 end AS description,
-case when (oppp.objectproductionpeople is not null and oppp.objectproductionpeople <> '') then
- regexp_replace(oppp.objectproductionpeople, '^.*\)''(.*)''$', '\1')
- else ''
-end as productionpeople,
-case when (oppr.objectproductionperson is not null and oppr.objectproductionperson <> '') then
- regexp_replace(oppr.objectproductionperson, '^.*\)''(.*)''$', '\1')
- else ''
-end as productionperson,
-case when (opog.objectproductionorganization is not null and opog.objectproductionorganization <> '') then
- regexp_replace(opog.objectproductionorganization, '^.*\)''(.*)''$', '\1')
- else ''
-end as productionorg,
+oppp.objectproductionpeople as productionpeople,
+oppr.objectproductionperson as productionperson,
+opog.objectproductionorganization as productionorg,
 case when (aca.item is not null and aca.item <> '') then
  regexp_replace(aca.item, '^.*\)''(.*)''$', '\1')
  else ''

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/coreAcquisition.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/coreAcquisition.jrxml
@@ -24,7 +24,7 @@ co.objectnumber AS "objectnumber",
 ong.objectName AS "objectname",
 dg.datedisplaydate AS "acquisitiondate",
 case when (bd.item is not null and bd.item <> '') then
- regexp_replace(bd.item, '^.*\)''(.*)''$', '\1')
+ bd.item
  when co.objectnumber is null then 'No objects are related to this Acquisition.'
  else ''
 end AS description,

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/coreGroupObject.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/coreGroupObject.jrxml
@@ -28,10 +28,7 @@ h1.name AS "csid",
 co.objectnumber objectNumber,
 sd.datedisplaydate fieldCollectionDate,
 ong.objectName objectName,
-case when (bd.item is not null and bd.item <> '') then
- regexp_replace(bd.item, '^.*\)''(.*)''$', '\1')
- else ''
-end AS description
+bd.item AS description
 FROM hierarchy h1
 JOIN groups_common gc ON (gc.id=h1.id)
 LEFT OUTER JOIN relations_common rc1 ON (h1.name=rc1.subjectcsid)

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/coreGroupObject.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/coreGroupObject.jrxml
@@ -7,6 +7,9 @@
 	<style name="SubTitle" forecolor="#666666" fontName="SansSerif" fontSize="18"/>
 	<style name="Column header" forecolor="#666666" fontName="SansSerif" fontSize="12" isBold="true"/>
 	<style name="Detail" fontName="SansSerif" fontSize="12"/>
+	<parameter name="deurnfields" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA["objectname"]]></defaultValueExpression>
+	</parameter>
 	<parameter name="tenantid" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA[15]]></defaultValueExpression>
 	</parameter>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/coreIntake.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/coreIntake.jrxml
@@ -7,6 +7,9 @@
 	<style name="SubTitle" forecolor="#666666" fontName="SansSerif" fontSize="18"/>
 	<style name="Column header" forecolor="#666666" fontName="SansSerif" fontSize="12" isBold="true"/>
 	<style name="Detail" fontName="SansSerif" fontSize="12"/>
+	<parameter name="deurnfields" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA["site,objectname,productionpeople"]]></defaultValueExpression>
+	</parameter>
 	<parameter name="tenantid" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA[15]]></defaultValueExpression>
 	</parameter>
@@ -21,19 +24,13 @@ inc.entryDate entryDate,
 inc.returnDate returnDate,
 h1.name AS "csid",
 co.objectnumber AS "objectnumber",
-case when (co.fieldcollectionplace  is not null and co.fieldcollectionplace  <> '') then
- regexp_replace(co.fieldcollectionplace , '^.*\)''(.*)''$', '\1')
- else ''
-end AS site,
+co.fieldcollectionplace AS site,
 ong.objectName AS "objectname",
 case when (bd.item is not null and bd.item <> '') then
  regexp_replace(bd.item, '^.*\)''(.*)''$', '\1')
  else ''
 end AS description,
-case when (oppp.objectproductionpeople is not null and oppp.objectproductionpeople <> '') then
- regexp_replace(oppp.objectproductionpeople, '^.*\)''(.*)''$', '\1')
- else ''
-end as productionpeople
+oppp.objectproductionpeople AS productionpeople
 FROM hierarchy  h1
 JOIN intakes_common inc ON (inc.id=h1.id)
 LEFT OUTER JOIN relations_common rc1 ON (h1.name=rc1.subjectcsid)

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/coreIntake.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/coreIntake.jrxml
@@ -26,10 +26,7 @@ h1.name AS "csid",
 co.objectnumber AS "objectnumber",
 co.fieldcollectionplace AS site,
 ong.objectName AS "objectname",
-case when (bd.item is not null and bd.item <> '') then
- regexp_replace(bd.item, '^.*\)''(.*)''$', '\1')
- else ''
-end AS description,
+bd.item AS description,
 oppp.objectproductionpeople AS productionpeople
 FROM hierarchy  h1
 JOIN intakes_common inc ON (inc.id=h1.id)

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/coreLoanIn.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/coreLoanIn.jrxml
@@ -30,10 +30,7 @@ h1.name AS "csid",
 co.objectnumber AS "objectnumber",
 co.fieldcollectionplace AS site,
 ong.objectName AS "objectname",
-case when (bd.item is not null and bd.item <> '') then
- regexp_replace(bd.item, '^.*\)''(.*)''$', '\1')
- else ''
-end AS description,
+bd.item AS description,
 oppp.objectproductionpeople AS productionpeople
 FROM hierarchy h1
 JOIN loansin_common lic ON (lic.id=h1.id)

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/coreLoanIn.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/coreLoanIn.jrxml
@@ -7,6 +7,9 @@
 	<style name="SubTitle" forecolor="#666666" fontName="SansSerif" fontSize="18"/>
 	<style name="Column header" forecolor="#666666" fontName="SansSerif" fontSize="12" isBold="true"/>
 	<style name="Detail" fontName="SansSerif" fontSize="12"/>
+	<parameter name="deurnfields" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA["site,objectname,productionpeople"]]></defaultValueExpression>
+	</parameter>
 	<parameter name="tenantid" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA[15]]></defaultValueExpression>
 	</parameter>
@@ -25,19 +28,13 @@ lic.loanReturnDate as loanReturnDate,
 lic.loanInNote as loanInNote,
 h1.name AS "csid",
 co.objectnumber AS "objectnumber",
-case when (co.fieldcollectionplace  is not null and co.fieldcollectionplace  <> '') then
- regexp_replace(co.fieldcollectionplace , '^.*\)''(.*)''$', '\1')
- else ''
-end AS site,
+co.fieldcollectionplace AS site,
 ong.objectName AS "objectname",
 case when (bd.item is not null and bd.item <> '') then
  regexp_replace(bd.item, '^.*\)''(.*)''$', '\1')
  else ''
 end AS description,
-case when (oppp.objectproductionpeople is not null and oppp.objectproductionpeople <> '') then
- regexp_replace(oppp.objectproductionpeople, '^.*\)''(.*)''$', '\1')
- else ''
-end as productionpeople
+oppp.objectproductionpeople AS productionpeople
 FROM hierarchy h1
 JOIN loansin_common lic ON (lic.id=h1.id)
 LEFT OUTER JOIN relations_common rc1 ON (h1.name=rc1.subjectcsid)

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/coreLoanOut.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/coreLoanOut.jrxml
@@ -30,10 +30,7 @@ h1.name AS "csid",
 co.objectnumber AS "objectnumber",
 co.fieldcollectionplace AS site,
 ong.objectName AS "objectname",
-case when (bd.item is not null and bd.item <> '') then
- regexp_replace(bd.item, '^.*\)''(.*)''$', '\1')
- else ''
-end AS description,
+bd.item AS description,
 oppp.objectproductionpeople as productionpeople
 FROM hierarchy h1
 JOIN loansout_common loc ON (loc.id=h1.id)

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/coreLoanOut.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/coreLoanOut.jrxml
@@ -7,6 +7,9 @@
 	<style name="SubTitle" forecolor="#666666" fontName="SansSerif" fontSize="18"/>
 	<style name="Column header" forecolor="#666666" fontName="SansSerif" fontSize="12" isBold="true"/>
 	<style name="Detail" fontName="SansSerif" fontSize="12"/>
+	<parameter name="deurnfields" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA["site,objectname,productionpeople"]]></defaultValueExpression>
+	</parameter>
 	<parameter name="tenantid" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA[15]]></defaultValueExpression>
 	</parameter>
@@ -25,19 +28,13 @@ loc.loanReturnDate loanReturnDate,
 loc.loanOutNote loanOutNote,
 h1.name AS "csid",
 co.objectnumber AS "objectnumber",
-case when (co.fieldcollectionplace  is not null and co.fieldcollectionplace  <> '') then
- regexp_replace(co.fieldcollectionplace , '^.*\)''(.*)''$', '\1')
- else ''
-end AS site,
+co.fieldcollectionplace AS site,
 ong.objectName AS "objectname",
 case when (bd.item is not null and bd.item <> '') then
  regexp_replace(bd.item, '^.*\)''(.*)''$', '\1')
  else ''
 end AS description,
-case when (oppp.objectproductionpeople is not null and oppp.objectproductionpeople <> '') then
- regexp_replace(oppp.objectproductionpeople, '^.*\)''(.*)''$', '\1')
- else ''
-end as productionpeople
+oppp.objectproductionpeople as productionpeople
 FROM hierarchy h1
 JOIN loansout_common loc ON (loc.id=h1.id)
 LEFT OUTER JOIN relations_common rc1 ON (h1.name=rc1.subjectcsid)

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/coreObjectExit.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/coreObjectExit.jrxml
@@ -7,6 +7,9 @@
 	<style name="SubTitle" forecolor="#666666" fontName="SansSerif" fontSize="18"/>
 	<style name="Column header" forecolor="#666666" fontName="SansSerif" fontSize="12" isBold="true"/>
 	<style name="Detail" fontName="SansSerif" fontSize="12"/>
+	<parameter name="deurnfields" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA["site,objectname,productionpeople"]]></defaultValueExpression>
+	</parameter>
 	<parameter name="tenantid" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA[15]]></defaultValueExpression>
 	</parameter>
@@ -24,20 +27,11 @@ case when (oec.currentOwner is not null and oec.currentOwner <> '') then
 end AS owner,
 h1.name AS "csid",
 co.objectnumber AS "objectnumber",
-case when (co.fieldcollectionplace  is not null and co.fieldcollectionplace  <> '') then
- regexp_replace(co.fieldcollectionplace , '^.*\)''(.*)''$', '\1')
- else ''
-end AS site,
+co.fieldcollectionplace AS site,
 -- co.fieldcollectionnote fieldcollectionnote,
 ong.objectName AS "objectname",
-case when (bd.item is not null and bd.item <> '') then
- regexp_replace(bd.item, '^.*\)''(.*)''$', '\1')
- else ''
-end AS description,
-case when (oppp.objectproductionpeople is not null and oppp.objectproductionpeople <> '') then
- regexp_replace(oppp.objectproductionpeople, '^.*\)''(.*)''$', '\1')
- else ''
-end as productionpeople
+bd.item AS description,
+oppp.objectproductionpeople AS productionpeople
 FROM hierarchy h1
 JOIN objectexit_common oec ON (oec.id=h1.id)
 LEFT OUTER JOIN relations_common rc1 ON (h1.name=rc1.subjectcsid)


### PR DESCRIPTION
**What does this do?**
Updates reports which have refnames to use the new deurnfields parameter

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1154

Many of the older reports needed to be updated in order to have any refnames de-urned. This is done by using the deurnfields parameter to handle refnames which appear in the details section of the reports.

**How should this be tested? Do these changes have associated tests?**

Testing requires running of each report in order to validate that the fields returned are de-urned. Many reports retrieve a related collectionobject, which should be created.
* Replace the reports with the updated jrxml
* Create a collectionobject with an objectname, production person role, production person, and computed location
* For each updated report, create a procedure and relate the collectionobject, then run the report
  - [x] Acquisition basic
  - [x] Acquisition Ethnographic
  - [x] Condition check basic
  - [x] Exhibition basic
  - [x] Group Obj Ethnographic  
  - [x] Intake Ethnographic
  - [x] LoanIn Basic
  - [x] LoanIn Ethnographic
  - [x] LoanOut Basic
  - [x] LoanOut Ethnographic
  - [x] ObjectExit Ethnographic 

**Dependencies for merging? Releasing to production?**
The commits for each individual jira, and would likely be best to merged without a squash.

If a report has already been run, it will need to be recompiled by collectionspace before the updates are visible. Just something to look out for when testing, especially on the dev deployment.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested each checked report