### PR TITLE
Add SAML providers to CORS allowed hosts for logout.

### DIFF
--- a/services/config/src/main/java/org/collectionspace/services/common/config/ConfigUtils.java
+++ b/services/config/src/main/java/org/collectionspace/services/common/config/ConfigUtils.java
@@ -187,6 +187,16 @@ public class ConfigUtils {
 		return null;
 	}
 
+	public static boolean isSAMLSingleLogoutEnabled(ServiceConfig serviceConfig) {
+		SAMLType saml = getSAML(serviceConfig);
+
+		if (saml != null) {
+			return (saml.getSingleLogout() != null);
+		}
+
+		return false;
+	}
+
 	public static List<SAMLRelyingPartyType> getSAMLRelyingPartyRegistrations(ServiceConfig serviceConfig) {
 		SAMLType saml = getSAML(serviceConfig);
 


### PR DESCRIPTION
**What does this do?**

This fixes a CORS error that happens during SAML logouts. During the logout process, the SAML identity provider needs to POST to a CSpace services endpoint. In order to allow this POST, the CORS configuration for that endpoint needs to have the SAML IdP added to its allowed origins.

This is similar to #367, but for logout instead of login.

**Why are we doing this? (with JIRA link)**

This is part of the SAML implementation work.

JIRA: https://collectionspace.atlassian.net/browse/DRYD-1243

**How should this be tested? Do these changes have associated tests?**

When SAML single logout is enabled, logout from a SAML account on the dev server should work, without any CORS errors.

**Dependencies for merging? Releasing to production?**

None

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran this locally.