### PR TITLE
Add SAML providers to CORS allowed hosts.

### DIFF
--- a/services/config/src/main/java/org/collectionspace/services/common/config/ConfigUtils.java
+++ b/services/config/src/main/java/org/collectionspace/services/common/config/ConfigUtils.java
@@ -207,6 +207,16 @@ public class ConfigUtils {
 		return (samlRegistrations != null && samlRegistrations.size() > 0);
 	}
 
+	public static String getUIBaseUrl(TenantBindingType tenantBinding) {
+		UIConfig uiConfig = tenantBinding.getUiConfig();
+
+		if (uiConfig != null) {
+			return uiConfig.getBaseUrl();
+		}
+
+		return null;
+	}
+
 	public static String getUILoginSuccessUrl(TenantBindingType tenantBinding) throws MalformedURLException {
 		UIConfig uiConfig = tenantBinding.getUiConfig();
 


### PR DESCRIPTION
**What does this do?**

This fixes a CORS error that happens during SAML logins. During the login process, the SAML identity provider needs to POST to a CSpace services endpoint. In order to allow this POST, the CORS configuration for that endpoint needs to have the SAML IdP added to its allowed origins.

**Why are we doing this? (with JIRA link)**

This is part of the SAML implementation work.

JIRA: https://collectionspace.atlassian.net/browse/DRYD-1243

**How should this be tested? Do these changes have associated tests?**

Login using SAML on the dev server should work, without any CORS errors.

**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran this locally.