### PR TITLE
DRYD-1237: Remove 'powered by' and CSpace logo from report footers.

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/coreAcquisition.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/coreAcquisition.jrxml
@@ -263,17 +263,6 @@ ORDER BY objectnumber]]>
 				</textElement>
 				<textFieldExpression><![CDATA[new java.util.Date()]]></textFieldExpression>
 			</textField>
-			<image onErrorType="Icon">
-				<reportElement uuid="92d4e522-3d77-4464-85f0-face1a366667" x="629" y="2" width="120" height="20"/>
-                                <imageExpression><![CDATA["https://pahma.cspace.berkeley.edu/collectionspace/ui/pahma/images/header-logo-cspace.png"]]></imageExpression>
-			</image>
-			<staticText>
-				<reportElement uuid="508adf6d-5e27-489d-b869-f859f4ca2b02" x="550" y="1" width="70" height="17"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="12"/>
-				</textElement>
-				<text><![CDATA[powered by]]></text>
-			</staticText>
 		</band>
 	</pageFooter>
 	<summary>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/coreGroupObject.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/coreGroupObject.jrxml
@@ -210,17 +210,6 @@ order by objectNumber]]>
 				</textElement>
 				<textFieldExpression><![CDATA[new java.util.Date()]]></textFieldExpression>
 			</textField>
-			<image onErrorType="Icon">
-				<reportElement uuid="44c4bdb0-9df3-4c99-bfd3-c0994fa5fe8d" x="450" y="0" width="120" height="20"/>
-                                <imageExpression><![CDATA["https://pahma.cspace.berkeley.edu/collectionspace/ui/pahma/images/header-logo-cspace.png"]]></imageExpression>
-			</image>
-			<staticText>
-				<reportElement uuid="0074b0c4-86b0-4c0e-b613-1fa1230b0fcd" x="371" y="1" width="70" height="17"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="12"/>
-				</textElement>
-				<text><![CDATA[powered by]]></text>
-			</staticText>
 		</band>
 	</pageFooter>
 	<lastPageFooter>
@@ -253,17 +242,6 @@ order by objectNumber]]>
 				</textElement>
 				<textFieldExpression><![CDATA[" " + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
-			<image onErrorType="Icon">
-				<reportElement uuid="20a7701e-defe-4c7b-bef9-999bcbc9fe13" x="450" y="0" width="120" height="20"/>
-				<imageExpression><![CDATA["https://pahma.cspace.berkeley.edu/collectionspace/ui/pahma/images/header-logo-cspace.png"]]></imageExpression>
-			</image>
-			<staticText>
-				<reportElement uuid="775624fe-8bb6-4605-b9c7-ba7274e0332c" x="371" y="1" width="70" height="17"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="12"/>
-				</textElement>
-				<text><![CDATA[powered by]]></text>
-			</staticText>
 		</band>
 	</lastPageFooter>
 	<summary>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/coreIntake.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/coreIntake.jrxml
@@ -242,17 +242,6 @@ ORDER BY objectnumber]]>
 				</textElement>
 				<textFieldExpression><![CDATA[new java.util.Date()]]></textFieldExpression>
 			</textField>
-			<image onErrorType="Icon">
-				<reportElement uuid="92d4e522-3d77-4464-85f0-face1a366667" x="629" y="2" width="120" height="20"/>
-                                <imageExpression><![CDATA["https://pahma.cspace.berkeley.edu/collectionspace/ui/pahma/images/header-logo-cspace.png"]]></imageExpression>
-			</image>
-			<staticText>
-				<reportElement uuid="508adf6d-5e27-489d-b869-f859f4ca2b02" x="550" y="1" width="70" height="17"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="12"/>
-				</textElement>
-				<text><![CDATA[powered by]]></text>
-			</staticText>
 		</band>
 	</pageFooter>
 	<summary>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/coreLoanIn.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/coreLoanIn.jrxml
@@ -263,17 +263,6 @@ ORDER BY objectnumber]]>
 				</textElement>
 				<textFieldExpression><![CDATA[new java.util.Date()]]></textFieldExpression>
 			</textField>
-			<image onErrorType="Icon">
-				<reportElement uuid="92d4e522-3d77-4464-85f0-face1a366667" x="629" y="2" width="120" height="20"/>
-                                <imageExpression><![CDATA["https://pahma.cspace.berkeley.edu/collectionspace/ui/pahma/images/header-logo-cspace.png"]]></imageExpression>
-			</image>
-			<staticText>
-				<reportElement uuid="508adf6d-5e27-489d-b869-f859f4ca2b02" x="550" y="1" width="70" height="17"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="12"/>
-				</textElement>
-				<text><![CDATA[powered by]]></text>
-			</staticText>
 		</band>
 	</pageFooter>
 	<summary>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/coreLoanOut.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/coreLoanOut.jrxml
@@ -261,17 +261,6 @@ ORDER BY objectnumber]]>
 				</textElement>
 				<textFieldExpression><![CDATA[new java.util.Date()]]></textFieldExpression>
 			</textField>
-			<image onErrorType="Icon">
-				<reportElement uuid="92d4e522-3d77-4464-85f0-face1a366667" x="629" y="2" width="120" height="20"/>
-                                <imageExpression><![CDATA["https://pahma.cspace.berkeley.edu/collectionspace/ui/pahma/images/header-logo-cspace.png"]]></imageExpression>
-			</image>
-			<staticText>
-				<reportElement uuid="508adf6d-5e27-489d-b869-f859f4ca2b02" x="550" y="1" width="70" height="17"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="12"/>
-				</textElement>
-				<text><![CDATA[powered by]]></text>
-			</staticText>
 		</band>
 	</pageFooter>
 	<summary>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/coreObjectExit.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/coreObjectExit.jrxml
@@ -248,17 +248,6 @@ ORDER BY objectnumber]]>
 				</textElement>
 				<textFieldExpression><![CDATA[new java.util.Date()]]></textFieldExpression>
 			</textField>
-			<image onErrorType="Icon">
-				<reportElement uuid="92d4e522-3d77-4464-85f0-face1a366667" x="629" y="2" width="120" height="20"/>
-                                <imageExpression><![CDATA["https://pahma.cspace.berkeley.edu/collectionspace/ui/pahma/images/header-logo-cspace.png"]]></imageExpression>
-			</image>
-			<staticText>
-				<reportElement uuid="508adf6d-5e27-489d-b869-f859f4ca2b02" x="550" y="1" width="70" height="17"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="12"/>
-				</textElement>
-				<text><![CDATA[powered by]]></text>
-			</staticText>
 		</band>
 	</pageFooter>
 	<summary>


### PR DESCRIPTION
**What does this do?**

This removes the "powered by" and CollectionSpace logo image from report footers.

**Why are we doing this? (with JIRA link)**

Several reports contributed by UC Berkeley contained this in the footer. The logo was retrieved from the URL https://pahma.cspace.berkeley.edu/collectionspace/ui/pahma/images/header-logo-cspace.png, which was not accessible outside of UC Berkeley, so a broken image icon would appear. This text and logo are removed, to be consistent with other reports.

**How should this be tested? Do these changes have associated tests?**

The following affected reports should continue to run successfully. There should be no "powered by" text, CollectionSpace logo, or image icon in the footer.

- Acquisition Ethnographic Object List
- Group Object Ethnographic Object List
- Intake Ethnographic Object List
- Loan In Ethnographic Object List
- Loan Out Ethnographic Object List
- Object Exit Ethnographic Object List

**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran the reports.