### PR TITLE
DRYD-1248: UCB - Duplicate Object Number Report

### DIFF
--- a/services/common/src/main/cspace/config/services/tenants/botgarden/botgarden-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/botgarden/botgarden-tenant-bindings.delta.xml
@@ -44,5 +44,13 @@
             </service:initHandler>
         </tenant:serviceBindings>
 
+        <tenant:serviceBindings merge:matcher="id" id="Reports">
+            <service:properties xmlns:service="http://collectionspace.org/services/config/service" xmlns:types="http://collectionspace.org/services/config/types">
+                <types:item merge:matcher="skip" merge:action="insert">
+                    <types:key>report</types:key>
+                    <types:value>duplicateobjectnumber</types:value>
+                </types:item>
+            </service:properties>
+        </tenant:serviceBindings>
     </tenant:tenantBinding>
 </tenant:TenantBindingConfig>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/duplicateobjectnumber.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/duplicateobjectnumber.jrxml
@@ -82,19 +82,19 @@ order by co.objectnumber, determination]]>
   </columnHeader>
   <detail>
     <band height="16" splitType="Prevent">
-      <textField isStretchWithOverflow="true" isBlankWhenNull="true">
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement stretchType="RelativeToBandHeight" x="59" y="0" width="249" height="15"
           isPrintWhenDetailOverflows="true" />
         <textElement />
         <textFieldExpression class="java.lang.String"><![CDATA[$F{determination}]]></textFieldExpression>
       </textField>
-      <textField isStretchWithOverflow="true" isBlankWhenNull="true">
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
         <reportElement stretchType="RelativeToBandHeight" x="319" y="0" width="221" height="15"
           isPrintWhenDetailOverflows="true" />
         <textElement />
         <textFieldExpression class="java.lang.String"><![CDATA[$F{collector}]]></textFieldExpression>
       </textField>
-      <textField isStretchWithOverflow="true">
+      <textField textAdjust="StretchHeight">
         <reportElement stretchType="RelativeToBandHeight" isPrintRepeatedValues="false" x="0" y="0"
           width="59" height="15" isPrintWhenDetailOverflows="true" />
         <textElement verticalAlignment="Middle">

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/duplicateobjectnumber.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/duplicateobjectnumber.jrxml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd"
+  name="duplicateobjectnumber" language="groovy" pageWidth="612" pageHeight="792" columnWidth="540"
+  leftMargin="36" rightMargin="36" topMargin="36" bottomMargin="36">
+  <property name="ireport.zoom" value="1.0" />
+  <property name="ireport.x" value="0" />
+  <property name="ireport.y" value="0" />
+  <queryString>
+    <![CDATA[select co.objectnumber accession_number,
+    case when (tig.taxon is not null and tig.taxon <> '')
+    then regexp_replace(tig.taxon, '^.*\)''(.*)''$', '\1')
+    end as determination,
+    case when (fc.item is not null and fc.item <> '')
+    then regexp_replace(fc.item, '^.*\)''(.*)''$', '\1')
+    end as collector
+from collectionobjects_common co
+left outer join hierarchy htig
+    on (co.id = htig.parentid and htig.name='collectionobjects_naturalhistory:taxonomicIdentGroupList' and htig.pos=0)
+left outer join taxonomicIdentGroup tig on (tig.id = htig.id)
+left outer join collectionobjects_common_fieldCollectors fc on (co.id = fc.id and fc.pos = 0)
+where co.objectnumber in
+(select co1.objectnumber
+from collectionobjects_common co1, misc m
+where co1.id=m.id and m.lifecyclestate <> 'deleted' and co1.objectnumber is not null
+group by co1.objectnumber
+having count(*) > 1)
+order by co.objectnumber, determination]]>
+  </queryString>
+  <field name="accession_number" class="java.lang.String" />
+  <field name="determination" class="java.lang.String" />
+  <field name="collector" class="java.lang.String" />
+  <group name="accession_number" keepTogether="true">
+    <groupExpression><![CDATA[$F{accession_number}]]></groupExpression>
+    <groupHeader>
+      <band height="10">
+        <line>
+          <reportElement x="0" y="5" width="539" height="1" forecolor="#999999" />
+        </line>
+      </band>
+    </groupHeader>
+  </group>
+  <background>
+    <band splitType="Stretch" />
+  </background>
+  <title>
+    <band height="25" splitType="Stretch">
+      <staticText>
+        <reportElement x="0" y="0" width="540" height="20" />
+        <textElement textAlignment="Center">
+          <font size="12" isBold="true" />
+        </textElement>
+        <text><![CDATA[Duplicate Accession Numbers]]></text>
+      </staticText>
+    </band>
+  </title>
+  <columnHeader>
+    <band height="22" splitType="Stretch">
+      <staticText>
+        <reportElement x="59" y="2" width="100" height="20" />
+        <textElement verticalAlignment="Middle">
+          <font isBold="true" />
+        </textElement>
+        <text><![CDATA[Determination]]></text>
+      </staticText>
+      <staticText>
+        <reportElement x="319" y="2" width="100" height="20" />
+        <textElement verticalAlignment="Middle">
+          <font isBold="true" />
+        </textElement>
+        <text><![CDATA[Collector]]></text>
+      </staticText>
+      <staticText>
+        <reportElement x="0" y="2" width="59" height="20" />
+        <textElement verticalAlignment="Middle">
+          <font isBold="true" />
+        </textElement>
+        <text><![CDATA[Accn No.]]></text>
+      </staticText>
+    </band>
+  </columnHeader>
+  <detail>
+    <band height="16" splitType="Prevent">
+      <textField isStretchWithOverflow="true" isBlankWhenNull="true">
+        <reportElement stretchType="RelativeToBandHeight" x="59" y="0" width="249" height="15"
+          isPrintWhenDetailOverflows="true" />
+        <textElement />
+        <textFieldExpression class="java.lang.String"><![CDATA[$F{determination}]]></textFieldExpression>
+      </textField>
+      <textField isStretchWithOverflow="true" isBlankWhenNull="true">
+        <reportElement stretchType="RelativeToBandHeight" x="319" y="0" width="221" height="15"
+          isPrintWhenDetailOverflows="true" />
+        <textElement />
+        <textFieldExpression class="java.lang.String"><![CDATA[$F{collector}]]></textFieldExpression>
+      </textField>
+      <textField isStretchWithOverflow="true">
+        <reportElement stretchType="RelativeToBandHeight" isPrintRepeatedValues="false" x="0" y="0"
+          width="59" height="15" isPrintWhenDetailOverflows="true" />
+        <textElement verticalAlignment="Middle">
+          <font size="9" />
+        </textElement>
+        <textFieldExpression class="java.lang.String"><![CDATA[$F{accession_number}]]></textFieldExpression>
+      </textField>
+    </band>
+  </detail>
+  <pageFooter>
+    <band height="21" splitType="Stretch">
+      <textField pattern="MMMMM dd, yyyy">
+        <reportElement x="0" y="0" width="100" height="20" />
+        <textElement />
+        <textFieldExpression class="java.util.Date"><![CDATA[new java.util.Date()]]></textFieldExpression>
+      </textField>
+      <textField>
+        <reportElement x="419" y="0" width="80" height="20" />
+        <textElement textAlignment="Right" />
+        <textFieldExpression class="java.lang.String"><![CDATA["Page "+$V{PAGE_NUMBER}+" of"]]></textFieldExpression>
+      </textField>
+      <textField evaluationTime="Report">
+        <reportElement x="499" y="0" width="40" height="20" />
+        <textElement />
+        <textFieldExpression class="java.lang.String"><![CDATA[" " + $V{PAGE_NUMBER}]]></textFieldExpression>
+      </textField>
+    </band>
+  </pageFooter>
+</jasperReport>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/duplicateobjectnumber.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/duplicateobjectnumber.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<document name="report">
+  <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
+    <name>Duplicate Object Number</name>
+    <notes>Duplicate Object Number Report</notes>
+    <forDocTypes>
+      <forDocType>CollectionObject</forDocType>
+    </forDocTypes>
+    <supportsSingleDoc>false</supportsSingleDoc>
+    <supportsDocList>true</supportsDocList>
+    <supportsGroup>false</supportsGroup>
+    <supportsNoContext>true</supportsNoContext>
+    <filename>duplicateobjectnumber.jrxml</filename>
+    <outputMIME>application/pdf</outputMIME>
+  </ns2:reports_common>
+</document>


### PR DESCRIPTION
**What does this do?**
* Adds report for detecting duplicate object numbers to the botgarden profile

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/jira/software/c/projects/DRYD/issues/DRYD-1248

This is part of the UCB bundle and is a report which can easily be added without needing other parts of the bundle. It appears to be for botgarden (see the join on `collectionobjects_naturalhistory`), so I've opted to only register it in the botgarden tenant bindings.

Changes to the original inclusion in the bundle are fairly minor, I believe I just ran the report through an xml formatter and updated some of the overflow rules to use the `textAdjust` attribute.

**How should this be tested? Do these changes have associated tests?**
* Build collectionspace with the botgarden tenant enabled
* Verify the `Duplicate Object Report` can be seen when searching for collectionobjects
* Verify that the `Duplicate Object Report` can be run

**Dependencies for merging? Releasing to production?**
Additional changes might be made to the registration payload -- we should verify how the report should be run so we know which `supports` flags to use. @remillet might be able to give some insight on this point.

There are some updates we can make to the report as well that I didn't do:
* Add tenantId parameter and add additional clause for core.tenantid = tenantid
  * This would bring the report more in line with the other reports, though not a major issue 
* Use the `deurnfields` parameter on `tig.taxon` (determination) and `fc.item` (collector)
  * Once again not major, just helps to clean up the query a little

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter has only verified that the sql and report execute, needs to run against dataset with duplicate object numbers