### PR TITLE
DRYD-1069: Allow docType to be group or null in group mode invocations.

### DIFF
--- a/services/batch/service/src/main/java/org/collectionspace/services/batch/nuxeo/BatchDocumentModelHandler.java
+++ b/services/batch/service/src/main/java/org/collectionspace/services/batch/nuxeo/BatchDocumentModelHandler.java
@@ -250,14 +250,25 @@ public class BatchDocumentModelHandler extends NuxeoDocumentModelHandler<BatchCo
 			//
 			// Ensure the batch job supports the requested invocation context's document type
 			if (!Invocable.INVOCATION_MODE_NO_CONTEXT.equalsIgnoreCase(invocationCtx.getMode())) {
+				String invDocType = invocationCtx.getDocType();
 				ForDocTypes forDocTypes = batchCommon.getForDocTypes();
-				if (forDocTypes != null) {
-					List<String> forDocTypeList = toLowerCase(forDocTypes.getForDocType()); // convert all strings to lowercase.
-					if (forDocTypeList == null || !forDocTypeList.contains(invocationCtx.getDocType().toLowerCase())) {
-						String msg = String.format("BatchResource: The batch job '%s' CSID='%s' does not support the invocation document type '%s'.",
-								batchCommon.getName(), csid, invocationCtx.getDocType());
-						throw new BadRequestException(msg);
-					}
+
+				List<String> forDocTypeList = (forDocTypes == null)
+					? new ArrayList<String>()
+					: toLowerCase(forDocTypes.getForDocType()); // convert all strings to lowercase.
+
+				if (Invocable.INVOCATION_MODE_GROUP.equalsIgnoreCase(invocationCtx.getMode())) {
+					// In group mode, allow the context doc type to be Group or null, even if the report wasn't registered
+					// with those types.
+
+					forDocTypeList.add("group");
+					forDocTypeList.add(null);
+				}
+
+				if (!forDocTypeList.contains(invDocType.toLowerCase())) {
+					String msg = String.format("BatchResource: The batch job '%s' CSID='%s' does not support the invocation document type '%s'.",
+							batchCommon.getName(), csid, invDocType);
+					throw new BadRequestException(msg);
 				}
 			}
 

--- a/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
+++ b/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
@@ -31,6 +31,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -272,15 +273,28 @@ public class ReportDocumentModelHandler extends NuxeoDocumentModelHandler<Report
 						"ReportResource: This Report does not support Invocation Mode: "
 	        			+invocationMode);
 			}
-	    	if (checkDocType) {
-	    		List<String> forDocTypeList =
-	    			(List<String>) NuxeoUtils.getProperyValue(docModel, InvocableJAXBSchema.FOR_DOC_TYPES); //docModel.getPropertyValue(InvocableJAXBSchema.FOR_DOC_TYPES);
-	    		if (forDocTypeList==null || !forDocTypeList.contains(invContext.getDocType())) {
-	        		throw new BadRequestException(
-	        				"ReportResource: Invoked with unsupported document type: "
-	        				+invContext.getDocType());
-	        	}
-	    	}
+			if (checkDocType) {
+				String invDocType = invContext.getDocType();
+				List<String> forDocTypeList = (List<String>) NuxeoUtils.getProperyValue(docModel, InvocableJAXBSchema.FOR_DOC_TYPES);
+
+				if (forDocTypeList == null) {
+					forDocTypeList = new ArrayList<String>();
+				}
+
+				if (Invocable.INVOCATION_MODE_GROUP.equalsIgnoreCase(invocationMode)) {
+					// In group mode, allow the context doc type to be Group or null, even if the report wasn't registered
+					// with those types.
+
+					forDocTypeList.add("Group");
+					forDocTypeList.add(null);
+				}
+
+				if (!forDocTypeList.contains(invDocType)) {
+					throw new BadRequestException(
+						"ReportResource: Invoked with unsupported document type: "
+						+invDocType);
+				}
+			}
 	    	reportFileNameProperty = (String) NuxeoUtils.getProperyValue(docModel, ReportJAXBSchema.FILENAME); //docModel.getPropertyValue(ReportJAXBSchema.FILENAME)); // Set the outgoing param with the report file name
 			//
 	    	// If the invocation context contains a MIME type then use it.  Otherwise, look in the report resource.  If no MIME type in the report resource,


### PR DESCRIPTION
**What does this do?**

This allows reports and batch jobs to be invoked with `mode`=`group` and `docType`=`Group`, or `mode`=`group` and no `docType`, regardless of the `forDocTypes` that the report/batch job was registered with. This should be allowed, because `mode`=`group` implies that the context document is a Group. 

**Why are we doing this? (with JIRA link)**

This allows authors to add reports/batch jobs that run in group mode, without also needing to specify `forDocType`=`Group`, which is redundant. It can also be confusing for reports that run in both group and list modes. For example, take a report that runs on lists of Objects, or a group (of Objects). For this, specifying `supportsGroup`=`true` and `supportsList`=`true` along with `forDocType`=[`CollectionObject`, `Group`] causes the report to appear on search results for _both_ Objects and Groups, which is not what is desired. What is desired is to appear on search results for Objects, and single Group records. With this change, this reports can be registered with `supportsGroup`=`true` and `supportsList`=`true`, but only `forDocType`=`CollectionObject`.

JIRA: https://github.com/collectionspace/cspace-ui.js/pull/184

**How should this be tested? Do these changes have associated tests?**

- Create a Group with related Objects.
- Using the REST API, run the "Group Basic List" report on the group, in group mode. Do this twice, with `docType`=`group`, and with no `docType` in the invocation payload. For example:

POST http://localhost:8180/cspace-services/reports/fd4b5237-f9fe-42e4-92f9/invoke
```
{
  "ns2:invocationContext": {
    "@xmlns:ns2": "http://collectionspace.org/services/common/invocable",
    "mode": "group",
    "outputMIME": "application/pdf",
    "docType": "Group",
    "groupCSID": "fc77f9e4-b444-4a1a-8713"
  }
}
```

POST http://localhost:8180/cspace-services/reports/fd4b5237-f9fe-42e4-92f9/invoke
```
{
  "ns2:invocationContext": {
    "@xmlns:ns2": "http://collectionspace.org/services/common/invocable",
    "mode": "group",
    "outputMIME": "application/pdf",
    "groupCSID": "fc77f9e4-b444-4a1a-8713"
  }
}
```

The report should run successfully in both cases.

**Dependencies for merging? Releasing to production?**

This is required by https://github.com/collectionspace/cspace-ui.js/pull/184.

**Has the application documentation been updated for these changes?**

I will update the relevant report/batch job authoring documentation.

**Did someone actually run this code to verify it works?**

@ray-lee ran this locally.
