### PR TITLE
Add combine param to report and batch searches.

### DIFF
--- a/services/batch/service/src/main/java/org/collectionspace/services/batch/BatchResource.java
+++ b/services/batch/service/src/main/java/org/collectionspace/services/batch/BatchResource.java
@@ -99,6 +99,12 @@ public class BatchResource extends NuxeoBasedResource {
             String docType = queryParams.getFirst(IQueryManager.SEARCH_TYPE_DOCTYPE);
             String className = queryParams.getFirst(IQueryManager.SEARCH_TYPE_CLASS_NAME);
             List<String> modes = queryParams.get(IQueryManager.SEARCH_TYPE_INVOCATION_MODE);
+            String combine = queryParams.getFirst(IQueryManager.SEARCH_COMBINE_QUERY_PARAM);
+
+            String qualifier = (combine != null && combine.equals(IQueryManager.SEARCH_COMBINE_OR))
+                ? IQueryManager.SEARCH_QUALIFIER_OR
+                : IQueryManager.SEARCH_QUALIFIER_AND;
+
             String whereClause = null;
             DocumentFilter documentFilter = null;
             String common_part = ctx.getCommonPartLabel();
@@ -107,21 +113,21 @@ public class BatchResource extends NuxeoBasedResource {
                 whereClause = QueryManager.createWhereClauseForInvocableByDocType(
                 		common_part, docType);
                 documentFilter = handler.getDocumentFilter();
-                documentFilter.appendWhereClause(whereClause, IQueryManager.SEARCH_QUALIFIER_AND);
+                documentFilter.appendWhereClause(whereClause, qualifier);
             }
 
             if (className != null && !className.isEmpty()) {
                 whereClause = QueryManager.createWhereClauseForInvocableByClassName(
                         common_part, className);
                 documentFilter = handler.getDocumentFilter();
-                documentFilter.appendWhereClause(whereClause, IQueryManager.SEARCH_QUALIFIER_AND);
+                documentFilter.appendWhereClause(whereClause, qualifier);
             }
 
             if (modes != null && !modes.isEmpty()) {
                 whereClause = QueryManager.createWhereClauseForInvocableByMode(
                 		common_part, modes);
                 documentFilter = handler.getDocumentFilter();
-                documentFilter.appendWhereClause(whereClause, IQueryManager.SEARCH_QUALIFIER_AND);
+                documentFilter.appendWhereClause(whereClause, qualifier);
             }
 
             if (whereClause !=null && logger.isDebugEnabled()) {

--- a/services/client/src/main/java/org/collectionspace/services/client/IQueryManager.java
+++ b/services/client/src/main/java/org/collectionspace/services/client/IQueryManager.java
@@ -30,6 +30,9 @@ import java.util.List;
 
 public interface IQueryManager {
 
+	final static String SEARCH_COMBINE_QUERY_PARAM = "combine";
+	final static String SEARCH_COMBINE_AND = "and";
+	final static String SEARCH_COMBINE_OR = "or";
 	final static String SEARCH_GROUP_OPEN = "(";
 	final static String SEARCH_GROUP_CLOSE = ")";
 	final static String SEARCH_TERM_SEPARATOR = " ";

--- a/services/report/service/src/main/java/org/collectionspace/services/report/ReportResource.java
+++ b/services/report/service/src/main/java/org/collectionspace/services/report/ReportResource.java
@@ -101,6 +101,12 @@ public class ReportResource extends NuxeoBasedResource {
             String docType = queryParams.getFirst(IQueryManager.SEARCH_TYPE_DOCTYPE);
             String filename = queryParams.getFirst(IQueryManager.SEARCH_TYPE_FILENAME);
             List<String> modes = queryParams.get(IQueryManager.SEARCH_TYPE_INVOCATION_MODE);
+            String combine = queryParams.getFirst(IQueryManager.SEARCH_COMBINE_QUERY_PARAM);
+
+            String qualifier = (combine != null && combine.equals(IQueryManager.SEARCH_COMBINE_OR))
+                ? IQueryManager.SEARCH_QUALIFIER_OR
+                : IQueryManager.SEARCH_QUALIFIER_AND;
+
             String whereClause = null;
             DocumentFilter documentFilter = null;
             String common_part =ctx.getCommonPartLabel();
@@ -108,19 +114,19 @@ public class ReportResource extends NuxeoBasedResource {
                 whereClause = QueryManager.createWhereClauseForInvocableByDocType(
                 		common_part, docType);
                 documentFilter = handler.getDocumentFilter();
-                documentFilter.appendWhereClause(whereClause, IQueryManager.SEARCH_QUALIFIER_AND);
+                documentFilter.appendWhereClause(whereClause, qualifier);
             }
             if (filename != null && !filename.isEmpty()) {
                 whereClause = QueryManager.createWhereClauseForInvocableByFilename(
                         common_part, filename);
                 documentFilter = handler.getDocumentFilter();
-                documentFilter.appendWhereClause(whereClause, IQueryManager.SEARCH_QUALIFIER_AND);
+                documentFilter.appendWhereClause(whereClause, qualifier);
             }
             if (modes != null && !modes.isEmpty()) {
                 whereClause = QueryManager.createWhereClauseForInvocableByMode(
                 		common_part, modes);
                 documentFilter = handler.getDocumentFilter();
-                documentFilter.appendWhereClause(whereClause, IQueryManager.SEARCH_QUALIFIER_AND);
+                documentFilter.appendWhereClause(whereClause, qualifier);
             }
             if (whereClause !=null && logger.isDebugEnabled()) {
                 logger.debug("The WHERE clause is: " + documentFilter.getWhereClause());


### PR DESCRIPTION
**What does this do?**

This adds a `combine` parameter to list requests for report and batch resources. This controls how the filters (`doctype`, `filename`, `classname`, `mode`) are combined. Set to `or` to combine the filters using an OR operation. No value or any other value will combine the filters using and AND operation.

**Why are we doing this? (with JIRA link)**

When viewing a Group record, the reports and batch jobs shown in the sidebar should be _either_ registered for doc type `Group`, _or_ for invocation mode `group`. There was previously no way to combine these filters using an OR operator.

JIRA: https://collectionspace.atlassian.net/browse/DRYD-1069

**How should this be tested? Do these changes have associated tests?**

With the default reports installed:
- Request `/cspace-services/reports?doctype=Group`
   There should be one result, Group Object Ethnographic Object List.
- Request `/cspace-services/reports?mode=group`
   There should be one result, Group Basic List.
- Request `/cspace-services/reports?doctype=Group&mode=group`
   There should be no results.
- Request `/cspace-services/reports?doctype=Group&mode=group&combine=and`
   There should be no results.
- Request `/cspace-services/reports?doctype=Group&mode=group&combine=or`
   There should be two results (both of the above).

**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

I will update the REST API documentation at https://collectionspace.atlassian.net/wiki/spaces/UNR/pages/1565362629/Batch+Job+Service+RESTful+APIs and https://collectionspace.atlassian.net/wiki/spaces/UNR/pages/1565363217/Reporting+Service+RESTful+APIs

**Did someone actually run this code to verify it works?**

@ray-lee ran this locally.
