### PR TITLE
Additional Report Updates

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/deaccessions.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/deaccessions.jrxml
@@ -26,6 +26,7 @@
     exit.id AS id,
     exit.exitnote,
     exit.exitnumber,
+    exit.exitquantity,
     exit.exitreason,
     exit.packingnote,
     exit.deaccessiondate,
@@ -132,6 +133,7 @@
 )
 SELECT
   exit.exitnumber,
+  exit.exitquantity,
   exit.exitdate,
   exit.exitmethod,
   exit.exitreason,
@@ -185,6 +187,11 @@ LEFT JOIN related_intakes intake ON intake.objcsid = obj.csid]]>
 	<field name="exitnumber" class="java.lang.String">
 		<property name="com.jaspersoft.studio.field.name" value="exitnumber"/>
 		<property name="com.jaspersoft.studio.field.label" value="exitnumber"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="objectexit_common"/>
+	</field>
+	<field name="exitquantity" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="exitquantity"/>
+		<property name="com.jaspersoft.studio.field.label" value="exitquantity"/>
 		<property name="com.jaspersoft.studio.field.tree.path" value="objectexit_common"/>
 	</field>
 	<field name="exitdate" class="java.lang.String">
@@ -415,6 +422,13 @@ LEFT JOIN related_intakes intake ON intake.objcsid = obj.csid]]>
 				</reportElement>
 				<textElement markup="styled"/>
 				<text><![CDATA[Exit number]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="100" y="0" width="100" height="60" uuid="df0dab5e-6620-4d94-a2e8-aa0e57ce83e2">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Exit quantity]]></text>
 			</staticText>
 			<staticText>
 				<reportElement style="Column header" x="200" y="0" width="100" height="60" uuid="d8c568a2-c8bf-4385-968b-ebd7e7b2b027">
@@ -713,6 +727,12 @@ LEFT JOIN related_intakes intake ON intake.objcsid = obj.csid]]>
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{exitnumber}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="100" y="0" width="100" height="30" uuid="6c9fc572-62c9-4591-bf13-9b50a671addc">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{exitquantity}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="200" y="0" width="100" height="30" uuid="198b574c-8492-4ea4-ab68-17b18f412c3f">

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/deed_of_gift.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/deed_of_gift.jrxml
@@ -38,7 +38,7 @@
 	$P!{whereclause}
 ), person_owners AS (
   SELECT ag.*,
-    string_agg(primaryterm.termdisplayname, '|') as primarydisplayname,
+    string_agg(primaryterm.termdisplayname, '|' ORDER BY term_hier.pos) as primarydisplayname,
     intake.csid as intakecsid
   FROM intakes intake
   INNER JOIN intakes_common_currentowners co ON co.id = intake.id AND co.pos = 0

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tombstone_with_creator.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tombstone_with_creator.jrxml
@@ -34,8 +34,8 @@
   namegroup.worktype,
   material.material,
   dimension.dimension,
-  dimension.value AS dimensionvalue,
-  dimension.measurementunit AS dimensionunit,
+  dimension.dimensionvalue,
+  dimension.dimensionunit,
   sd.datedisplaydate AS artworkdate,
   media.objectcsid AS mediacsid
 FROM collectionobjects_common obj
@@ -48,12 +48,21 @@ LEFT JOIN collectionobjects_publicart_publicartcollections coll ON coll.id = obj
 LEFT JOIN collectionobjects_common_briefdescriptions bd ON bd.id = obj.id AND bd.pos = 0
 LEFT JOIN collectionobjects_common_owners owner ON owner.id = obj.id AND owner.pos = 0
 LEFT JOIN collectionobjects_common_inventorystatuslist inventory ON inventory.id = obj.id AND inventory.pos = 0
-LEFT JOIN hierarchy measured_hier on measured_hier.parentid = obj.id and measured_hier.primarytype = 'measuredPartGroup' and measured_hier.pos = 0
-LEFT JOIN hierarchy dimension_hier on dimension_hier.parentid = measured_hier.id and dimension_hier.primarytype = 'dimensionSubGroup' and dimension_hier.pos = 0
-LEFT JOIN dimensionsubgroup dimension on dimension.id = dimension_hier.id
 LEFT JOIN hierarchy pdg_hier on pdg_hier.parentid = obj.id AND pdg_hier.primarytype = 'publicartProductionDateGroup' and pdg_hier.pos = 0
 LEFT JOIN hierarchy sdg_hier on sdg_hier.parentid = pdg_hier.id AND sdg_hier.primarytype = 'structuredDateGroup'
 LEFT JOIN structureddategroup sd on sd.id = sdg_hier.id
+LEFT JOIN (
+ SELECT
+  measured_hier.parentid,
+  string_agg(dimension.dimension, '|') AS dimension,
+  string_agg(dimension.value::text, '|') AS dimensionvalue,
+  string_agg(dimension.measurementunit, '|') AS dimensionunit
+  FROM hierarchy measured_hier
+  INNER JOIN hierarchy dimension_hier on dimension_hier.parentid = measured_hier.id and dimension_hier.primarytype = 'dimensionSubGroup'
+  LEFT JOIN dimensionsubgroup dimension on dimension.id = dimension_hier.id
+  WHERE measured_hier.primarytype = 'measuredPartGroup'
+  GROUP BY measured_hier.parentid
+) dimension on dimension.parentid = obj.id
 LEFT JOIN (
   SELECT
     creator_hier.parentid,
@@ -142,7 +151,7 @@ $P!{whereclause}]]>
     <property name="com.jaspersoft.studio.field.label" value="dimension"/>
     <property name="com.jaspersoft.studio.field.tree.path" value="dimensionsubgroup"/>
   </field>
-  <field name="dimensionvalue" class="java.lang.Double">
+  <field name="dimensionvalue" class="java.lang.String">
     <property name="com.jaspersoft.studio.field.name" value="dimensionvalue"/>
     <property name="com.jaspersoft.studio.field.label" value="dimensionvalue"/>
     <property name="com.jaspersoft.studio.field.tree.path" value="dimensionsubgroup"/>


### PR DESCRIPTION
**What does this do?**
Brings in additional changes requested for reports:

* DRYD-1118: Ensure ordering for term names
* DRYD-1130: Add exit quantity
* DRYD-1196: Aggregate dimension values

**Why are we doing this? (with JIRA link)**
These changes are the latest requested from testing the reports. For deed of gift, we want to make sure the primary change is first, so we use order by on the aggregation. Deaccession had a typo in the original requested changes which resulted in exit quantity being removed; this has been re-added. In tombstone with creator, the dimension fields were requested to be aggregated. 

* https://collectionspace.atlassian.net/browse/DRYD-1118
* https://collectionspace.atlassian.net/browse/DRYD-1130
* https://collectionspace.atlassian.net/browse/DRYD-1196

**How should this be tested? Do these changes have associated tests?**

* Redeploy the reports
* Run the deed of gift report on an Intake procedure; see the correct order for the owner term names
* Run the deaccession report for Object Exits; see the exit quantity field returned
* Run the tombstone with creator report for CollectionObjects; see aggregated dimensions

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally