### PR TITLE
Set overflow and null rules for results

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/accessions.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/accessions.jrxml
@@ -356,109 +356,109 @@ LEFT JOIN related_media media ON media.objcsid = obj.csid]]>
 	<detail>
 		<band height="66" splitType="Stretch">
 			<property name="com.jaspersoft.studio.unit.height" value="px"/>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="0" y="0" width="100" height="30" uuid="2c9d4090-6f2b-4f69-990f-8f9f2d5561fe">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{acquisitionreferencenumber}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="100" y="0" width="100" height="30" uuid="9b5e0176-bff5-49ce-a043-c53c2dc63c8e">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{accessiondate}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="200" y="0" width="100" height="30" uuid="9b607c40-bd0f-4175-ba4a-820f9c47965d">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{acquisitiondate}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="300" y="0" width="100" height="30" uuid="99f211f2-823e-4835-837c-c4f01747460c">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{acquisitionmethod}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="400" y="0" width="100" height="30" uuid="ac56c021-bd7e-4d2e-8147-d61bda92419c">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{acquisitionsource}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="500" y="0" width="100" height="30" uuid="83d043b0-3f48-43bd-98b3-13f8f77c6491">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{approvalgroup}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="600" y="0" width="100" height="30" uuid="3463786d-f302-4b6f-95da-40db00e707b9">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{approvalindividual}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="700" y="0" width="100" height="30" uuid="8c3f45c4-1c03-4def-977e-487651be6a1a">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{approvalstatus}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="800" y="0" width="100" height="30" uuid="256a37ec-1b0c-4f88-9b16-23ee81fad5d8">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{approvaldate}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="900" y="0" width="100" height="30" uuid="f5483166-f9ee-4e6b-b07a-e92fd3b16cb0">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{acquisitionnote}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1000" y="0" width="100" height="30" uuid="ad70ae62-4e08-45d5-9579-8704b059879c">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{acquisitionprovisos}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1100" y="0" width="100" height="30" uuid="2ae0c1d6-fcc7-4aee-b3ef-023716b54e4b">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{creditline}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1200" y="0" width="100" height="30" uuid="6808a8d0-b840-40af-9d8e-ebb153040e5a">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{objectnumber}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1300" y="0" width="100" height="30" uuid="8ed99c27-103b-4090-8c29-cdb18e031fb9">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{objectname}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1400" y="0" width="100" height="30" uuid="7a0e5d56-7af8-4bfd-b327-60992006f8f9">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{objectproductiondate}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1500" y="0" width="100" height="30" uuid="8e933259-1f43-4839-b0ab-8aef51648b4d">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{collection}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1600" y="0" width="100" height="30" uuid="90440d7c-7304-4ecb-8328-5ef7773f31b5">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{briefdescription}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1700" y="0" width="100" height="30" uuid="bda766c9-fb07-41cf-ac32-37f629023d4f">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/box_list.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/box_list.jrxml
@@ -145,34 +145,34 @@ LEFT OUTER JOIN thumbnails ON thumbnails.objectcsid = co.csid]]>
 	<detail>
 		<band height="66" splitType="Stretch">
 			<property name="com.jaspersoft.studio.unit.height" value="px"/>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="0" y="0" width="100" height="30" uuid="00603df5-d974-4732-9ae8-299fa37b2987">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{movementreferencenumber}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="100" y="0" width="100" height="30" uuid="9de99e14-7bd6-47a9-b28e-903bb3f7bf6b">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{termdisplayname}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="200" y="0" width="100" height="30" uuid="53e52de5-3610-4c50-b27d-0cfa6b66410e">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{termname}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="300" y="0" width="100" height="30" uuid="9a48e9ea-699b-42b8-85f1-090a20cb0a38">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{objectnumber}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="400" y="0" width="100" height="30" uuid="de6e4b2e-cf86-4733-90b9-8bc416968623">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/condition.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/condition.jrxml
@@ -425,145 +425,145 @@ $P!{whereclause}]]>
 	<detail>
 		<band height="66" splitType="Stretch">
 			<property name="com.jaspersoft.studio.unit.height" value="px"/>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="0" y="0" width="100" height="30" uuid="34739193-2dcb-4387-8284-fd24f4706904">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{objectnumber}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="100" y="0" width="100" height="30" uuid="529adab3-6a52-459d-96ec-cd38a4bd4c93">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{objecttitle}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="200" y="0" width="100" height="30" uuid="2b48e622-5e32-446a-bf28-9774811125af">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{computedcurrentlocation}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="300" y="0" width="100" height="30" uuid="177d5084-83c1-4b52-8717-adf6231b2eb8">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{conditioncheckrefnumber}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="400" y="0" width="100" height="30" uuid="0379bfa9-7b8b-4d13-a5fa-6d64d43ebf9d">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{assessmentdate}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="500" y="0" width="100" height="30" uuid="b09479c8-6012-482f-a4bd-f0dc316f7755">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{conditioncheckmethod}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="600" y="0" width="100" height="30" uuid="2266b3e3-a874-4269-bc46-8f8eb974dfa5">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{conditionchecknote}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="700" y="0" width="100" height="30" uuid="6bbb65c7-c336-4b3b-bd17-d248c54b29d3">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{conditioncheckreason}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="800" y="0" width="100" height="30" uuid="9b914486-8ddb-4169-95d3-226e53b9e491">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{conditionchecker}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="900" y="0" width="100" height="30" uuid="e4a1fe39-4c56-4236-aac4-bc95edef2084">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{objectauditcategory}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1000" y="0" width="100" height="30" uuid="6e19e025-7e56-47c9-bf12-726b32e87fa5">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{conservationtreatmentpriority}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1100" y="0" width="100" height="30" uuid="075bd94f-4bc9-4023-98ee-5fdce4386950">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{nextconditioncheckdate}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1200" y="0" width="100" height="30" uuid="925908e3-aba0-4e68-a4d6-a5a1545fc42b">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{completeness}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1300" y="0" width="100" height="30" uuid="0eb55128-c734-4b2c-8721-012033891d7a">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{techassessment}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1400" y="0" width="100" height="30" uuid="7d9350d9-a343-4a16-b513-34761e8e7c78">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{condition}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1500" y="0" width="100" height="30" uuid="45f5fab1-9ebd-4898-916b-76cb5060b8fa">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{envconditionnote}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1600" y="0" width="100" height="30" uuid="908bb4ca-411c-43c2-b96c-21d01012f2e6">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{displayrecommendations}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1700" y="0" width="100" height="30" uuid="dbdb7ee0-3f88-4920-94bd-85edcb5c79d8">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{handlingrecommendations}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1800" y="0" width="100" height="30" uuid="1ca18fc8-0f07-426d-ae4c-34148ad5f94a">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{envrecommendations}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1900" y="0" width="100" height="30" uuid="89957c32-74ab-4545-8481-70977d5e75cf">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{specialrequirements}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="2000" y="0" width="100" height="30" uuid="2cbdf3fc-58d9-4a8a-a24c-16bf8baf99af">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{legalreqsheld}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="2100" y="0" width="100" height="30" uuid="362785d3-2875-46fb-91d6-96f550e3d4da">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{legalreqsheldbegindate}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="2200" y="0" width="100" height="30" uuid="523caf3a-8e56-41dd-965a-15c7cbbaefaa">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{legalreqsheldrenewdate}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="2300" y="0" width="100" height="30" uuid="7421a5d1-67af-4dc6-b090-34c8217f8113">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/deaccessions.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/deaccessions.jrxml
@@ -753,265 +753,265 @@ LEFT JOIN related_intakes intake ON intake.exitcsid = exit.csid]]>
 	<detail>
 		<band height="66" splitType="Stretch">
 			<property name="com.jaspersoft.studio.unit.height" value="px"/>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="0" y="0" width="100" height="30" uuid="56afbd1a-4861-43a3-9e26-9b6755882991">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{exitnumber}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="100" y="0" width="100" height="30" uuid="6c9fc572-62c9-4591-bf13-9b50a671addc">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{exitquantity}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="200" y="0" width="100" height="30" uuid="198b574c-8492-4ea4-ab68-17b18f412c3f">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{exitdate}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="300" y="0" width="100" height="30" uuid="8a166167-cbb1-4e06-a8c9-0da3f1978c8b">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{exitmethod}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="400" y="0" width="100" height="30" uuid="f9b9d5f4-2b5f-4f5b-99bf-957c84aeead9">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{exitreason}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="500" y="0" width="100" height="30" uuid="8567f1d2-a36c-4be5-ad52-31d84937445d">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{deaccessionapprovalgroup}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="600" y="0" width="100" height="30" uuid="1e377b18-993c-4d7c-9c5f-794bcc292e2f">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{deaccessionapprovalindividual}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="700" y="0" width="100" height="30" uuid="cf58a4c8-7a81-45fd-98d2-1665cf086fe7">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{deaccessionapprovalstatus}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="800" y="0" width="100" height="30" uuid="7080720c-f950-472a-86a7-59bf70dd17a0">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{deaccessionapprovaldate}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="900" y="0" width="100" height="30" uuid="7f3c6b34-7d67-40a9-941d-9ab1bac2c0e6">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{deaccessionapprovaldate}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1000" y="0" width="100" height="30" uuid="427c6ba1-a7b7-4053-91f8-a968e2578786">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{exitnote}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1100" y="0" width="100" height="30" uuid="fe9cd903-d44a-4929-b3b8-646292d7b665">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{packingnote}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1200" y="0" width="100" height="30" uuid="7484898e-b56c-48e4-9240-d0335437038a">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{objectnumber}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1300" y="0" width="100" height="30" uuid="23044237-4704-4781-8d11-9b6a986deb6f">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{objectname}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1400" y="0" width="100" height="30" uuid="f11f0936-4d53-4ebe-9479-70e9b63da7b1">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{productiondate}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1500" y="0" width="100" height="30" uuid="ce3c8a6c-0cec-45aa-b6b5-a46f4afcbdfc">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{collection}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1600" y="0" width="100" height="30" uuid="5cbb37f2-63bc-4c94-b895-520ddefc9dea">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{briefdescription}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1700" y="0" width="100" height="30" uuid="400f3d73-058e-4485-a2cf-ccf6222688cb">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{objecthistorynote}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1800" y="0" width="100" height="30" uuid="a74806df-eeb0-4251-8f91-9d0e3d6aed22">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{proposed_primaryname}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1900" y="0" width="100" height="30" uuid="7c20f6cf-9100-4faf-b844-f0f2540a90fe">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{proposed_secondaryname}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="2000" y="0" width="100" height="30" uuid="cbf4ed81-59bb-4446-a665-26a77da6b3c5">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{proposed_addresstype}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="2100" y="0" width="100" height="30" uuid="9ec2d144-7d38-4742-b01d-4480a90b1049">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{proposed_addressplace1}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="2200" y="0" width="100" height="30" uuid="dac21fe6-179b-4acf-8028-a45b8423b66d">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{proposed_addressplace2}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="2300" y="0" width="100" height="30" uuid="2baf5e12-c474-4a7a-a3b7-f67a32445bc3">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{proposed_addressmunicipality}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="2400" y="0" width="100" height="30" uuid="21266cb8-c3e8-4286-9560-d067a80c493f">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{proposed_addressstateorprovince}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="2500" y="0" width="100" height="30" uuid="b5edfdb4-9f0b-4f98-9fd7-44ed3b04844c">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{proposed_addresspostcode}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="2600" y="0" width="100" height="30" uuid="670bcf02-0320-45fb-b93d-34794c1544d0">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{proposed_addresscountry}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="2700" y="0" width="100" height="30" uuid="06c0ea34-3c7b-4130-b28d-5ee7d35d8b55">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{recip_primaryname}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="2800" y="0" width="100" height="30" uuid="a85ada24-3a62-4e93-93de-0b4cb8463137">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{recip_secondaryname}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="2900" y="0" width="100" height="30" uuid="44e0bd3a-c6bd-48da-a78c-1f14a942d0d7">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{recip_addresstype}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="3000" y="0" width="100" height="30" uuid="f739a888-540f-4158-a5b8-d8a08a423225">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{recip_addressplace1}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="3100" y="0" width="100" height="30" uuid="9cf7c268-94fc-4732-b770-e894ece870b3">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{recip_addressplace2}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="3200" y="0" width="100" height="30" uuid="82b22f93-b85f-4cb9-896d-0ef14de27096">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{recip_addressmunicipality}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="3300" y="0" width="100" height="30" uuid="ccbb5a34-1a9a-4597-9fdd-bf6adfa8de77">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{recip_addressstateorprovince}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="3400" y="0" width="100" height="30" uuid="36bc8c12-2fbc-4d16-8610-53b5f0bbb7ed">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{recip_addresspostcode}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="3500" y="0" width="100" height="30" uuid="f192af1c-8269-4d91-a8f9-845d01703352">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{recip_addresscountry}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="3600" y="0" width="100" height="30" uuid="d32be13e-9677-49ca-bd91-5406bcbf1d7d">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{disposalprovisos}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="3700" y="0" width="100" height="30" uuid="71decb7b-184a-4f82-951f-9ac3d0318c01">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{disposalnote}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="3800" y="0" width="100" height="30" uuid="baf5031d-afb9-45b9-b1f0-897c10dc2ece">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{deaccessiondate}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="3900" y="0" width="100" height="30" uuid="07f966c0-343e-4b5e-a133-d4dfe1343c2f">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{disposaldate}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="4000" y="0" width="100" height="30" uuid="f0612414-22e0-4882-99fb-91b6f2c74100">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{disposalmethod}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="4100" y="0" width="100" height="30" uuid="c29d0b1c-3e58-4058-9c6e-9c5c6027f034">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{disposalvalue}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="4200" y="0" width="100" height="30" uuid="1cfa324e-e689-47d5-8538-cdca3b18619a">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{acquisition}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="4300" y="0" width="100" height="30" uuid="1d2a375e-394e-472d-8414-34f07977c18e">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/deed_of_gift.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/deed_of_gift.jrxml
@@ -300,91 +300,91 @@ left join related_object_media media on media.objcsid = obj.csid]]>
 	<detail>
 		<band height="66" splitType="Stretch">
 			<property name="com.jaspersoft.studio.unit.height" value="px"/>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="0" y="0" width="100" height="30"
 					uuid="1784fb4e-c82a-4ca4-bd0b-d16cfc521e4c">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{primarydisplayname}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="100" y="0" width="100" height="30"
 					uuid="c206b5d0-24e2-444f-98c0-ee82bb10c9b6">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{secondarydisplayname}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="200" y="0" width="100" height="30"
 					uuid="656cd834-b03b-4bab-89b1-eb531c4671ad">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{addressplace1}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="300" y="0" width="100" height="30"
 					uuid="095a3d47-8846-4132-9709-301f17e42730">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{addressplace2}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="400" y="0" width="100" height="30"
 					uuid="7e8caf36-4137-436f-8ecd-bc4b62f7c095">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{addresscountry}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="500" y="0" width="100" height="30"
 					uuid="9c6c3516-1dfc-4462-8f06-5a6a9038ec02">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{addressmunicipality}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="600" y="0" width="100" height="30"
 					uuid="76ec2c07-08d3-4aa5-bc04-04e7df1e4c63">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{addresspostcode}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="700" y="0" width="100" height="30"
 					uuid="3f7c46cc-49e4-4a1d-8167-710c10826b9f">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{addressstateorprovince}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="800" y="0" width="100" height="30"
 					uuid="5f96c515-5f23-40ac-afe6-e085e4ff35d5">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{addresstype}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="900" y="0" width="100" height="30"
 					uuid="27b7b994-66e0-4220-ba5a-50006df9bf01">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{objectname}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1000" y="0" width="100" height="30"
 					uuid="0b3fb2a4-9d45-49de-9e22-2437df91a62f">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{productiondate}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1100" y="0" width="100" height="30"
 					uuid="26203b73-ba5d-44ea-9868-59f78cd8a528">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{collection}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1200" y="0" width="100" height="30"
 					uuid="85ef11c9-a6c8-43d6-ba2e-5fd9a2eddbee">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/incoming_loan.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/incoming_loan.jrxml
@@ -349,121 +349,121 @@ $P!{whereclause}]]>
     <detail>
         <band height="66" splitType="Stretch">
             <property name="com.jaspersoft.studio.unit.height" value="px"/>
-            <textField>
+            <textField textAdjust="StretchHeight" isBlankWhenNull="true">
                 <reportElement style="Detail" x="0" y="0" width="100" height="30" uuid="2cae5ffe-6fe9-4c3a-87c5-de1b2d341045">
                     <property name="com.jaspersoft.studio.unit.y" value="px"/>
                 </reportElement>
                 <textFieldExpression><![CDATA[$F{loaninnumber}]]></textFieldExpression>
             </textField>
-            <textField>
+            <textField textAdjust="StretchHeight" isBlankWhenNull="true">
                 <reportElement style="Detail" x="100" y="0" width="100" height="30" uuid="0623482b-f407-41e2-b35f-d7290310b3e3">
                     <property name="com.jaspersoft.studio.unit.y" value="px"/>
                 </reportElement>
                 <textFieldExpression><![CDATA[$F{lender}]]></textFieldExpression>
             </textField>
-            <textField>
+            <textField textAdjust="StretchHeight" isBlankWhenNull="true">
                 <reportElement style="Detail" x="200" y="0" width="100" height="30" uuid="228de520-8cd5-4b42-a1e8-df205b0762bc">
                     <property name="com.jaspersoft.studio.unit.y" value="px"/>
                 </reportElement>
                 <textFieldExpression><![CDATA[$F{lenderscontact}]]></textFieldExpression>
             </textField>
-            <textField>
+            <textField textAdjust="StretchHeight" isBlankWhenNull="true">
                 <reportElement style="Detail" x="300" y="0" width="100" height="30" uuid="751b3aa3-2ef8-46d9-aca0-8e8b1fdab429">
                     <property name="com.jaspersoft.studio.unit.y" value="px"/>
                 </reportElement>
                 <textFieldExpression><![CDATA[$F{addresstype}]]></textFieldExpression>
             </textField>
-            <textField>
+            <textField textAdjust="StretchHeight" isBlankWhenNull="true">
                 <reportElement style="Detail" x="400" y="0" width="100" height="30" uuid="212a1743-aaed-4a25-ad1c-63e8a700c3b0">
                     <property name="com.jaspersoft.studio.unit.y" value="px"/>
                 </reportElement>
                 <textFieldExpression><![CDATA[$F{addressplace1}]]></textFieldExpression>
             </textField>
-            <textField>
+            <textField textAdjust="StretchHeight" isBlankWhenNull="true">
                 <reportElement style="Detail" x="500" y="0" width="100" height="30" uuid="121c3954-246a-4fd0-924f-1b49c7b35789">
                     <property name="com.jaspersoft.studio.unit.y" value="px"/>
                 </reportElement>
                 <textFieldExpression><![CDATA[$F{addressplace2}]]></textFieldExpression>
             </textField>
-            <textField>
+            <textField textAdjust="StretchHeight" isBlankWhenNull="true">
                 <reportElement style="Detail" x="600" y="0" width="100" height="30" uuid="39a3305a-d0fe-4ec7-9c64-a179168c1acb">
                     <property name="com.jaspersoft.studio.unit.y" value="px"/>
                 </reportElement>
                 <textFieldExpression><![CDATA[$F{addresscountry}]]></textFieldExpression>
             </textField>
-            <textField>
+            <textField textAdjust="StretchHeight" isBlankWhenNull="true">
                 <reportElement style="Detail" x="700" y="0" width="100" height="30" uuid="08151de1-9f5b-4ceb-8307-e6dbcd232e1f">
                     <property name="com.jaspersoft.studio.unit.y" value="px"/>
                 </reportElement>
                 <textFieldExpression><![CDATA[$F{addressmunicipality}]]></textFieldExpression>
             </textField>
-            <textField>
+            <textField textAdjust="StretchHeight" isBlankWhenNull="true">
                 <reportElement style="Detail" x="800" y="0" width="100" height="30" uuid="a21c89a1-5a24-427f-81f7-6290d96c78b5">
                     <property name="com.jaspersoft.studio.unit.y" value="px"/>
                 </reportElement>
                 <textFieldExpression><![CDATA[$F{addresspostcode}]]></textFieldExpression>
             </textField>
-            <textField>
+            <textField textAdjust="StretchHeight" isBlankWhenNull="true">
                 <reportElement style="Detail" x="900" y="0" width="100" height="30" uuid="dc41e925-0e83-4fe7-8e0a-fea51565bd47">
                     <property name="com.jaspersoft.studio.unit.y" value="px"/>
                 </reportElement>
                 <textFieldExpression><![CDATA[$F{addressstateorprovince}]]></textFieldExpression>
             </textField>
-            <textField>
+            <textField textAdjust="StretchHeight" isBlankWhenNull="true">
                 <reportElement style="Detail" x="1000" y="0" width="100" height="30" uuid="e3387335-e220-4a38-ae31-1c295efe946b">
                     <property name="com.jaspersoft.studio.unit.y" value="px"/>
                 </reportElement>
                 <textFieldExpression><![CDATA[$F{loanindate}]]></textFieldExpression>
             </textField>
-            <textField>
+            <textField textAdjust="StretchHeight" isBlankWhenNull="true">
                 <reportElement style="Detail" x="1100" y="0" width="100" height="30" uuid="40993859-ff47-44f9-b27d-afec3518ca85">
                     <property name="com.jaspersoft.studio.unit.y" value="px"/>
                 </reportElement>
                 <textFieldExpression><![CDATA[$F{loanrenewalapplicationdate}]]></textFieldExpression>
             </textField>
-            <textField>
+            <textField textAdjust="StretchHeight" isBlankWhenNull="true">
                 <reportElement style="Detail" x="1200" y="0" width="100" height="30" uuid="b2c5ebaf-d0b4-4b76-b5fd-abce1b0f432e">
                     <property name="com.jaspersoft.studio.unit.y" value="px"/>
                 </reportElement>
                 <textFieldExpression><![CDATA[$F{objectnumber}]]></textFieldExpression>
             </textField>
-            <textField>
+            <textField textAdjust="StretchHeight" isBlankWhenNull="true">
                 <reportElement style="Detail" x="1300" y="0" width="100" height="30" uuid="734774c5-3036-4066-95fd-a7e9734b7ea6">
                     <property name="com.jaspersoft.studio.unit.y" value="px"/>
                 </reportElement>
                 <textFieldExpression><![CDATA[$F{objectname}]]></textFieldExpression>
             </textField>
-            <textField>
+            <textField textAdjust="StretchHeight" isBlankWhenNull="true">
                 <reportElement style="Detail" x="1400" y="0" width="100" height="30" uuid="c6250d41-01f6-4a43-99ab-a22d31fa0c01">
                     <property name="com.jaspersoft.studio.unit.y" value="px"/>
                 </reportElement>
                 <textFieldExpression><![CDATA[$F{objvalueamount}]]></textFieldExpression>
             </textField>
-            <textField>
+            <textField textAdjust="StretchHeight" isBlankWhenNull="true">
                 <reportElement style="Detail" x="1500" y="0" width="100" height="30" uuid="81ccdc07-b547-4460-939b-a16f3b2e74fc">
                     <property name="com.jaspersoft.studio.unit.y" value="px"/>
                 </reportElement>
                 <textFieldExpression><![CDATA[$F{objvaluecurrency}]]></textFieldExpression>
             </textField>
-            <textField>
+            <textField textAdjust="StretchHeight" isBlankWhenNull="true">
                 <reportElement style="Detail" x="1600" y="0" width="100" height="30" uuid="85c7d7d8-93af-4aca-b09c-6b14bb9107b5">
                     <property name="com.jaspersoft.studio.unit.y" value="px"/>
                 </reportElement>
                 <textFieldExpression><![CDATA[$F{loanvalueamount}]]></textFieldExpression>
             </textField>
-            <textField>
+            <textField textAdjust="StretchHeight" isBlankWhenNull="true">
                 <reportElement style="Detail" x="1700" y="0" width="100" height="30" uuid="477ec7dd-a9d7-4b11-bdf6-8e4a4a6ff788">
                     <property name="com.jaspersoft.studio.unit.y" value="px"/>
                 </reportElement>
                 <textFieldExpression><![CDATA[$F{loanvaluecurrency}]]></textFieldExpression>
             </textField>
-            <textField>
+            <textField textAdjust="StretchHeight" isBlankWhenNull="true">
                 <reportElement style="Detail" x="1800" y="0" width="100" height="30" uuid="16b65e20-0072-4567-a4c9-b56b1667a1d2">
                     <property name="com.jaspersoft.studio.unit.y" value="px"/>
                 </reportElement>
                 <textFieldExpression><![CDATA[$F{loangroup}]]></textFieldExpression>
             </textField>
-            <textField>
+            <textField textAdjust="StretchHeight" isBlankWhenNull="true">
                 <reportElement style="Detail" x="1900" y="0" width="100" height="30" uuid="6a1b03db-17c5-4747-95ee-120c1c652f1b">
                     <property name="com.jaspersoft.studio.unit.y" value="px"/>
                 </reportElement>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/incoming_loan_letter.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/incoming_loan_letter.jrxml
@@ -235,62 +235,62 @@ left outer join person_contacts pc on pc.loanid = loanin.csid]]>
 	<detail>
 		<band height="50">
 			<property name="com.jaspersoft.studio.layout" value="com.jaspersoft.studio.editor.layout.FreeLayout"/>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement x="0" y="0" width="100" height="30" uuid="b7031da3-fa26-431d-91cd-a73b4709fc49">
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 					<property name="com.jaspersoft.studio.unit.width" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{lender_termdisplayname}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement x="100" y="0" width="100" height="30" uuid="a45fa9bd-55e6-474a-8571-099c400f4791">
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{contact_termdisplayname}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement x="200" y="0" width="100" height="30" uuid="adbc8947-55c5-4b49-8b9f-20fdd90546cb">
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{lender_addresstype}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement x="300" y="0" width="100" height="30" uuid="50526dbe-1701-4d76-90aa-41593ba7d184">
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{lender_addressplace1}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement x="400" y="0" width="100" height="30" uuid="0e8e683e-37e9-4561-8ffa-48d85d1a32e8">
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{lender_addressplace2}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement x="500" y="0" width="100" height="30" uuid="b2b512cd-f061-440f-b83c-4fb8c8d2cb03">
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{lender_addresscountry}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement x="600" y="0" width="100" height="30" uuid="bcdc2de1-8562-41eb-9bdb-d9c24e35e462">
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{lender_addressmunicipality}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement x="700" y="0" width="100" height="30" uuid="401ff189-6051-43ee-9ccc-a62fe2d954cb">
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{lender_addresspostcode}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement x="800" y="0" width="100" height="30" uuid="b00311a6-076d-46ef-ab90-9405e8d954e0">
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{lender_addressstateorprovince}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement x="900" y="0" width="100" height="30" uuid="2ff6b56e-9731-441e-b9d9-b14f9268a313">
 					<property name="com.jaspersoft.studio.unit.width" value="px"/>
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
@@ -298,7 +298,7 @@ left outer join person_contacts pc on pc.loanid = loanin.csid]]>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{loanindate}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement x="1000" y="0" width="100" height="30" uuid="0ea61055-9756-4e94-9549-dd95e009479a">
 					<property name="com.jaspersoft.studio.unit.width" value="px"/>
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/obj_computed_location.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/obj_computed_location.jrxml
@@ -178,37 +178,37 @@ $P!{whereclause}]]>
 	<detail>
 		<band height="66" splitType="Stretch">
 			<property name="com.jaspersoft.studio.unit.height" value="px"/>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="0" y="0" width="100" height="30" uuid="7362be03-1a72-418e-a0da-1309cf959811">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{objectnumber}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="100" y="0" width="100" height="30" uuid="6e5c5cd7-f3a1-4794-8cb1-e65145ec11f4">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{title}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="200" y="0" width="100" height="30" uuid="3eb519fb-f717-4769-9582-7e7ebb07a511">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{finalname}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="300" y="0" width="100" height="30" uuid="4d34814d-7e29-4ccc-9fd6-9b7fcbe93bbb">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{computedcurrentlocation}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="400" y="0" width="100" height="30" uuid="8f539dce-a584-4071-a43f-0e91aa3e568f">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{locationname}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="500" y="0" width="100" height="30" uuid="7aaa4bcf-472f-451e-b096-f17ef2ecfbbd">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/obj_current_place_details.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/obj_current_place_details.jrxml
@@ -359,127 +359,127 @@ LEFT JOIN movements mvmt ON mvmt.objcsid = object.csid]]>
 	<detail>
 		<band height="66" splitType="Stretch">
 			<property name="com.jaspersoft.studio.unit.height" value="px"/>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="0" y="0" width="100" height="30" uuid="0b4226db-59bd-47c4-9fd9-04182e661f98">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{objectnumber}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="100" y="0" width="100" height="30" uuid="2b6bffc9-cd8a-41c6-a5e3-68c5bf1e873b">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{title}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="200" y="0" width="100" height="30" uuid="4c064f7a-6c45-4f3a-aed6-7537d3132e18">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{briefdescription}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="300" y="0" width="100" height="30" uuid="fe4d3600-9e7b-4c21-9d8a-998cfb7dd389">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{computedcurrentlocation}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="400" y="0" width="100" height="30" uuid="77b39c76-0028-40d1-8e46-b5091384d18a">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{currentlocationnote}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="500" y="0" width="100" height="30" uuid="38c831c3-e87b-43f1-98b1-eb14215490e8">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{placementtype}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="600" y="0" width="100" height="30" uuid="9fedea73-1e42-49ff-815e-bdc65d07a339">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{placementenvironment}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="700" y="0" width="100" height="30" uuid="de7cb024-1d8f-49e4-afa0-3d0e19afaeda">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{owner}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="800" y="0" width="100" height="30" uuid="9945ff11-6d87-48eb-b6e1-ffc04fd01729">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{ownertype}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="900" y="0" width="100" height="30" uuid="bb81a72c-fb37-4bca-b9d6-900d146f8632">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{ownerdate}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1000" y="0" width="100" height="30" uuid="beb9ca2f-aa8d-4388-a613-149a03ef720f">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{ownershipnote}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1100" y="0" width="100" height="30" uuid="85cd9aeb-5b6b-4710-9b63-d66f3b0708c5">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{addressplace1}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1200" y="0" width="100" height="30" uuid="474972e2-1443-4aee-a308-803f8621b5b7">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{addressplace2}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1300" y="0" width="100" height="30" uuid="275e25ba-7ef9-492f-8281-40c7588600a3">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{addressmunicipality}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1400" y="0" width="100" height="30" uuid="6ac1ee87-fed2-4528-8f12-c8f002f8ba04">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{addressstateorprovince}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1500" y="0" width="100" height="30" uuid="1b426d71-dd59-4ef1-95a9-cb5015ea09a8">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{addresscountry}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1600" y="0" width="100" height="30" uuid="cfcbc346-027a-4d6f-b094-c199ced97f0b">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{addresstype}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1700" y="0" width="100" height="30" uuid="7b07b72d-13e5-4de2-8cb5-fb88bff514fe">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{addresspostcode}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1800" y="0" width="100" height="30" uuid="6896e1e8-0bc3-46c8-a96e-4271b90fd293">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{decimallatitude}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1900" y="0" width="100" height="30" uuid="16d3f5fd-7271-44c2-9c39-5288e3ef669a">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{decimallongitude}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="2000" y="0" width="100" height="30" uuid="ced14c38-aa9f-4f37-a468-a478312e545c">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/outgoing_loan.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/outgoing_loan.jrxml
@@ -356,121 +356,121 @@ $P!{whereclause}
   <detail>
     <band height="66" splitType="Stretch">
       <property name="com.jaspersoft.studio.unit.height" value="px"/>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="0" y="0" width="100" height="30" uuid="87fafe2a-7b2a-433c-8440-926f5a750b5f">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{loanoutnumber}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="100" y="0" width="100" height="30" uuid="bab80b3a-e8d5-4c25-924b-758c4670107c">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{borrower}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="200" y="0" width="100" height="30" uuid="fc9c6181-58b1-41e3-b3a8-83f827cf022e">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{borrowerscontact}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="300" y="0" width="100" height="30" uuid="624834c8-81d7-4412-b8dc-2a9b815989dd">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{addresstype}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="400" y="0" width="100" height="30" uuid="c6ff1ca8-3214-4941-8a7e-9da39051b4da">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{addressplace1}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="500" y="0" width="100" height="30" uuid="edcdd538-cb26-4440-803a-52d0c1369be3">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{addressplace2}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="600" y="0" width="100" height="30" uuid="16b2267d-e844-48e3-b5e8-c8c2f7b4c081">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{addresscountry}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="700" y="0" width="100" height="30" uuid="82c4bb0f-3bb8-4e17-8de5-2cf9bf389f2e">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{addressmunicipality}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="800" y="0" width="100" height="30" uuid="eddcc588-8f60-452d-8dd2-be47a11aae3a">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{addresspostcode}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="900" y="0" width="100" height="30" uuid="30082e40-1545-432b-836a-eb74b307d255">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{addressstateorprovince}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="1000" y="0" width="100" height="30" uuid="8f89dca7-b1bf-4936-8c66-5a31bdcc1cf2">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{loanoutdate}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="1100" y="0" width="100" height="30" uuid="c9ff25cc-2642-4642-a1ea-0ae142eaaf8b">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{loanrenewalapplicationdate}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="1200" y="0" width="100" height="30" uuid="aa45e199-0803-47ce-b415-b7d1607ed5d5">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{objectnumber}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="1300" y="0" width="100" height="30" uuid="0a8c6654-d5ee-4359-8899-873d77a757dc">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{objectname}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="1400" y="0" width="100" height="30" uuid="9fbf094d-4093-455c-9c8a-3062a8c7ccfd">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{objvalueamount}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="1500" y="0" width="100" height="30" uuid="0ea9afd4-9730-4983-bdd1-59418b57fbd0">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{objvaluecurrency}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="1600" y="0" width="100" height="30" uuid="4b9a3472-b72c-49ab-8d35-80eeaa1e6c81">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{loanvalueamount}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="1700" y="0" width="100" height="30" uuid="ffa7daf8-1b19-4189-bed5-89e0af96c483">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{loanvaluecurrency}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="1800" y="0" width="100" height="30" uuid="50b791cd-4504-4c57-bd9a-b2e798edf5cc">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{loangroup}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="1900" y="0" width="100" height="30" uuid="0e3c00b0-462b-442f-8f91-0b1cf95422fe">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/outgoing_loan_letter.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/outgoing_loan_letter.jrxml
@@ -237,62 +237,62 @@ left outer join contacts c on c.loancsid = loanout.csid]]>
 	<detail>
 		<band height="50">
 			<property name="com.jaspersoft.studio.layout" value="com.jaspersoft.studio.editor.layout.FreeLayout"/>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement x="0" y="0" width="100" height="30" uuid="669c0a16-aa08-4fc8-a969-140c20f90689">
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 					<property name="com.jaspersoft.studio.unit.width" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{borrowername}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement x="100" y="0" width="100" height="30" uuid="ead3d075-5957-4d63-9670-70f600710cae">
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{contactname}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement x="200" y="0" width="200" height="30" uuid="aea1ea4a-70cc-45d5-a099-9f856be4c851">
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{addresstype}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement x="400" y="0" width="200" height="30" uuid="a7109e2b-483f-4052-bf13-6022ea74b332">
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{addressplace1}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement x="600" y="0" width="200" height="30" uuid="74dfacf6-7e41-4ffa-bcfb-6d5dc8c14afb">
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{addressplace2}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement x="800" y="0" width="200" height="30" uuid="81fdd2ae-1a39-490f-b08b-954f74f3ab90">
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{addresscountry}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement x="1000" y="0" width="200" height="30" uuid="992e0ab4-439c-4761-aab5-651bd6a347fa">
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{addressmunicipality}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement x="1200" y="0" width="200" height="30" uuid="308e2265-d600-4c3e-8887-bf6ba75be30b">
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{addresspostcode}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement x="1400" y="0" width="200" height="30" uuid="141efbac-3107-48d8-a700-13f040a119c9">
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{addressstateorprovince}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement x="1600" y="0" width="200" height="30" uuid="9fdda0b3-57df-4e08-a096-65f4bc4a5f37">
 					<property name="com.jaspersoft.studio.unit.width" value="px"/>
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
@@ -300,7 +300,7 @@ left outer join contacts c on c.loancsid = loanout.csid]]>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{loanoutdate}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement x="1800" y="0" width="200" height="30" uuid="9b13ca57-62c4-4187-a067-c38ba997bbae">
 					<property name="com.jaspersoft.studio.unit.width" value="px"/>
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/referral.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/referral.jrxml
@@ -446,157 +446,157 @@ $P!{whereclause}]]>
   <detail>
     <band height="66" splitType="Stretch">
       <property name="com.jaspersoft.studio.unit.height" value="px"/>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="0" y="0" width="100" height="30" uuid="1dd104f4-2abc-44bf-8057-eb5f5c5a6c8a">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{entrynumber}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="100" y="0" width="100" height="30" uuid="5eb9bd9c-5f80-4064-b9b6-8222ea78c0db">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{entrydate}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="200" y="0" width="100" height="30" uuid="a38af829-c71b-4dda-ace5-1b5d8296f306">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{entrymethod}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="300" y="0" width="100" height="30" uuid="329e59c9-69d2-4950-b10f-9e10413b3281">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{termdisplayname}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="400" y="0" width="100" height="30" uuid="a54544f4-2540-489b-9cb9-f56b100773e1">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{altdisplayname}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="500" y="0" width="100" height="30" uuid="201834a7-2cf9-4aa3-bf96-ad72b7aeaee5">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{addresstype}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="600" y="0" width="100" height="30" uuid="046d2f78-2081-4df5-a98d-cf589268e97c">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{addressplace1}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="700" y="0" width="100" height="30" uuid="00f62f5e-35a2-4d00-a2ab-c4037a169357">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{addressplace2}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="800" y="0" width="100" height="30" uuid="62c9145d-cecc-4bc3-bfcc-62b81a62bdf1">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{addressmunicipality}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="900" y="0" width="100" height="30" uuid="81aef955-6748-41bb-bed8-c3a79903ebc4">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{addressstateorprovince}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="1000" y="0" width="100" height="30" uuid="9a0adfdb-292e-46bc-8e08-4208f923ea01">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{addresspostcode}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="1100" y="0" width="100" height="30" uuid="d2767251-d90c-4670-a800-50e7122146a1">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{addresscountry}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="1200" y="0" width="100" height="30" uuid="7f38b1fb-e9b8-4063-9049-309496166548">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{approvalgroup}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="1300" y="0" width="100" height="30" uuid="973c7347-bd8b-43af-a447-bb4389103caf">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{approvalindividual}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="1400" y="0" width="100" height="30" uuid="7c3499fa-1d67-4731-b561-1b20e0b92e03">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{approvalstatus}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="1500" y="0" width="100" height="30" uuid="76ddc72f-015f-4729-b2cb-4dd5e8affe16">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{approvaldate}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="1600" y="0" width="100" height="30" uuid="76ddc72f-015f-4729-b2cb-4dd5e8affe16">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{approvalnote}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="1700" y="0" width="100" height="30" uuid="a6ea4754-fe7f-4a51-8caf-ed0c6f15e03d">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{entrynote}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="1800" y="0" width="100" height="30" uuid="3d8ff89f-43d2-42b8-9e64-0179eb64b530">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{packingnote}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="1900" y="0" width="100" height="30" uuid="c8a6192d-efcd-40c1-8e85-29f30a7faf3c">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{objectnumber}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="2000" y="0" width="100" height="30" uuid="10e5887e-19c3-44fa-9ce3-e4059d50841d">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{objectname}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="2100" y="0" width="100" height="30" uuid="10e5887e-19c3-44fa-9ce3-e4059d50841d">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{productiondate}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="2200" y="0" width="100" height="30" uuid="89ac7407-9a73-4036-a0d8-47a722e4c981">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{collection}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="2300" y="0" width="100" height="30" uuid="3d5ce70a-a89b-4861-93df-31ad79e1cef3">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{briefdescription}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="2400" y="0" width="100" height="30" uuid="95af2457-23da-4559-bbbf-91731f42c4bf">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{objecthistorynote}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="2500" y="0" width="100" height="30" uuid="2df963f7-fd20-4867-a981-02b5a2f4dd74">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tombstone_with_budget.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tombstone_with_budget.jrxml
@@ -306,91 +306,91 @@ $P!{whereclause}]]>
 	<detail>
 		<band height="66" splitType="Stretch">
 			<property name="com.jaspersoft.studio.unit.height" value="px"/>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="0" y="0" width="100" height="30" uuid="b2e5d1cf-fb6d-41df-9445-86da42726096">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{objectnumber}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="100" y="0" width="100" height="30" uuid="fb043df7-300f-40a1-9c25-9c4c5aa8020c">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{title}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="200" y="0" width="100" height="30" uuid="f412c611-8b7d-457b-ae24-3f287afa7b20">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{creator}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="300" y="0" width="100" height="30" uuid="d6f44c66-ac62-4d17-9930-ee964bd30d6e">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{briefdescription}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="400" y="0" width="100" height="30" uuid="d0f0dc9f-6558-4459-86cd-b0672875c9ca">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{collection}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="500" y="0" width="100" height="30" uuid="76124f26-72f7-4ea1-9535-0cf58feb1d4e">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{owner}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="600" y="0" width="100" height="30" uuid="495d8de0-c693-45db-a4e1-29346b1614de">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{installationtype}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="700" y="0" width="100" height="30" uuid="4bddf1c6-a41b-4826-904f-2ad5fb404f3e">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{worktype}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="800" y="0" width="100" height="30" uuid="c6e16da7-169d-4cca-a03c-079627298ff9">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{material}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="900" y="0" width="100" height="30" uuid="c961a497-57f7-453d-b7b7-eb6e642730bb">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{dimension}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1000" y="0" width="100" height="30" uuid="90e06353-8e5a-4320-bff8-c0f51af49d2c">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{dimensionvalue}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1100" y="0" width="100" height="30" uuid="92b62fb7-de65-4c41-add5-59c4e1ae5332">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{dimensionunit}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1200" y="0" width="100" height="30" uuid="e67d1a01-bb33-4a25-8ebf-de7467387c5f">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{artworkdate}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1300" y="0" width="100" height="30" uuid="c8b3c3a4-5941-4a6a-8c2d-e4a6b5de7aca">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{acquisitionfundingvalue}]]></textFieldExpression>
 			</textField>
-			<textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1400" y="0" width="100" height="30" uuid="6f2a0ddc-3505-463a-8ead-a02bc4772a51">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tombstone_with_creator.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tombstone_with_creator.jrxml
@@ -271,85 +271,85 @@ $P!{whereclause}]]>
   <detail>
     <band height="66" splitType="Stretch">
       <property name="com.jaspersoft.studio.unit.height" value="px"/>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="0" y="0" width="100" height="30" uuid="44d7432d-bbc2-424e-a48b-1dc69d9defcd">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{objectnumber}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="100" y="0" width="100" height="30" uuid="e82bb98e-446e-41fd-b27d-cd4b894631be">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{title}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="200" y="0" width="100" height="30" uuid="78d1e447-d4a1-46cd-89df-7660630171c6">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{creator}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="300" y="0" width="100" height="30" uuid="62fbe3a1-a1bf-4106-85bc-9350fe383626">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{creatorrole}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="400" y="0" width="100" height="30" uuid="a5df8077-4ddb-44ed-a65b-942c4cbdb294">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{briefdescription}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="500" y="0" width="100" height="30" uuid="11ce4e1b-669a-471b-aba6-1f99c6e729b5">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{collection}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="600" y="0" width="100" height="30" uuid="a70078ec-0a25-42f9-bc36-02c445b701c1">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{owner}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="700" y="0" width="100" height="30" uuid="15a61d9d-d100-4d35-afcf-3a67b3c513f8">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{installationtype}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="800" y="0" width="100" height="30" uuid="0c98f40e-f37e-4c24-943b-7472703d9425">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{worktype}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="900" y="0" width="100" height="30" uuid="e2946faa-4db0-4d95-9c7b-62b6d38ab115">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{material}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="1000" y="0" width="100" height="30" uuid="b9a762ce-afc5-4ee9-85d7-800ed3c67168">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{dimension}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="1100" y="0" width="100" height="30" uuid="e4b071d7-999b-43c5-8b31-ef4c57d72396">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{dimensionvalue}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="1200" y="0" width="100" height="30" uuid="291496e0-488f-4694-a0c3-1db4dabc2ff7">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{dimensionunit}]]></textFieldExpression>
       </textField>
-      <textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement style="Detail" x="1300" y="0" width="100" height="30" uuid="5dd7a01a-6d95-4500-ac85-f65fcd29a136">
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>


### PR DESCRIPTION
**What does this do?**
* Set overflow and null rules for results

**Why are we doing this? (with JIRA link)**
This issue was brought up in [DRYD-1198](https://collectionspace.atlassian.net/browse/DRYD-1198) as results were being truncated in the csv report for certain fields. I decided to copy some of the older reports which set overflow rules (using `textAdjust`) and apply them to all fields in the result set so that none of them will have truncation applied and will instead "stretch". In addition I updated the reports so that null fields will be blank instead of returning `null`, which had been done in other reports as well.

**How should this be tested? Do these changes have associated tests?**
* For one of the given reports, create a procedure or object that has enough data to cause an overflow in one of its fields (I'm not sure what the previous limit was it seems like it's ~21 or 22 characters)
* Run the report and see that the returned data is not truncated
* Since the change is the same for each field, testing all shouldn't be necessary but would be ideal 

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested on the condition report