### PR TITLE
Update jasper and reformat reports

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/LoansOut_List_Basic.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/LoansOut_List_Basic.jrxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 6.1.1.final using JasperReports Library version 6.1.1  -->
 <!-- 2015-12-16T19:37:02 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="Loans Out Basic List" pageWidth="1224" pageHeight="792" orientation="Landscape" whenNoDataType="NoDataSection" columnWidth="1184" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isIgnorePagination="true" uuid="a1f690a3-5977-4467-85f8-6b0bcd5b7210">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="Loans Out Basic List" pageWidth="1350" pageHeight="792" orientation="Landscape" whenNoDataType="NoDataSection" columnWidth="1184" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isIgnorePagination="true" uuid="a1f690a3-5977-4467-85f8-6b0bcd5b7210">
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
@@ -91,53 +91,53 @@
 				<text><![CDATA[Object ID Number]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="92" y="0" width="91" height="70" uuid="5a0747d2-475e-4e7e-9b77-17f698a71044"/>
+				<reportElement style="Column header" x="100" y="0" width="91" height="70" uuid="5a0747d2-475e-4e7e-9b77-17f698a71044"/>
 				<text><![CDATA[Title]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="183" y="0" width="91" height="70" uuid="1b422491-b2ee-4c2d-8776-4e94e8abffda"/>
+				<reportElement style="Column header" x="200" y="0" width="91" height="70" uuid="1b422491-b2ee-4c2d-8776-4e94e8abffda"/>
 				<text><![CDATA[Object Name]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="274" y="0" width="91" height="70" uuid="412ffaf7-3c55-4310-8466-ac6aa0607f25"/>
+				<reportElement style="Column header" x="300" y="0" width="91" height="70" uuid="412ffaf7-3c55-4310-8466-ac6aa0607f25"/>
 				<text><![CDATA[Description]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="365" y="0" width="91" height="70" uuid="8eecf6ce-1042-46b3-9f49-6911fa6f548c"/>
+				<reportElement style="Column header" x="400" y="0" width="91" height="70" uuid="8eecf6ce-1042-46b3-9f49-6911fa6f548c"/>
 				<text><![CDATA[Production Organization]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="456" y="0" width="91" height="70" uuid="13868288-46e3-4680-93fa-14a465fcfa55"/>
+				<reportElement style="Column header" x="500" y="0" width="91" height="70" uuid="13868288-46e3-4680-93fa-14a465fcfa55"/>
 				<text><![CDATA[Production Organization Role]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="547" y="0" width="91" height="70" uuid="82cd3dd1-acdd-4f54-9157-8e75a1e146a6"/>
+				<reportElement style="Column header" x="600" y="0" width="91" height="70" uuid="82cd3dd1-acdd-4f54-9157-8e75a1e146a6"/>
 				<text><![CDATA[Production Person]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="638" y="0" width="91" height="70" uuid="93649d14-c40b-4609-b046-09595ea1fa42"/>
+				<reportElement style="Column header" x="700" y="0" width="91" height="70" uuid="93649d14-c40b-4609-b046-09595ea1fa42"/>
 				<text><![CDATA[Production Person Role]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="729" y="0" width="91" height="70" uuid="f4ff61db-98b8-47df-a319-4a88682a8501"/>
+				<reportElement style="Column header" x="800" y="0" width="91" height="70" uuid="f4ff61db-98b8-47df-a319-4a88682a8501"/>
 				<text><![CDATA[Production People]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="820" y="0" width="91" height="70" uuid="3924b676-d044-465e-a2b6-330ef321abad"/>
+				<reportElement style="Column header" x="900" y="0" width="91" height="70" uuid="3924b676-d044-465e-a2b6-330ef321abad"/>
 				<text><![CDATA[Production Date]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" stretchType="RelativeToTallestObject" x="911" y="0" width="91" height="70" uuid="687d278e-794e-4221-9052-894cecdb2c0f">
+				<reportElement style="Column header" stretchType="RelativeToTallestObject" x="1000" y="0" width="91" height="70" uuid="687d278e-794e-4221-9052-894cecdb2c0f">
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 				</reportElement>
 				<text><![CDATA[Dimensions]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" stretchType="RelativeToTallestObject" x="1002" y="0" width="91" height="70" uuid="6c1c0e43-03d3-4164-8893-76ef9d85ca26"/>
+				<reportElement style="Column header" stretchType="RelativeToTallestObject" x="1100" y="0" width="91" height="70" uuid="6c1c0e43-03d3-4164-8893-76ef9d85ca26"/>
 				<text><![CDATA[Number of Objects]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" stretchType="RelativeToTallestObject" x="1093" y="0" width="91" height="70" uuid="0e255747-7bd3-4e8a-a7f6-96d79b2e44e4"/>
+				<reportElement style="Column header" stretchType="RelativeToTallestObject" x="1200" y="0" width="91" height="70" uuid="0e255747-7bd3-4e8a-a7f6-96d79b2e44e4"/>
 				<text><![CDATA[Current Location]]></text>
 			</staticText>
 		</band>
@@ -150,51 +150,51 @@
 				<textFieldExpression><![CDATA[$F{objectnumber}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="92" y="0" width="91" height="51" uuid="c7a74edc-c985-466f-9d1a-1a053b057c40"/>
+				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="100" y="0" width="91" height="51" uuid="c7a74edc-c985-466f-9d1a-1a053b057c40"/>
 				<textFieldExpression><![CDATA[$F{title}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="183" y="0" width="91" height="51" uuid="967aa94c-4d64-47fc-9234-4c4eccfd8de5"/>
+				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="200" y="0" width="91" height="51" uuid="967aa94c-4d64-47fc-9234-4c4eccfd8de5"/>
 				<textFieldExpression><![CDATA[$F{objectname}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="274" y="0" width="91" height="51" uuid="955d1530-7a02-4fff-bcbf-a77fdf7106a2"/>
+				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="300" y="0" width="91" height="51" uuid="955d1530-7a02-4fff-bcbf-a77fdf7106a2"/>
 				<textFieldExpression><![CDATA[$F{description}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="365" y="0" width="91" height="51" uuid="cd2614be-d303-42ec-b1ae-17986df423dd"/>
+				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="400" y="0" width="91" height="51" uuid="cd2614be-d303-42ec-b1ae-17986df423dd"/>
 				<textFieldExpression><![CDATA[$F{oporg}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="456" y="0" width="91" height="51" uuid="f9b9b475-9f9e-48a7-8016-330cbcfb0fae"/>
+				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="500" y="0" width="91" height="51" uuid="f9b9b475-9f9e-48a7-8016-330cbcfb0fae"/>
 				<textFieldExpression><![CDATA[$F{objectproductionorganizationrole}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="547" y="0" width="91" height="51" uuid="2c3a2c4b-9124-43c8-8be3-69c482f4e5ad"/>
+				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="600" y="0" width="91" height="51" uuid="2c3a2c4b-9124-43c8-8be3-69c482f4e5ad"/>
 				<textFieldExpression><![CDATA[$F{opperson}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="638" y="0" width="91" height="51" uuid="baa2cb50-03d1-45e0-9e32-dac575891da9"/>
+				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="700" y="0" width="91" height="51" uuid="baa2cb50-03d1-45e0-9e32-dac575891da9"/>
 				<textFieldExpression><![CDATA[$F{objectproductionpersonrole}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="729" y="0" width="91" height="51" uuid="00f2e1c6-6a9d-445a-9bb0-8792754d5f66"/>
+				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="800" y="0" width="91" height="51" uuid="00f2e1c6-6a9d-445a-9bb0-8792754d5f66"/>
 				<textFieldExpression><![CDATA[$F{objectproductionpeople}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="820" y="0" width="91" height="51" uuid="f28c35cd-bc86-49a7-95ff-cebf40b6434f"/>
+				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="900" y="0" width="91" height="51" uuid="f28c35cd-bc86-49a7-95ff-cebf40b6434f"/>
 				<textFieldExpression><![CDATA[$F{datedisplaydate}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="911" y="0" width="91" height="51" uuid="274ac7cc-d075-46bd-9597-39892c40d201"/>
+				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="1000" y="0" width="91" height="51" uuid="274ac7cc-d075-46bd-9597-39892c40d201"/>
 				<textFieldExpression><![CDATA[$F{dimensionsummary}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="1002" y="0" width="91" height="51" uuid="b9726228-b679-47da-b31d-456cd589b566"/>
+				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="1100" y="0" width="91" height="51" uuid="b9726228-b679-47da-b31d-456cd589b566"/>
 				<textFieldExpression><![CDATA[$F{numberofobjects}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="1093" y="0" width="91" height="51" uuid="569e8c92-bc33-49c8-bad7-a80b144d5406">
+				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="1200" y="0" width="91" height="51" uuid="569e8c92-bc33-49c8-bad7-a80b144d5406">
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{computedcurrentlocation}]]></textFieldExpression>
@@ -207,7 +207,7 @@
 	<noData>
 		<band height="50">
 			<staticText>
-				<reportElement uuid="f449dbd9-0782-4ffc-9296-1c09a978c94b" style="Column header" x="0" y="22" width="375" height="28"/>
+				<reportElement uuid="f449dbd9-0782-4ffc-9296-1c09a978c94b" style="Column header" x="1300" y="22" width="375" height="28"/>
 				<textElement>
 					<font size="14"/>
 				</textElement>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/LoansOut_List_Basic.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/LoansOut_List_Basic.jrxml
@@ -207,7 +207,7 @@
 	<noData>
 		<band height="50">
 			<staticText>
-				<reportElement uuid="f449dbd9-0782-4ffc-9296-1c09a978c94b" style="Column header" x="1300" y="22" width="375" height="28"/>
+				<reportElement uuid="f449dbd9-0782-4ffc-9296-1c09a978c94b" style="Column header" x="0" y="22" width="375" height="28"/>
 				<textElement>
 					<font size="14"/>
 				</textElement>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/LoansOut_List_Basic.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/LoansOut_List_Basic.jrxml
@@ -145,55 +145,55 @@
 	<detail>
 		<band height="51" splitType="Stretch">
 			<property name="com.jaspersoft.studio.layout" value="com.jaspersoft.studio.editor.layout.HorizontalRowLayout"/>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="0" y="0" width="92" height="51" uuid="020a8318-9170-4d22-a0ad-31192ed44b9a"/>
 				<textFieldExpression><![CDATA[$F{objectnumber}]]></textFieldExpression>
 			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="92" y="0" width="91" height="51" uuid="c7a74edc-c985-466f-9d1a-1a053b057c40"/>
 				<textFieldExpression><![CDATA[$F{title}]]></textFieldExpression>
 			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="183" y="0" width="91" height="51" uuid="967aa94c-4d64-47fc-9234-4c4eccfd8de5"/>
 				<textFieldExpression><![CDATA[$F{objectname}]]></textFieldExpression>
 			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="274" y="0" width="91" height="51" uuid="955d1530-7a02-4fff-bcbf-a77fdf7106a2"/>
 				<textFieldExpression><![CDATA[$F{description}]]></textFieldExpression>
 			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="365" y="0" width="91" height="51" uuid="cd2614be-d303-42ec-b1ae-17986df423dd"/>
 				<textFieldExpression><![CDATA[$F{oporg}]]></textFieldExpression>
 			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="456" y="0" width="91" height="51" uuid="f9b9b475-9f9e-48a7-8016-330cbcfb0fae"/>
 				<textFieldExpression><![CDATA[$F{objectproductionorganizationrole}]]></textFieldExpression>
 			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="547" y="0" width="91" height="51" uuid="2c3a2c4b-9124-43c8-8be3-69c482f4e5ad"/>
 				<textFieldExpression><![CDATA[$F{opperson}]]></textFieldExpression>
 			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="638" y="0" width="91" height="51" uuid="baa2cb50-03d1-45e0-9e32-dac575891da9"/>
 				<textFieldExpression><![CDATA[$F{objectproductionpersonrole}]]></textFieldExpression>
 			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="729" y="0" width="91" height="51" uuid="00f2e1c6-6a9d-445a-9bb0-8792754d5f66"/>
 				<textFieldExpression><![CDATA[$F{objectproductionpeople}]]></textFieldExpression>
 			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="820" y="0" width="91" height="51" uuid="f28c35cd-bc86-49a7-95ff-cebf40b6434f"/>
 				<textFieldExpression><![CDATA[$F{datedisplaydate}]]></textFieldExpression>
 			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="911" y="0" width="91" height="51" uuid="274ac7cc-d075-46bd-9597-39892c40d201"/>
 				<textFieldExpression><![CDATA[$F{dimensionsummary}]]></textFieldExpression>
 			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="1002" y="0" width="91" height="51" uuid="b9726228-b679-47da-b31d-456cd589b566"/>
 				<textFieldExpression><![CDATA[$F{numberofobjects}]]></textFieldExpression>
 			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" stretchType="RelativeToTallestObject" x="1093" y="0" width="91" height="51" uuid="569e8c92-bc33-49c8-bad7-a80b144d5406">
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 				</reportElement>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/coreGroupObject.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/coreGroupObject.jrxml
@@ -64,14 +64,14 @@ order by objectNumber]]>
 				</textElement>
 				<text><![CDATA[Object Group Report]]></text>
 			</staticText>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+			<textField textAdjust="ScaleFont" isBlankWhenNull="true">
 				<reportElement uuid="ffbefba5-bdd8-47eb-a9f6-d85d1f1e3c44" style="SubTitle" stretchType="RelativeToTallestObject" x="70" y="65" width="244" height="20" forecolor="#000000" backcolor="#FFFFFF"/>
 				<textElement verticalAlignment="Top">
 					<font fontName="SansSerif" size="14"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{grouptitle}]]></textFieldExpression>
 			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement uuid="70cd7a91-bca3-48c4-9123-ab94514d6b31" style="Detail" stretchType="RelativeToTallestObject" x="320" y="65" width="250" height="40" backcolor="#CCCCCC"/>
 				<textElement verticalAlignment="Top">
 					<font fontName="SansSerif" isItalic="false"/>
@@ -92,7 +92,7 @@ order by objectNumber]]>
 				</textElement>
 				<text><![CDATA[Owner:]]></text>
 			</staticText>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+			<textField textAdjust="ScaleFont" isBlankWhenNull="true">
 				<reportElement uuid="eb709d53-8668-436c-8cbe-f1ac018a2682" stretchType="RelativeToTallestObject" x="70" y="85" width="244" height="20"/>
 				<textElement>
 					<font size="14"/>
@@ -147,28 +147,28 @@ order by objectNumber]]>
 	</pageHeader>
 	<detail>
 		<band height="21" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement uuid="c9f761c7-d296-4000-99be-22a8cb4c6d0d" style="Detail" positionType="Float" stretchType="RelativeToTallestObject" x="0" y="2" width="92" height="15"/>
 				<textElement>
 					<font fontName="SansSerif" size="9"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{objectnumber}]]></textFieldExpression>
 			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement uuid="86b252eb-eff5-4353-b989-67cbaedafb55" style="Detail" stretchType="RelativeToTallestObject" mode="Transparent" x="95" y="2" width="120" height="15"/>
 				<textElement>
 					<font fontName="SansSerif" size="9"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{objectname}]]></textFieldExpression>
 			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement uuid="acf79eab-fcac-4beb-8309-10b1f434ee32" style="Detail" stretchType="RelativeToTallestObject" mode="Transparent" x="335" y="2" width="235" height="15"/>
 				<textElement>
 					<font fontName="SansSerif" size="9"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{description}]]></textFieldExpression>
 			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement uuid="ebef13fb-c2c2-42a2-bc7a-0aa2ad7f1a65" style="Detail" stretchType="RelativeToTallestObject" mode="Transparent" x="217" y="2" width="114" height="15"/>
 				<textElement>
 					<font fontName="SansSerif" size="9"/>

--- a/services/report/pom.xml
+++ b/services/report/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>net.sf.jasperreports</groupId>
 			<artifactId>jasperreports</artifactId>
-			<version>6.3.1</version>
+			<version>6.11.0</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>itext</artifactId>
@@ -34,7 +34,7 @@
 		<dependency>
 			<groupId>net.sf.jasperreports</groupId>
 			<artifactId>jasperreports-functions</artifactId>
-			<version>6.3.1</version>
+			<version>6.11.0</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>itext</artifactId>
@@ -45,7 +45,7 @@
 		<dependency>
 			<groupId>net.sf.jasperreports</groupId>
 			<artifactId>jasperreports-fonts</artifactId>
-			<version>6.0.0</version>
+			<version>6.11.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mozilla</groupId>

--- a/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
+++ b/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
@@ -230,11 +230,12 @@ public class ReportDocumentModelHandler extends NuxeoDocumentModelHandler<Report
 				}
 				StringBuilder sb = new StringBuilder();
 				boolean first = true;
-				for(String csidItem : csids) {
-					if(first)
+				for (String csidItem : csids) {
+					if (first) {
 						first = false;
-					else
+					} else {
 						sb.append(CSID_LIST_SEPARATOR);
+					}
 	   				sb.append(assertValidCsid(csidItem));
 				}
     		params.put(REPORTS_STD_CSIDLIST_PARAM, sb.toString());
@@ -394,13 +395,15 @@ public class ReportDocumentModelHandler extends NuxeoDocumentModelHandler<Report
 			String outputFilename = reportFileName;
 			// Strip extension from report filename.
 			int idx = outputFilename.lastIndexOf(".");
-			if(idx>0)
+			if (idx > 0) {
 				outputFilename = outputFilename.substring(0, idx);
+			}
 			// Strip any sub-dir from report filename.
 			idx = outputFilename.lastIndexOf(File.separator);
-			if(idx>0)
-				outputFilename = outputFilename.substring(idx+1);
-			if(outputMimeType.equals(MediaType.APPLICATION_XML)) {
+			if (idx > 0) {
+				outputFilename = outputFilename.substring(idx + 1);
+			}
+			if (outputMimeType.equals(MediaType.APPLICATION_XML)) {
 				params.put(JRParameter.IS_IGNORE_PAGINATION, Boolean.TRUE);
 				exporter = new JRXmlExporter();
 				outputFilename = outputFilename+".xml";

--- a/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
+++ b/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
@@ -35,9 +35,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
-
-import javax.ws.rs.core.MediaType;
 import javax.naming.NamingException;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import net.sf.jasperreports.engine.JRException;
@@ -48,16 +47,15 @@ import net.sf.jasperreports.engine.JasperCompileManager;
 import net.sf.jasperreports.engine.JasperFillManager;
 import net.sf.jasperreports.engine.JasperPrint;
 import net.sf.jasperreports.engine.design.JasperDesign;
+import net.sf.jasperreports.engine.export.HtmlExporter;
 import net.sf.jasperreports.engine.export.JRCsvExporter;
 import net.sf.jasperreports.engine.export.JRCsvExporterParameter;
-import net.sf.jasperreports.engine.export.JRHtmlExporter;
 import net.sf.jasperreports.engine.export.JRPdfExporter;
 import net.sf.jasperreports.engine.export.JRXmlExporter;
 import net.sf.jasperreports.engine.export.ooxml.JRDocxExporter;
 import net.sf.jasperreports.engine.export.ooxml.JRPptxExporter;
 import net.sf.jasperreports.engine.export.ooxml.JRXlsxExporter;
 import net.sf.jasperreports.engine.xml.JRXmlLoader;
-
 import org.collectionspace.authentication.AuthN;
 import org.collectionspace.services.ReportJAXBSchema;
 import org.collectionspace.services.account.AccountResource;
@@ -66,20 +64,11 @@ import org.collectionspace.services.authorization.CSpaceResource;
 import org.collectionspace.services.authorization.PermissionException;
 import org.collectionspace.services.authorization.URIResourceImpl;
 import org.collectionspace.services.authorization.perms.ActionType;
-import org.collectionspace.services.report.ResourceActionGroup;
-import org.collectionspace.services.report.ResourceActionGroupList;
-import org.collectionspace.services.report.ReportsCommon.ForRoles;
-import org.collectionspace.services.report.MIMEType;
-import org.collectionspace.services.report.MIMETypeItemType;
-import org.collectionspace.services.report.ReportResource;
-import org.collectionspace.services.report.ReportsCommon;
-import org.collectionspace.services.report.ReportsOuputMimeList;
 import org.collectionspace.services.client.PoxPayloadIn;
 import org.collectionspace.services.client.PoxPayloadOut;
 import org.collectionspace.services.client.ReportClient;
 import org.collectionspace.services.common.CSWebApplicationException;
 import org.collectionspace.services.common.ServiceMain;
-import org.collectionspace.services.common.api.JEEServerDeployment;
 import org.collectionspace.services.common.api.FileTools;
 import org.collectionspace.services.common.api.Tools;
 import org.collectionspace.services.common.authorization_mgt.ActionGroup;
@@ -95,16 +84,21 @@ import org.collectionspace.services.common.storage.JDBCTools;
 import org.collectionspace.services.config.service.ServiceBindingType;
 import org.collectionspace.services.config.types.PropertyItemType;
 import org.collectionspace.services.jaxb.InvocableJAXBSchema;
-import org.collectionspace.services.nuxeo.client.java.NuxeoDocumentModelHandler;
 import org.collectionspace.services.nuxeo.client.java.CoreSessionInterface;
+import org.collectionspace.services.nuxeo.client.java.NuxeoDocumentModelHandler;
 import org.collectionspace.services.nuxeo.client.java.NuxeoRepositoryClientImpl;
 import org.collectionspace.services.nuxeo.util.NuxeoUtils;
-
+import org.collectionspace.services.report.MIMEType;
+import org.collectionspace.services.report.MIMETypeItemType;
+import org.collectionspace.services.report.ReportResource;
+import org.collectionspace.services.report.ReportsCommon;
+import org.collectionspace.services.report.ReportsCommon.ForRoles;
+import org.collectionspace.services.report.ReportsOuputMimeList;
+import org.collectionspace.services.report.ResourceActionGroup;
+import org.collectionspace.services.report.ResourceActionGroupList;
 import org.jfree.util.Log;
-
-import org.nuxeo.ecm.core.api.model.PropertyException;
 import org.nuxeo.ecm.core.api.DocumentModel;
-
+import org.nuxeo.ecm.core.api.model.PropertyException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -411,7 +405,7 @@ public class ReportDocumentModelHandler extends NuxeoDocumentModelHandler<Report
 				exporter = new JRXmlExporter();
 				outputFilename = outputFilename+".xml";
 			} else if(outputMimeType.equals(MediaType.TEXT_HTML)) {
-				exporter = new JRHtmlExporter();
+				exporter = new HtmlExporter();
 				outputFilename = outputFilename+".html";
 			} else if(outputMimeType.equals(ReportClient.PDF_MIME_TYPE)) {
 				exporter = new JRPdfExporter();


### PR DESCRIPTION
**What does this do?**
* Updates jasper to 6.11.0
* Updates formatting for LoanOut Basic List
* Updates formatting for Group Object Ethnographic List 

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1164, https://collectionspace.atlassian.net/browse/DRYD-1159

Formatting changes were requested in various jira issues in addition to de-urning. As part of this, there's a new attribute for `textField` so that different approaches can be taken depending on the report. Jasper is being updated as well in order to make use of the new attribute. When nuxeo is updated further we'll have an opportunity to bring Jasper fully up to date.

**How should this be tested? Do these changes have associated tests?**
* Rebuild collectionspace 
* Run the Group Object Ethnographic List with a long title 
  * This should scale the font size down in order to avoid overlapping with the owner below
  * `StretchHeight` would be nice to use here, but it wasn't having any effect when testing. I'm not sure if it was the layout impacting it or what, but that's the reason for using `ScaleFont`
* Run the LoanOut Basic List and check the dimension and number of objects columns 

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against the two updated reports