### PR TITLE
Workflow Reports and Report Updates

### DIFF
--- a/services/common/src/main/cspace/config/services/tenants/fcart/fcart-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/fcart/fcart-tenant-bindings.delta.xml
@@ -270,5 +270,14 @@
 				}
 			</tenant:mapping>
 		</tenant:elasticSearchIndexConfig>
+
+		<tenant:serviceBindings merge:matcher="id" id="Reports">
+			<service:properties xmlns:service="http://collectionspace.org/services/config/service" xmlns:types="http://collectionspace.org/services/config/types">
+				<types:item merge:matcher="skip" merge:action="insert">
+					<types:key>report</types:key>
+					<types:value>artwork_description</types:value>
+				</types:item>
+			</service:properties>
+		</tenant:serviceBindings>
 	</tenant:tenantBinding>
 </tenant:TenantBindingConfig>

--- a/services/common/src/main/cspace/config/services/tenants/publicart/publicart-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/publicart/publicart-tenant-bindings.delta.xml
@@ -22,6 +22,10 @@
 					<types:key>report</types:key>
 					<types:value>tombstone_with_creator</types:value>
 				</types:item>
+				<types:item merge:matcher="skip" merge:action="insert">
+					<types:key>report</types:key>
+					<types:value>full_obj_place</types:value>
+				</types:item>
 			</service:properties>
 		</tenant:serviceBindings>
 	</tenant:tenantBinding>

--- a/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
+++ b/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
@@ -701,6 +701,10 @@
 					<types:key>report</types:key>
 					<types:value>outgoing_loan</types:value>
 				</types:item>
+				<types:item>
+					<types:key>report</types:key>
+					<types:value>borrowing_receipt</types:value>
+				</types:item>
 			</service:properties>
 			<service:object xmlns:service="http://collectionspace.org/services/config/service" name="Report"
 				version="1.0">

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/accessions.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/accessions.jrxml
@@ -19,7 +19,7 @@
 	<style name="Column header" fontName="SansSerif" fontSize="12" isBold="true"/>
 	<style name="Detail" fontName="SansSerif" fontSize="12"/>
 	<parameter name="deurnfields" class="java.lang.String" isForPrompting="false">
-		<defaultValueExpression><![CDATA["acquisitionsource"]]></defaultValueExpression>
+		<defaultValueExpression><![CDATA["acquisitionsource,objectname"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="tenantid" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA["1"]]></defaultValueExpression>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/accessions.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/accessions.jrxml
@@ -75,7 +75,7 @@
   FROM acquisitions acq
   INNER JOIN relations_common rels ON rels.subjectcsid = acq.csid AND rels.objectdocumenttype = 'CollectionObject'
   INNER JOIN misc on misc.id = rels.id AND misc.lifecyclestate != 'deleted'
-  INNER JOIN hierarchy hier ON hier.name = rels.objectcsid AND hier.primarytype = 'CollectionObject'
+  INNER JOIN hierarchy hier ON hier.name = rels.objectcsid
   INNER JOIN collectionobjects_common object ON object.id = hier.id
   LEFT JOIN collectionobjects_common_briefdescriptions bd ON bd.id = object.id AND bd.pos = 0
   LEFT JOIN hierarchy ong_hier ON ong_hier.parentid = object.id AND ong_hier.primarytype = 'objectNameGroup' AND ong_hier.pos = 0

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/artwork_description.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/artwork_description.jrxml
@@ -1,0 +1,260 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 6.20.1.final using JasperReports Library version 6.20.1-7584acb244139816654f64e2fd57a00d3e31921e  -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="artwork_description" pageWidth="1000" pageHeight="800" orientation="Landscape" columnWidth="100" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isIgnorePagination="true" uuid="49b29b35-57c3-422f-8699-01975b0a33f9">
+	<property name="com.jaspersoft.studio.data.sql.tables" value=""/>
+	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="nuxeo"/>
+	<property name="com.jaspersoft.studio.data.sql.SQLQueryDesigner.sash.w1" value="193"/>
+	<property name="com.jaspersoft.studio.data.sql.SQLQueryDesigner.sash.w2" value="800"/>
+	<property name="com.jaspersoft.studio.property.dataset.dialog.DatasetDialog.sash.w1" value="625"/>
+	<property name="com.jaspersoft.studio.property.dataset.dialog.DatasetDialog.sash.w2" value="361"/>
+	<style name="Column header" fontName="SansSerif" fontSize="12" isBold="true"/>
+	<style name="Detail" fontName="SansSerif" fontSize="12"/>
+	<parameter name="deurnfields" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA["objectproductionperson"]]></defaultValueExpression>
+	</parameter>
+	<parameter name="tenantid" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA["1"]]></defaultValueExpression>
+	</parameter>
+	<parameter name="csid" class="java.lang.String" isForPrompting="false"/>
+	<parameter name="whereclause" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA[$P{csid} != null ?  "WHERE hier.name = '" + $P{csid} + "'"  : ""]]></defaultValueExpression>
+	</parameter>
+	<queryString language="SQL">
+		<![CDATA[SELECT
+	obj.objectnumber,
+	ong.objectname,
+	tg.title,
+	person.objectproductionperson,
+	sdg.datedisplaydate,
+	fineart.materialtechniquedescription,
+	material.material,
+	technique.technique,
+	dimension.dimension,
+	media.objectcsid AS mediacsid
+FROM collectionobjects_common obj
+INNER JOIN hierarchy hier on hier.id = obj.id
+INNER JOIN misc ON misc.id = obj.id and misc.lifecyclestate != 'deleted'
+INNER JOIN collectionspace_core core ON misc.id = core.id AND core.tenantid = $P{tenantid}
+LEFT JOIN collectionobjects_fineart fineart ON fineart.id = obj.id
+LEFT JOIN hierarchy ong_hier ON ong_hier.parentid = obj.id AND ong_hier.primarytype = 'objectNameGroup' AND ong_hier.pos = 0
+LEFT JOIN objectnamegroup ong ON ong.id = ong_hier.id
+LEFT JOIN hierarchy title_hier ON title_hier.parentid = obj.id AND title_hier.primarytype = 'titleGroup' AND title_hier.pos = 0
+LEFT JOIN titlegroup tg ON tg.id = title_hier.id
+LEFT JOIN hierarchy person_hier ON person_hier.parentid = obj.id AND person_hier.primarytype = 'objectProductionPersonGroup' AND person_hier.pos = 0
+LEFT JOIN objectproductionpersongroup person ON person.id = person_hier.id
+LEFT JOIN hierarchy sdg_hier ON sdg_hier.parentid = obj.id AND sdg_hier.primarytype = 'structuredDateGroup' AND sdg_hier.name = 'collectionobjects_common:objectProductionDateGroupList' AND sdg_hier.pos = 0
+LEFT JOIN structureddategroup sdg ON sdg.id = sdg_hier.id
+LEFT JOIN hierarchy material_hier on material_hier.parentid = obj.id and material_hier.primarytype = 'materialGroup' and material_hier.pos = 0
+LEFT JOIN materialgroup material on material.id = material_hier.id
+LEFT JOIN hierarchy technique_hier on technique_hier.parentid = obj.id and technique_hier.primarytype = 'techniqueGroup' and technique_hier.pos = 0
+LEFT JOIN techniquegroup technique on technique.id = technique_hier.id
+LEFT JOIN (
+ SELECT
+	measured_hier.parentid,
+	string_agg(concat(dimension.dimension, ' ', dimension.value::text, ' ', dimension.measurementunit), ' | ') AS dimension
+	FROM hierarchy measured_hier
+	INNER JOIN hierarchy dimension_hier on dimension_hier.parentid = measured_hier.id and dimension_hier.primarytype = 'dimensionSubGroup'
+	LEFT JOIN dimensionsubgroup dimension on dimension.id = dimension_hier.id
+	WHERE measured_hier.primarytype = 'measuredPartGroup'
+	GROUP BY measured_hier.parentid
+) dimension on dimension.parentid = obj.id
+LEFT JOIN (
+	SELECT relation.*
+	FROM relations_common relation
+	INNER JOIN misc ON misc.id = relation.id AND misc.lifecyclestate != 'deleted'
+	WHERE relation.objectdocumenttype = 'Media' AND relation.subjectdocumenttype = 'CollectionObject'
+) media ON media.subjectcsid = hier.name
+$P!{whereclause}]]>
+	</queryString>
+	<field name="objectnumber" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="objectnumber"/>
+		<property name="com.jaspersoft.studio.field.label" value="objectnumber"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="collectionobjects_common"/>
+	</field>
+	<field name="objectname" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="objectname"/>
+		<property name="com.jaspersoft.studio.field.label" value="objectname"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="objectnamegroup"/>
+	</field>
+	<field name="title" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="title"/>
+		<property name="com.jaspersoft.studio.field.label" value="title"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="titlegroup"/>
+	</field>
+	<field name="objectproductionperson" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="objectproductionperson"/>
+		<property name="com.jaspersoft.studio.field.label" value="objectproductionperson"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="objectproductionpersongroup"/>
+	</field>
+	<field name="datedisplaydate" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="datedisplaydate"/>
+		<property name="com.jaspersoft.studio.field.label" value="datedisplaydate"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="structureddategroup"/>
+	</field>
+	<field name="materialtechniquedescription" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="materialtechniquedescription"/>
+		<property name="com.jaspersoft.studio.field.label" value="materialtechniquedescription"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="collectionobjects_fineart"/>
+	</field>
+	<field name="material" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="material"/>
+		<property name="com.jaspersoft.studio.field.label" value="material"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="materialgroup"/>
+	</field>
+	<field name="technique" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="technique"/>
+		<property name="com.jaspersoft.studio.field.label" value="technique"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="techniquegroup"/>
+	</field>
+	<field name="dimension" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="dimension"/>
+		<property name="com.jaspersoft.studio.field.label" value="dimension"/>
+	</field>
+	<field name="mediacsid" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="mediacsid"/>
+		<property name="com.jaspersoft.studio.field.label" value="mediacsid"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="relations_common"/>
+	</field>
+	<background>
+		<band splitType="Stretch"/>
+	</background>
+	<columnHeader>
+		<band height="44" splitType="Stretch">
+			<property name="com.jaspersoft.studio.layout" value="com.jaspersoft.studio.editor.layout.FreeLayout"/>
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+			<staticText>
+				<reportElement style="Column header" x="0" y="0" width="100" height="44" uuid="a25b7e00-dc64-44b8-b3cb-c02e4eea961f">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Object Number]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="100" y="0" width="100" height="44" uuid="3e25ffb6-3606-4fbd-bb2a-6eeece4f41e9">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Object Name]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="200" y="0" width="100" height="44" uuid="b4efbef7-3e35-4796-8993-d7022342b6d4">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Title]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="300" y="0" width="100" height="44" uuid="3cdbd088-f8c3-442e-974b-374bb2d3a14c">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Production Person]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="400" y="0" width="100" height="44" uuid="8e0edd98-6f3f-4bd3-a0a2-b3c6b2306376">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Production Date]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="500" y="0" width="100" height="44" uuid="cc8bc8f2-e0cc-45e6-b1f2-a761a9b845cd">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Material/Technique Description]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="600" y="0" width="100" height="44" uuid="d98f1448-ad69-4028-b5ec-63569ff66044">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Material]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="700" y="0" width="100" height="44" uuid="c0b8e895-2d26-4ea9-93e1-43154dc113fe">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Production Technique]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="800" y="0" width="100" height="44" uuid="c72ea836-2194-4c87-aca3-0db148c21ac2">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Measurement]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="900" y="0" width="100" height="44" uuid="d81a8943-8525-42ba-815d-32c7dbf837af">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Media]]></text>
+			</staticText>
+		</band>
+	</columnHeader>
+	<detail>
+		<band height="66" splitType="Stretch">
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="0" y="0" width="100" height="30" uuid="a94b63dc-6a68-47b3-9843-016b65caf79d">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{objectnumber}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="100" y="0" width="100" height="30" uuid="484788ab-011c-4079-998c-81f6666f8533">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{objectname}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="200" y="0" width="100" height="30" uuid="d892212f-d882-4478-89ed-60cef306a91e">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{title}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="300" y="0" width="100" height="30" uuid="4e01762a-9a31-4327-bc3a-6bd4442fa784">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{objectproductionperson}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="400" y="0" width="100" height="30" uuid="f2da256f-bdda-44bb-8e58-98b115eee361">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{datedisplaydate}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="500" y="0" width="100" height="30" uuid="a623c09c-2415-40cc-b121-4a275f2e887f">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{materialtechniquedescription}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="600" y="0" width="100" height="30" uuid="33ab16b3-d35c-4d66-8c53-c304de906ba1">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{material}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="700" y="0" width="100" height="30" uuid="95326767-7dd8-46db-a369-a296437d5a05">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{technique}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="800" y="0" width="100" height="30" uuid="b5e03fd0-1d20-48b1-a7a6-1e195285b228">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{dimension}]]></textFieldExpression>
+			</textField>
+			<image onErrorType="Blank">
+				<reportElement x="900" y="0" width="50" height="50" uuid="e0d804b1-8cf5-4db9-a910-515e6239210a" />
+				<imageExpression><![CDATA["cspace://media/" + $F{mediacsid} + "/blob/derivatives/Thumbnail/content"]]></imageExpression>
+			</image>
+		</band>
+	</detail>
+</jasperReport>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/artwork_description.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/artwork_description.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<document name="report">
+  <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
+    <name>Artwork Description</name>
+    <notes>Artwork Description</notes>
+    <forDocTypes>
+      <forDocType>CollectionObject</forDocType>
+    </forDocTypes>
+    <supportsSingleDoc>true</supportsSingleDoc>
+    <supportsDocList>false</supportsDocList>
+    <supportsGroup>false</supportsGroup>
+    <supportsNoContext>true</supportsNoContext>
+    <filename>artwork_description.jrxml</filename>
+    <outputMIME>text/csv</outputMIME>
+  </ns2:reports_common>
+</document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/borrowing_receipt.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/borrowing_receipt.jrxml
@@ -1,0 +1,240 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 6.20.1.final using JasperReports Library version 6.20.1-7584acb244139816654f64e2fd57a00d3e31921e  -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="borrowing_receipt" pageWidth="1000" pageHeight="800" orientation="Landscape" columnWidth="100" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isIgnorePagination="true" uuid="69c8cb28-5625-4a2b-a2ca-34fb3800a6d8">
+	<property name="com.jaspersoft.studio.data.sql.tables" value=""/>
+	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="nuxeo"/>
+	<property name="com.jaspersoft.studio.data.sql.SQLQueryDesigner.sash.w1" value="193"/>
+	<property name="com.jaspersoft.studio.data.sql.SQLQueryDesigner.sash.w2" value="800"/>
+	<property name="com.jaspersoft.studio.property.dataset.dialog.DatasetDialog.sash.w1" value="625"/>
+	<property name="com.jaspersoft.studio.property.dataset.dialog.DatasetDialog.sash.w2" value="361"/>
+	<style name="Column header" fontName="SansSerif" fontSize="12" isBold="true"/>
+	<style name="Detail" fontName="SansSerif" fontSize="12"/>
+	<parameter name="deurnfields" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA["borrower,objectproductionperson,computedcurrentlocation"]]></defaultValueExpression>
+	</parameter>
+	<parameter name="tenantid" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA["1"]]></defaultValueExpression>
+	</parameter>
+	<parameter name="csid" class="java.lang.String" isForPrompting="false"/>
+	<parameter name="whereclause" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA[$P{csid} != null ?  "WHERE hier.name = '" + $P{csid} + "'"  : ""]]></defaultValueExpression>
+	</parameter>
+	<queryString language="SQL">
+		<![CDATA[SELECT
+	loan.loanoutnumber,
+	loan.borrower,
+	object.objectnumber,
+	object.objectname,
+	object.title,
+	object.objectproductionperson,
+	object.objectproductiondate,
+	object.computedcurrentlocation,
+	object.mediacsid
+FROM loansout_common loan
+INNER JOIN hierarchy hier ON hier.id = loan.id
+INNER JOIN misc ON misc.id = loan.id AND misc.lifecyclestate != 'deleted'
+INNER JOIN collectionspace_core core ON misc.id = core.id AND core.tenantid = $P{tenantid}
+-- related objects
+LEFT JOIN (
+	SELECT
+		hier.name AS csid,
+		relation.subjectcsid,
+		obj.objectnumber,
+		obj.computedcurrentlocation,
+		ong.objectname,
+		tg.title,
+		person.objectproductionperson,
+		sdg.datedisplaydate AS objectproductiondate,
+		media.objectcsid AS mediacsid
+	FROM collectionobjects_common obj
+	INNER JOIN hierarchy hier ON hier.id = obj.id
+	INNER JOIN misc on misc.id = obj.id AND misc.lifecyclestate != 'deleted'
+	INNER JOIN relations_common relation ON relation.objectcsid = hier.name
+		AND relation.subjectdocumenttype = 'Loanout'
+		AND relation.objectdocumenttype = 'CollectionObject'
+	LEFT JOIN hierarchy ong_hier ON ong_hier.parentid = obj.id AND ong_hier.primarytype = 'objectNameGroup' AND ong_hier.pos = 0
+	LEFT JOIN objectnamegroup ong ON ong.id = ong_hier.id
+	LEFT JOIN hierarchy title_hier ON title_hier.parentid = obj.id AND title_hier.primarytype = 'titleGroup' AND title_hier.pos = 0
+	LEFT JOIN titlegroup tg ON tg.id = title_hier.id
+	LEFT JOIN hierarchy person_hier ON person_hier.parentid = obj.id AND person_hier.primarytype = 'objectProductionPersonGroup' AND person_hier.pos = 0
+	LEFT JOIN objectproductionpersongroup person ON person.id = person_hier.id
+	LEFT JOIN hierarchy sdg_hier ON sdg_hier.parentid = obj.id AND sdg_hier.primarytype = 'structuredDateGroup' AND sdg_hier.name = 'collectionobjects_common:objectProductionDateGroupList' AND sdg_hier.pos = 0
+	LEFT JOIN structureddategroup sdg ON sdg.id = sdg_hier.id
+	LEFT JOIN relations_common media ON media.subjectcsid = hier.name AND media.objectdocumenttype = 'Media' AND media.subjectdocumenttype = 'CollectionObject'
+) object ON object.subjectcsid = hier.name
+$P!{whereclause}]]>
+	</queryString>
+	<field name="loanoutnumber" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="loanoutnumber"/>
+		<property name="com.jaspersoft.studio.field.label" value="loanoutnumber"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="loansout_common"/>
+	</field>
+	<field name="borrower" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="borrower"/>
+		<property name="com.jaspersoft.studio.field.label" value="borrower"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="loansout_common"/>
+	</field>
+	<field name="objectnumber" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="objectnumber"/>
+		<property name="com.jaspersoft.studio.field.label" value="objectnumber"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="collectionobjects_common"/>
+	</field>
+	<field name="objectname" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="objectname"/>
+		<property name="com.jaspersoft.studio.field.label" value="objectname"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="collectionobjects_common"/>
+	</field>
+	<field name="title" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="title"/>
+		<property name="com.jaspersoft.studio.field.label" value="title"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="collectionobjects_common"/>
+	</field>
+	<field name="objectproductionperson" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="objectproductionperson"/>
+		<property name="com.jaspersoft.studio.field.label" value="objectproductionperson"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="collectionobjects_common"/>
+	</field>
+	<field name="objectproductiondate" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="objectproductiondate"/>
+		<property name="com.jaspersoft.studio.field.label" value="objectproductiondate"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="collectionobjects_common"/>
+	</field>
+	<field name="computedcurrentlocation" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="computedcurrentlocation"/>
+		<property name="com.jaspersoft.studio.field.label" value="computedcurrentlocation"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="collectionobjects_common"/>
+	</field>
+	<field name="mediacsid" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="mediacsid"/>
+		<property name="com.jaspersoft.studio.field.label" value="mediacsid"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="collectionobjects_common"/>
+	</field>
+	<background>
+		<band splitType="Stretch"/>
+	</background>
+	<columnHeader>
+		<band height="44" splitType="Stretch">
+			<property name="com.jaspersoft.studio.layout" value="com.jaspersoft.studio.editor.layout.FreeLayout"/>
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+			<staticText>
+				<reportElement style="Column header" x="0" y="0" width="100" height="44" uuid="c4532d84-99ec-4168-93e8-73d986ed72af">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[LoanOut Number]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="100" y="0" width="100" height="44" uuid="4e891d6f-4ff0-4b2f-9af0-7336d90acd22">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Borrower]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="200" y="0" width="100" height="44" uuid="cb4ccc79-dbbe-47ce-9b71-7c9746016278">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Object Number]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="300" y="0" width="100" height="44" uuid="3cad2341-164c-41cc-860f-e888e366958e">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Object Name]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="400" y="0" width="100" height="44" uuid="a8ef0763-9326-4005-9400-d79dcce96245">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Object Title]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="500" y="0" width="100" height="44" uuid="dc6b337c-ce38-430b-8b82-beccc4c3e5e1">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Production Person]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="600" y="0" width="100" height="44" uuid="8edfffc1-e100-4af0-bae4-f582573ede1e">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Production Date]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="700" y="0" width="100" height="44" uuid="86f1f4b9-0dc8-49af-a3d7-30a8da89114c">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Current Location]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="800" y="0" width="100" height="44" uuid="e50a7d74-c6f3-4070-b7b0-466f485aeadf">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Related Media]]></text>
+			</staticText>
+		</band>
+	</columnHeader>
+	<detail>
+		<band height="66" splitType="Stretch">
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="0" y="0" width="100" height="30" uuid="cbab2f64-4b56-44ec-bfc8-a87b1180e6f1">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{loanoutnumber}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="100" y="0" width="100" height="30" uuid="062d0cd8-6943-4570-82c3-54dededf6943">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{borrower}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="200" y="0" width="100" height="30" uuid="22b386e5-f43d-4dcc-abc6-fbc5387d10d7">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{objectnumber}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="300" y="0" width="100" height="30" uuid="75357bf9-2789-41e5-9d31-4ff8ddaf544f">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{objectname}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="400" y="0" width="100" height="30" uuid="17ee49b8-7c2d-4ebb-a61b-93945a51a90c">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{title}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="500" y="0" width="100" height="30" uuid="2604982b-936d-4bb8-a615-7ebf5edd3e39">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{objectproductionperson}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="600" y="0" width="100" height="30" uuid="d735f6df-c949-4bbd-bc2b-d7df2bf2cdd9">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{objectproductiondate}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="700" y="0" width="100" height="30" uuid="1be89a70-b461-4907-b2d2-a43440f61723">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{computedcurrentlocation}]]></textFieldExpression>
+			</textField>
+			<image onErrorType="Blank">
+				<reportElement x="800" y="0" width="50" height="50" uuid="a7c10fcc-0020-478b-bcfe-cb191daa365f"/>
+				<imageExpression><![CDATA["cspace://media/" + $F{mediacsid} + "/blob/derivatives/Thumbnail/content"]]></imageExpression>
+			</image>
+		</band>
+	</detail>
+</jasperReport>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/borrowing_receipt.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/borrowing_receipt.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<document name="report">
+  <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
+    <name>Borrowing Receipt</name>
+    <notes>Borrowing Receipt</notes>
+    <forDocTypes>
+      <forDocType>Loanout</forDocType>
+    </forDocTypes>
+    <supportsSingleDoc>true</supportsSingleDoc>
+    <supportsDocList>false</supportsDocList>
+    <supportsGroup>false</supportsGroup>
+    <supportsNoContext>true</supportsNoContext>
+    <filename>borrowing_receipt.jrxml</filename>
+    <outputMIME>text/csv</outputMIME>
+  </ns2:reports_common>
+</document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/box_list.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/box_list.jrxml
@@ -35,7 +35,7 @@
   FROM lmis lmi
   INNER JOIN relations_common rels ON rels.subjectcsid = lmi.csid AND rels.objectdocumenttype = 'CollectionObject'
   INNER JOIN misc ON misc.id = rels.id AND misc.lifecyclestate != 'deleted'
-  INNER JOIN hierarchy hier ON hier.name = rels.objectcsid AND hier.primarytype = 'CollectionObject'
+  INNER JOIN hierarchy hier ON hier.name = rels.objectcsid
   INNER JOIN collectionobjects_common co ON co.id = hier.id
 ), objectnames AS (
   SELECT ong.objectname, co.csid AS objectcsid

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/deaccessions.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/deaccessions.jrxml
@@ -10,7 +10,7 @@
 	<style name="Column header" fontName="SansSerif" fontSize="12" isBold="true"/>
 	<style name="Detail" fontName="SansSerif" fontSize="12"/>
 	<parameter name="deurnfields" class="java.lang.String" isForPrompting="false">
-		<defaultValueExpression><![CDATA["disposalmethod"]]></defaultValueExpression>
+		<defaultValueExpression><![CDATA["disposalmethod,objectname"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="tenantid" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA["1"]]></defaultValueExpression>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/deed_of_gift.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/deed_of_gift.jrxml
@@ -21,6 +21,9 @@
 	<property name="com.jaspersoft.studio.unit.columnSpacing" value="pixel"/>
 	<style name="Column header" fontName="SansSerif" fontSize="12" isBold="true"/>
 	<style name="Detail" fontName="SansSerif" fontSize="12"/>
+	<parameter name="deurnfields" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA["objectname"]]></defaultValueExpression>
+	</parameter>
 	<parameter name="tenantid" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA["1"]]></defaultValueExpression>
 	</parameter>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/deed_of_gift.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/deed_of_gift.jrxml
@@ -60,7 +60,7 @@
   FROM intakes intake
   INNER JOIN relations_common rels ON rels.subjectcsid = intake.csid AND rels.objectdocumenttype = 'CollectionObject'
   INNER JOIN misc on misc.id = rels.id AND misc.lifecyclestate != 'deleted'
-  INNER JOIN hierarchy hier ON hier.name = rels.objectcsid AND hier.primarytype = 'CollectionObject'
+  INNER JOIN hierarchy hier ON hier.name = rels.objectcsid
   INNER JOIN collectionobjects_common object ON object.id = hier.id
   LEFT JOIN collectionobjects_common_briefdescriptions bd ON bd.id = object.id AND bd.pos = 0
   LEFT JOIN hierarchy ong_hier ON ong_hier.parentid = object.id AND ong_hier.primarytype = 'objectNameGroup' AND ong_hier.pos = 0

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/full_obj_place.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/full_obj_place.jrxml
@@ -1,0 +1,803 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 6.20.1.final using JasperReports Library version 6.20.1-7584acb244139816654f64e2fd57a00d3e31921e  -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="obj_full_place" pageWidth="3800" pageHeight="800" orientation="Landscape" columnWidth="100" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isIgnorePagination="true" uuid="f6c7eb78-afcd-4bd5-9a53-61ee9a1f43f8">
+	<property name="com.jaspersoft.studio.data.sql.tables" value=""/>
+	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="nuxeo"/>
+	<property name="com.jaspersoft.studio.data.sql.SQLQueryDesigner.sash.w1" value="193"/>
+	<property name="com.jaspersoft.studio.data.sql.SQLQueryDesigner.sash.w2" value="800"/>
+	<property name="com.jaspersoft.studio.property.dataset.dialog.DatasetDialog.sash.w1" value="625"/>
+	<property name="com.jaspersoft.studio.property.dataset.dialog.DatasetDialog.sash.w2" value="361"/>
+	<style name="Column header" fontName="SansSerif" fontSize="12" isBold="true"/>
+	<style name="Detail" fontName="SansSerif" fontSize="12"/>
+	<parameter name="deurnfields" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA["publicartproductiondatetype,publicartproductionperson,publicartproductionpersonrole,responsibledepartment,publishto,installationtype,worktype,material,collection,owner,computedcurrentlocation,placementtype,placetype,placeowner,addressmunicipality,addressstateorprovince,addresscountry,addresstype,addresstype,broaderplace"]]></defaultValueExpression>
+	</parameter>
+	<parameter name="tenantid" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA["5000"]]></defaultValueExpression>
+	</parameter>
+	<parameter name="csid" class="java.lang.String" isForPrompting="false"/>
+	<parameter name="whereclause" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA[$P{csid} != null ? "WHERE hier.name = '" + $P{csid} + "'" : ""]]></defaultValueExpression>
+	</parameter>
+	<queryString language="SQL">
+		<![CDATA[SELECT
+	obj.objectnumber,
+	tg.title,
+	dategroup.publicartproductiondatetype,
+	proddate.datedisplaydate AS objectproductiondate,
+	creator.publicartproductionperson,
+	creator.publicartproductionpersonrole,
+	rd.item AS responsibledepartment,
+	obj.recordstatus,
+	publishto.item AS publishto,
+	installationtype.item AS installationtype,
+	obj.numberofobjects,
+	worktype.objectname AS worktype,
+	material.material, -- deurn
+	bd.item AS briefdescription,
+	comment.item AS comment,
+	collections.item AS collection,
+	owners.item AS owner,
+	dimension.dimension,
+	obj.computedcurrentlocation,
+	movement.currentlocationnote,
+	placement.item AS placementtype,
+	place_pa.placementenvironment,
+	placetype.item AS placetype,
+	placeowner.owner AS placeowner,
+	placeowner.ownershipnote,
+	placeowner.ownertype,
+	placeownerdate.datedisplaydate AS ownershipdate,
+	address.addressplace1,
+	address.addressplace2,
+	address.addressmunicipality,
+	address.addressstateorprovince,
+	address.addresscountry,
+	address.addresstype,
+	address.addresspostcode,
+	geo.decimallatitude,
+	geo.decimallongitude,
+	broaderplace.objectrefname AS broaderplace
+FROM collectionobjects_common obj
+INNER JOIN hierarchy hier on hier.id = obj.id
+INNER JOIN misc ON misc.id = obj.id and misc.lifecyclestate != 'deleted'
+INNER JOIN collectionspace_core core ON misc.id = core.id AND core.tenantid = $P{tenantid}
+LEFT JOIN hierarchy title_hier ON title_hier.parentid = obj.id AND title_hier.primarytype = 'titleGroup' AND title_hier.pos = 0
+LEFT JOIN titlegroup tg ON tg.id = title_hier.id
+LEFT JOIN hierarchy proddategroup_hier ON proddategroup_hier.parentid = obj.id AND proddategroup_hier.primarytype = 'publicartProductionDateGroup' AND proddategroup_hier.pos = 0
+LEFT JOIN publicartproductiondategroup dategroup ON dategroup.id = proddategroup_hier.id
+LEFT JOIN hierarchy proddate_hier ON proddate_hier.parentid = proddategroup_hier.id
+LEFT JOIN structureddategroup proddate ON proddate.id = proddate_hier.id
+LEFT JOIN hierarchy creator_hier ON creator_hier.parentid = obj.id AND creator_hier.primarytype = 'publicartProductionPersonGroup' AND creator_hier.pos = 0
+LEFT JOIN publicartproductionpersongroup creator ON creator.id = creator_hier.id
+LEFT JOIN collectionobjects_common_responsibledepartments rd ON rd.id = obj.id AND rd.pos = 0
+LEFT JOIN collectionobjects_common_publishtolist publishto ON publishto.id = obj.id AND publishto.pos = 0
+LEFT JOIN collectionobjects_common_inventorystatuslist installationtype ON installationtype.id = obj.id AND installationtype.pos = 0
+LEFT JOIN collectionobjects_common_briefdescriptions bd ON bd.id = obj.id AND bd.pos = 0
+LEFT JOIN collectionobjects_common_comments comment ON comment.id = obj.id AND comment.pos = 0
+LEFT JOIN hierarchy work_hier on work_hier.parentid = obj.id and work_hier.primarytype = 'objectNameGroup' and work_hier.pos = 0
+LEFT JOIN objectnamegroup worktype on worktype.id = work_hier.id
+LEFT JOIN hierarchy material_hier on material_hier.parentid = obj.id and material_hier.primarytype = 'materialGroup' and material_hier.pos = 0
+LEFT JOIN materialgroup material on material.id = material_hier.id
+LEFT JOIN collectionobjects_publicart_publicartcollections collections ON collections.id = obj.id AND collections.pos = 0
+LEFT JOIN collectionobjects_common_owners owners ON owners.id = obj.id AND owners.pos = 0
+-- aggregate for the dimension
+LEFT JOIN (
+	SELECT
+		measured_hier.parentid,
+		string_agg(concat(dimension.dimension, ' ', dimension.value::text, ' ', dimension.measurementunit), ' | ') AS dimension
+	FROM hierarchy measured_hier
+	INNER JOIN hierarchy dimension_hier on dimension_hier.parentid = measured_hier.id and dimension_hier.primarytype = 'dimensionSubGroup'
+	LEFT JOIN dimensionsubgroup dimension on dimension.id = dimension_hier.id
+	WHERE measured_hier.primarytype = 'measuredPartGroup'
+	GROUP BY measured_hier.parentid
+) dimension on dimension.parentid = obj.id
+-- get the correct movement from relation + computed location
+LEFT JOIN (
+	SELECT
+		relation.objectcsid,
+		movement.currentlocation,
+		movement.currentlocationnote
+	FROM relations_common relation
+	INNER JOIN misc ON misc.id = relation.id AND misc.lifecyclestate != 'deleted'
+	INNER JOIN hierarchy hier ON hier.name = relation.subjectcsid
+	INNER JOIN movements_common movement ON movement.id = hier.id
+	WHERE relation.objectdocumenttype = 'CollectionObject' AND relation.subjectdocumenttype = 'Movement'
+) movement ON movement.objectcsid = hier.name AND movement.currentlocation = obj.computedcurrentlocation
+-- place and all place fields
+LEFT JOIN places_common place on place.refname = obj.computedcurrentlocation
+LEFT JOIN places_publicart_placementtypes placement on placement.id = place.id AND placement.pos = 0
+LEFT JOIN places_publicart place_pa on place_pa.id = place.id
+LEFT JOIN places_publicart_publicartplacetypes placetype on placetype.id = place.id AND placetype.pos = 0
+LEFT JOIN hierarchy placeowner_hier on placeowner_hier.parentid = place.id and placeowner_hier.primarytype = 'publicartPlaceOwnerGroup' and placeowner_hier.pos = 0
+LEFT JOIN hierarchy placeownerdate_hier on placeownerdate_hier.parentid = placeowner_hier.id
+LEFT JOIN publicartplaceownergroup placeowner on placeowner.id = placeowner_hier.id
+LEFT JOIN structureddategroup placeownerdate on placeownerdate.id = placeownerdate_hier.id
+LEFT JOIN hierarchy addr_hier ON addr_hier.parentid = place.id AND addr_hier.primarytype = 'addrGroup' AND addr_hier.pos = 0
+LEFT JOIN addrgroup address ON address.id = addr_hier.id
+LEFT JOIN hierarchy geo_hier ON geo_hier.parentid = place.id AND geo_hier.primarytype = 'placeGeoRefGroup' AND geo_hier.pos = 0
+LEFT JOIN placegeorefgroup geo ON geo.id = geo_hier.id
+LEFT JOIN hierarchy place_hier on place_hier.id = place.id
+LEFT JOIN relations_common broaderplace ON broaderplace.subjectcsid = place_hier.name AND broaderplace.relationshiptype = 'hasBroader'
+$P!{whereclause}]]>
+	</queryString>
+	<field name="objectnumber" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="objectnumber"/>
+		<property name="com.jaspersoft.studio.field.label" value="objectnumber"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="collectionobjects_common"/>
+	</field>
+	<field name="title" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="title"/>
+		<property name="com.jaspersoft.studio.field.label" value="title"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="titlegroup"/>
+	</field>
+	<field name="publicartproductiondatetype" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="publicartproductiondatetype"/>
+		<property name="com.jaspersoft.studio.field.label" value="publicartproductiondatetype"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="publicartproductiondategroup"/>
+	</field>
+	<field name="objectproductiondate" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="objectproductiondate"/>
+		<property name="com.jaspersoft.studio.field.label" value="objectproductiondate"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="structureddategroup"/>
+	</field>
+	<field name="publicartproductionperson" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="publicartproductionperson"/>
+		<property name="com.jaspersoft.studio.field.label" value="publicartproductionperson"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="publicartproductionpersongroup"/>
+	</field>
+	<field name="publicartproductionpersonrole" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="publicartproductionpersonrole"/>
+		<property name="com.jaspersoft.studio.field.label" value="publicartproductionpersonrole"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="publicartproductionpersongroup"/>
+	</field>
+	<field name="responsibledepartment" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="responsibledepartment"/>
+		<property name="com.jaspersoft.studio.field.label" value="responsibledepartment"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="collectionobjects_common_responsibledepartments"/>
+	</field>
+	<field name="recordstatus" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="recordstatus"/>
+		<property name="com.jaspersoft.studio.field.label" value="recordstatus"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="collectionobjects_common"/>
+	</field>
+	<field name="publishto" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="publishto"/>
+		<property name="com.jaspersoft.studio.field.label" value="publishto"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="collectionobjects_common_publishtolist"/>
+	</field>
+	<field name="installationtype" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="installationtype"/>
+		<property name="com.jaspersoft.studio.field.label" value="installationtype"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="collectionobjects_common_inventorystatuslist"/>
+	</field>
+	<field name="numberofobjects" class="java.lang.Long">
+		<property name="com.jaspersoft.studio.field.name" value="numberofobjects"/>
+		<property name="com.jaspersoft.studio.field.label" value="numberofobjects"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="collectionobjects_common"/>
+	</field>
+	<field name="worktype" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="worktype"/>
+		<property name="com.jaspersoft.studio.field.label" value="worktype"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="objectnamegroup"/>
+	</field>
+	<field name="material" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="material"/>
+		<property name="com.jaspersoft.studio.field.label" value="material"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="materialgroup"/>
+	</field>
+	<field name="briefdescription" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="briefdescription"/>
+		<property name="com.jaspersoft.studio.field.label" value="briefdescription"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="collectionobjects_common_briefdescriptions"/>
+	</field>
+	<field name="comment" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="comment"/>
+		<property name="com.jaspersoft.studio.field.label" value="comment"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="collectionobjects_common_comments"/>
+	</field>
+	<field name="collection" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="collection"/>
+		<property name="com.jaspersoft.studio.field.label" value="collection"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="collectionobjects_publicart_publicartcollections"/>
+	</field>
+	<field name="owner" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="owner"/>
+		<property name="com.jaspersoft.studio.field.label" value="owner"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="collectionobjects_common_owners"/>
+	</field>
+	<field name="dimension" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="dimension"/>
+		<property name="com.jaspersoft.studio.field.label" value="dimension"/>
+	</field>
+	<field name="computedcurrentlocation" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="computedcurrentlocation"/>
+		<property name="com.jaspersoft.studio.field.label" value="computedcurrentlocation"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="collectionobjects_common"/>
+	</field>
+	<field name="currentlocationnote" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="currentlocationnote"/>
+		<property name="com.jaspersoft.studio.field.label" value="currentlocationnote"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="movements_common"/>
+	</field>
+	<field name="placementtype" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="placementtype"/>
+		<property name="com.jaspersoft.studio.field.label" value="placementtype"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="places_publicart_placementtypes"/>
+	</field>
+	<field name="placementenvironment" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="placementenvironment"/>
+		<property name="com.jaspersoft.studio.field.label" value="placementenvironment"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="places_publicart"/>
+	</field>
+	<field name="placetype" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="placetype"/>
+		<property name="com.jaspersoft.studio.field.label" value="placetype"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="places_publicart_publicartplacetypes"/>
+	</field>
+	<field name="placeowner" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="placeowner"/>
+		<property name="com.jaspersoft.studio.field.label" value="placeowner"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="publicartplaceownergroup"/>
+	</field>
+	<field name="ownershipnote" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="ownershipnote"/>
+		<property name="com.jaspersoft.studio.field.label" value="ownershipnote"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="publicartplaceownergroup"/>
+	</field>
+	<field name="ownertype" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="ownertype"/>
+		<property name="com.jaspersoft.studio.field.label" value="ownertype"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="publicartplaceownergroup"/>
+	</field>
+	<field name="ownershipdate" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="ownershipdate"/>
+		<property name="com.jaspersoft.studio.field.label" value="ownershipdate"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="structureddategroup"/>
+	</field>
+	<field name="addressplace1" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="addressplace1"/>
+		<property name="com.jaspersoft.studio.field.label" value="addressplace1"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="addrgroup"/>
+	</field>
+	<field name="addressplace2" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="addressplace2"/>
+		<property name="com.jaspersoft.studio.field.label" value="addressplace2"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="addrgroup"/>
+	</field>
+	<field name="addressmunicipality" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="addressmunicipality"/>
+		<property name="com.jaspersoft.studio.field.label" value="addressmunicipality"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="addrgroup"/>
+	</field>
+	<field name="addressstateorprovince" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="addressstateorprovince"/>
+		<property name="com.jaspersoft.studio.field.label" value="addressstateorprovince"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="addrgroup"/>
+	</field>
+	<field name="addresscountry" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="addresscountry"/>
+		<property name="com.jaspersoft.studio.field.label" value="addresscountry"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="addrgroup"/>
+	</field>
+	<field name="addresstype" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="addresstype"/>
+		<property name="com.jaspersoft.studio.field.label" value="addresstype"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="addrgroup"/>
+	</field>
+	<field name="addresspostcode" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="addresspostcode"/>
+		<property name="com.jaspersoft.studio.field.label" value="addresspostcode"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="addrgroup"/>
+	</field>
+	<field name="decimallatitude" class="java.lang.Double">
+		<property name="com.jaspersoft.studio.field.name" value="decimallatitude"/>
+		<property name="com.jaspersoft.studio.field.label" value="decimallatitude"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="placegeorefgroup"/>
+	</field>
+	<field name="decimallongitude" class="java.lang.Double">
+		<property name="com.jaspersoft.studio.field.name" value="decimallongitude"/>
+		<property name="com.jaspersoft.studio.field.label" value="decimallongitude"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="placegeorefgroup"/>
+	</field>
+	<field name="broaderplace" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="broaderplace"/>
+		<property name="com.jaspersoft.studio.field.label" value="broaderplace"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="relations_common"/>
+	</field>
+	<background>
+		<band splitType="Stretch"/>
+	</background>
+	<columnHeader>
+		<band height="44" splitType="Stretch">
+			<property name="com.jaspersoft.studio.layout" value="com.jaspersoft.studio.editor.layout.FreeLayout"/>
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+			<staticText>
+				<reportElement style="Column header" x="0" y="0" width="100" height="44" uuid="119975c6-15b4-4b7c-a2d0-8815d558d7f2">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Artwork ID]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="100" y="0" width="100" height="44" uuid="d0373d0c-ba31-4842-8df0-a82c66f46e9f">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Title]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="200" y="0" width="100" height="44" uuid="249592a9-ab99-4d8e-9de9-befada32b462">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Production Date]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="300" y="0" width="100" height="44" uuid="1d833620-fec4-4323-96de-c69600d3b544">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Production Date Type]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="400" y="0" width="100" height="44" uuid="16af1455-1c01-4981-bf2f-fa779267f296">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Creator]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="500" y="0" width="100" height="44" uuid="61d945d1-a38a-4c79-8eca-ecabbb0952e3">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Creator Role]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="600" y="0" width="100" height="44" uuid="0b898d02-9a4d-4658-a814-d8ac7995a982">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Program Name]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="700" y="0" width="100" height="44" uuid="5fe7a538-c02f-4eac-804b-61f20e3fcf46">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Record Status]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="800" y="0" width="100" height="44" uuid="18be299c-697d-4592-9d93-3433eb23f45b">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Publish To]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="900" y="0" width="100" height="44" uuid="8f24e0f8-c446-4e7d-b897-64855ae352ab">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Instalation Type]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="1000" y="0" width="100" height="44" uuid="78297946-2a88-48de-ab53-5095b6dc9fe7">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Number of Objects]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="1100" y="0" width="100" height="44" uuid="0541559f-12d5-4d75-a112-dff48c0d9652">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Work Type]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="1200" y="0" width="100" height="44" uuid="1f3f8de3-237f-4382-ade7-3798d2af6aa0">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Materal]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="1300" y="0" width="100" height="44" uuid="40c138fe-ed94-4433-b5ad-4dbe3a9ff58a">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Description]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="1400" y="0" width="100" height="44" uuid="8955cde4-401d-4b39-888a-80ca8377ab5b">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Comments]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="1500" y="0" width="100" height="44" uuid="28d7ef37-ab72-4c23-bf6e-5ddefbcf15de">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Collection]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="1600" y="0" width="100" height="44" uuid="c5b66644-aec1-4802-841d-ddd49e6bee61">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Owner]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="1700" y="0" width="100" height="44" uuid="dbdb09ca-bf41-4c94-a80a-50676f3188d8">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Measurement]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="1800" y="0" width="100" height="44" uuid="86aaf027-c117-4784-b68b-774c323af062">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Computed Current Location]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="1900" y="0" width="100" height="44" uuid="2567c664-ac15-41e6-a652-cf7a53529154">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Location Note]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="2000" y="0" width="100" height="44" uuid="393afbf0-a326-4eb7-b7a0-9acfa0a3566d">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Placement Type]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="2100" y="0" width="100" height="44" uuid="7e5650fd-da0c-40d1-a4b5-81e4bf38c690">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Placement Environment]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="2200" y="0" width="100" height="44" uuid="312f7bea-182e-4fa4-a86c-85a0d1986618">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Place Type]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="2300" y="0" width="100" height="44" uuid="a34709db-d110-456b-b3bc-08fea3c18bb8">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Place Owner]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="2400" y="0" width="100" height="44" uuid="a7344557-a4f0-4817-9e33-fc7b7d9a968f">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Place Owner Type]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="2500" y="0" width="100" height="44" uuid="86997684-5ee3-4006-a20d-ffcecb9a644e">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Place Owner Date]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="2600" y="0" width="100" height="44" uuid="7d45bb4d-1a17-4772-be09-90d8a234c96e">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Place Owner Note]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="2700" y="0" width="100" height="44" uuid="87a7e5c2-454a-4977-a66b-4c1cbb26ad20">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Place Address Line 1]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="2800" y="0" width="100" height="44" uuid="e62e7a71-7b1b-4712-ac21-398a8a437ec5">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Place Address Line 2]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="2900" y="0" width="100" height="44" uuid="e9bccab6-8123-4500-9948-fe37aaa4cc7e">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Place Municipality]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="3000" y="0" width="100" height="44" uuid="c3642e31-40cd-40c8-9ae0-0b377e822f36">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Place State/Province]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="3100" y="0" width="100" height="44" uuid="e5870420-6ff1-4614-a748-094f0de46672">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Place Country]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="3200" y="0" width="100" height="44" uuid="5091f4c3-f1dc-4a4d-ba57-695dcc1a22ca">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Place Address Type]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="3300" y="0" width="100" height="44" uuid="d621f46a-fc12-4f69-b24f-04dc79b33db4">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Place Postal Code]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="3400" y="0" width="100" height="44" uuid="01116813-4fad-41a5-8c65-8b53d4d0891b">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Decimal Latitude]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="3500" y="0" width="100" height="44" uuid="66e11760-4686-49d8-bac9-7fdac46d0bbf">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Decimal Longitude]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="3600" y="0" width="100" height="44" uuid="0be5512b-143a-4b09-a2da-afe5725b5eaa">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Hierarchy Broader Place]]></text>
+			</staticText>
+		</band>
+	</columnHeader>
+	<detail>
+		<band height="66" splitType="Stretch">
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="0" y="0" width="100" height="30" uuid="9f91a43b-cc9f-4873-99f8-7ce83a9794e5">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{objectnumber}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="100" y="0" width="100" height="30" uuid="a0037a18-3b74-4434-845d-6daa3e7f371d">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{title}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="200" y="0" width="100" height="30" uuid="d5ad38fe-b24e-414a-b834-0089dcbc73d1">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{objectproductiondate}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="300" y="0" width="100" height="30" uuid="c800d128-e2e0-4c02-b94e-9f5668b9f53c">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{publicartproductiondatetype}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="400" y="0" width="100" height="30" uuid="684b01a8-875b-4405-a580-b9ef32528154">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{publicartproductionperson}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="500" y="0" width="100" height="30" uuid="c9a6e1f9-b088-4e28-8d3a-f185609211b5">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{publicartproductionpersonrole}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="600" y="0" width="100" height="30" uuid="86bdc0bd-65c1-4c30-9716-7d4815131536">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{responsibledepartment}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="700" y="0" width="100" height="30" uuid="616f0d88-8f75-45c1-8c78-3358f7643e46">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{recordstatus}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="800" y="0" width="100" height="30" uuid="a9ea9475-58ae-48eb-929d-c8f5193dbfa1">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{publishto}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="900" y="0" width="100" height="30" uuid="dc23e896-31a4-4780-810e-14c0af95174a">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{installationtype}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="1000" y="0" width="100" height="30" uuid="cfef9aae-abe3-4d71-a704-71334ee0ac4b">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{numberofobjects}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="1100" y="0" width="100" height="30" uuid="7384199e-4476-46a9-88f0-ddb9a89eb948">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{worktype}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="1200" y="0" width="100" height="30" uuid="7368bb5a-e0a0-492c-8396-56385eaa187a">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{material}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="1300" y="0" width="100" height="30" uuid="f0be7108-9cbb-483a-ae78-a1a4bd4636bf">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{briefdescription}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="1400" y="0" width="100" height="30" uuid="6fe06969-298c-4d56-84da-203ae0a446f0">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{comment}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="1500" y="0" width="100" height="30" uuid="de9184ff-9c09-43b7-899d-349eea573fbf">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{collection}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="1600" y="0" width="100" height="30" uuid="05d7d996-03ef-49f8-b43a-226864d2b9e9">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{owner}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="1700" y="0" width="100" height="30" uuid="66f56234-95fe-4b57-beae-3d9211327156">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{dimension}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="1800" y="0" width="100" height="30" uuid="b4a2ef8e-fd1d-44ba-891f-1b75472880c0">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{computedcurrentlocation}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="1900" y="0" width="100" height="30" uuid="284f507d-1c90-4b07-bca5-5dd3cd6f2363">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{currentlocationnote}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="2000" y="0" width="100" height="30" uuid="52b33190-796b-42ba-990c-ab86d1d02950">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{placementtype}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="2100" y="0" width="100" height="30" uuid="1ae3ea7d-79cd-4254-aa47-67dc138787f6">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{placementenvironment}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="2200" y="0" width="100" height="30" uuid="ff9d2e44-827c-43d9-9a79-b138a679019e">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{placetype}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="2300" y="0" width="100" height="30" uuid="f29bc0cb-c282-49fe-bc66-86b32da69ceb">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{placeowner}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="2400" y="0" width="100" height="30" uuid="1da21fcb-9911-4637-a551-d22aa5f59e0f">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{ownershipnote}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="2500" y="0" width="100" height="30" uuid="cea54e87-5160-4f39-a263-b6de262b0b31">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{ownertype}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="2600" y="0" width="100" height="30" uuid="68dd5f62-0ad1-45f5-8542-b59194ce2df1">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{ownershipdate}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="2700" y="0" width="100" height="30" uuid="7e9c4946-6a6a-4e5f-80ae-f4b39d4c625d">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{addressplace1}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="2800" y="0" width="100" height="30" uuid="a6f09f39-5826-453e-bfd7-43c37c7cac3e">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{addressplace2}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="2900" y="0" width="100" height="30" uuid="aeb0ed59-c40a-483e-b7c0-5762dde5b8f5">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{addressmunicipality}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="3000" y="0" width="100" height="30" uuid="384553e7-a5c3-4a91-9c32-97d0897a2f6f">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{addressstateorprovince}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="3100" y="0" width="100" height="30" uuid="6b3790da-45b2-44d4-8955-ebc2d6542e2d">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{addresscountry}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="3200" y="0" width="100" height="30" uuid="29d1118d-ebfb-4d65-9ca5-ad9188d33609">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{addresstype}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="3300" y="0" width="100" height="30" uuid="89de5ace-4b29-4bc7-9f5f-6bda4357b7e8">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{addresspostcode}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="3400" y="0" width="100" height="30" uuid="c254ca87-73c1-431a-bd8d-1bd459f80392">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{decimallatitude}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="3500" y="0" width="100" height="30" uuid="b23c57bf-7658-4f27-8fc9-63a657f10da3">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{decimallongitude}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="3600" y="0" width="100" height="30" uuid="d1103a09-9178-42c8-ad5a-695cc568c8ce">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{broaderplace}]]></textFieldExpression>
+			</textField>
+		</band>
+	</detail>
+</jasperReport>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/full_obj_place.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/full_obj_place.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<document name="report">
+  <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
+    <name>Full Object with Place Details</name>
+    <notes>Full Object with Place Details</notes>
+    <forDocTypes>
+      <forDocType>CollectionObject</forDocType>
+    </forDocTypes>
+    <supportsSingleDoc>true</supportsSingleDoc>
+    <supportsDocList>false</supportsDocList>
+    <supportsGroup>false</supportsGroup>
+    <supportsNoContext>true</supportsNoContext>
+    <filename>full_obj_place.jrxml</filename>
+    <outputMIME>text/csv</outputMIME>
+  </ns2:reports_common>
+</document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/incoming_loan.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/incoming_loan.jrxml
@@ -10,7 +10,7 @@
     <style name="Column header" fontName="SansSerif" fontSize="12" isBold="true"/>
     <style name="Detail" fontName="SansSerif" fontSize="12"/>
     <parameter name="deurnfields" class="java.lang.String" isForPrompting="false">
-        <defaultValueExpression><![CDATA["lender,lenderscontact,objvaluecurrency,loanvaluecurrency,loangroup"]]></defaultValueExpression>
+        <defaultValueExpression><![CDATA["lender,lenderscontact,objvaluecurrency,loanvaluecurrency,loangroup,objectname"]]></defaultValueExpression>
     </parameter>
     <parameter name="tenantid" class="java.lang.String" isForPrompting="false">
         <defaultValueExpression><![CDATA["1"]]></defaultValueExpression>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/obj_current_place_details.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/obj_current_place_details.jrxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 6.20.1.final using JasperReports Library version 6.20.1-7584acb244139816654f64e2fd57a00d3e31921e  -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="objectfullcurrentplace" pageWidth="2200" pageHeight="595" orientation="Landscape" columnWidth="802" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isIgnorePagination="true" uuid="5a82d2c4-148b-43c2-8c7c-d2da30c26fe1">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="objectfullcurrentplace" pageWidth="2300" pageHeight="595" orientation="Landscape" columnWidth="802" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isIgnorePagination="true" uuid="5a82d2c4-148b-43c2-8c7c-d2da30c26fe1">
 	<property name="com.jaspersoft.studio.data.sql.tables" value=""/>
 	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="nuxeo"/>
 	<property name="com.jaspersoft.studio.data.sql.SQLQueryDesigner.sash.w1" value="193"/>
@@ -10,7 +10,7 @@
 	<style name="Column header" fontName="SansSerif" fontSize="12" isBold="true"/>
 	<style name="Detail" fontName="SansSerif" fontSize="12"/>
 	<parameter name="deurnfields" class="java.lang.String" isForPrompting="false">
-		<defaultValueExpression><![CDATA["computedcurrentlocation,placementtype,owner,addressmunicipality,addressstateorprovince,addresscountry,addresstype,broaderplace"]]></defaultValueExpression>
+		<defaultValueExpression><![CDATA["computedcurrentlocation,placementtype,owner,addressmunicipality,addressstateorprovince,addresscountry,addresstype,broaderplace,placetype"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="tenantid" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA["5000"]]></defaultValueExpression>
@@ -41,6 +41,7 @@
 ), movements AS (
   select mvmt.currentlocationnote,
     placement_type.item AS placementtype, pa.placementenvironment,
+    placetype.item AS placetype,
     owner.owner, owner.ownertype, owner.ownershipnote, owner_sdg.datedisplaydate AS ownerdate,
     addr.addressplace1, addr.addressplace2, addr.addressmunicipality, addr.addressstateorprovince,
     addr.addresscountry, addr.addresstype, addr.addresspostcode,
@@ -51,6 +52,7 @@
   INNER JOIN movements_common mvmt ON mvmt.currentlocation = obj.computedcurrentlocation
   INNER JOIN places_common place ON mvmt.currentlocation = place.refname
   INNER JOIN hierarchy place_hier ON place_hier.id = place.id
+  LEFT JOIN places_publicart_publicartplacetypes placetype on placetype.id = place.id AND placetype.pos = 0
   LEFT JOIN places_publicart_placementtypes placement_type ON placement_type.id = place.id AND placement_type.pos = 0
   LEFT JOIN places_publicart pa ON pa.id = place.id
   LEFT JOIN hierarchy owner_hier ON owner_hier.parentid = place.id AND owner_hier.primarytype = 'publicartPlaceOwnerGroup' AND owner_hier.pos = 0
@@ -69,6 +71,7 @@ SELECT
   object.briefdescription,
   object.computedcurrentlocation,
   mvmt.currentlocationnote,
+  mvmt.placetype,
   mvmt.placementtype,
   mvmt.placementenvironment,
   mvmt.owner, mvmt.ownertype, mvmt.ownerdate, mvmt.ownershipnote,
@@ -109,6 +112,11 @@ LEFT JOIN movements mvmt ON mvmt.objcsid = object.csid]]>
 		<property name="com.jaspersoft.studio.field.name" value="currentlocationnote"/>
 		<property name="com.jaspersoft.studio.field.label" value="currentlocationnote"/>
 		<property name="com.jaspersoft.studio.field.tree.path" value="movements_common"/>
+	</field>
+	<field name="placetype" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="placetype"/>
+		<property name="com.jaspersoft.studio.field.label" value="placetype"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="places_publicart_publicartplacetypes"/>
 	</field>
 	<field name="placementtype" class="java.lang.String">
 		<property name="com.jaspersoft.studio.field.name" value="placementtype"/>
@@ -354,6 +362,14 @@ LEFT JOIN movements mvmt ON mvmt.objcsid = object.csid]]>
 				<textElement markup="styled"/>
 				<text><![CDATA[Hierarchy Broader Place]]></text>
 			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="2100" y="0" width="100" height="44"
+					uuid="955bb0bc-b307-4203-ab12-76afb73e7b6a">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Place Type]]></text>
+			</staticText>
 		</band>
 	</columnHeader>
 	<detail>
@@ -484,6 +500,12 @@ LEFT JOIN movements mvmt ON mvmt.objcsid = object.csid]]>
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{broaderplace}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="2100" y="0" width="100" height="30" uuid="1c538723-362b-4729-aafa-b5b2aed583b4">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{placetype}]]></textFieldExpression>
 			</textField>
 		</band>
 	</detail>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/outgoing_loan.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/outgoing_loan.jrxml
@@ -10,7 +10,7 @@
   <style name="Column header" fontName="SansSerif" fontSize="12" isBold="true"/>
   <style name="Detail" fontName="SansSerif" fontSize="12"/>
   <parameter name="deurnfields" class="java.lang.String" isForPrompting="false">
-    <defaultValueExpression><![CDATA["borrower,borrowerscontact,objvaluecurrency,loanvaluecurrency,loangroup,loanstatus"]]></defaultValueExpression>
+    <defaultValueExpression><![CDATA["borrower,borrowerscontact,objvaluecurrency,loanvaluecurrency,loangroup,loanstatus,objectname"]]></defaultValueExpression>
   </parameter>
   <parameter name="tenantid" class="java.lang.String" isForPrompting="false">
     <defaultValueExpression><![CDATA["1"]]></defaultValueExpression>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/referral.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/referral.jrxml
@@ -10,7 +10,7 @@
   <style name="Column header" fontName="SansSerif" fontSize="12" isBold="true"/>
   <style name="Detail" fontName="SansSerif" fontSize="12"/>
   <parameter name="deurnfields" class="java.lang.String" isForPrompting="false">
-    <defaultValueExpression><![CDATA["entrymethod,currentlocation"]]></defaultValueExpression>
+    <defaultValueExpression><![CDATA["entrymethod,currentlocation,objectname"]]></defaultValueExpression>
   </parameter>
   <parameter name="tenantid" class="java.lang.String" isForPrompting="false">
     <defaultValueExpression><![CDATA["1"]]></defaultValueExpression>


### PR DESCRIPTION
**What does this do?**
This brings in new reports as well as fixes to reports from 7.2:
* Add Borrowing Receipt report to core
* Add Artwork Description report to fcart
* Add Full Object With Place Details report to publicart
* Add PlaceType field to Object with Full Current Place
* Remove condition on primary type for relation joins
* Deurn objectname field

**Why are we doing this? (with JIRA link)**
**New Reports**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1278

These are the 3 new reports which were requested. Fairly straightforward additions. 

**Report Updates**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1282

The updates are from things we saw after 7.2 release which weren't caught by QA. Notably, the `placeType` field was missing from the object w/ current place report. 

It was reported that related objects weren't being returned for a few reports (accessions, deed of gift, box list). This was being caused by the primary type having a different name for tenants, so I opted to drop the condition from the join since we're already using the csid. 

Object names weren't being deurned when running under publicart, and I saw they override the field to be controlled. This was resolved by adding `objectName` to the deurn fields list.  

**How should this be tested? Do these changes have associated tests?**
* Enable the core, fcart, and publicart tenants
* Deploy collectionspace
* Test the borrowing receipt runs for core
  * From loan out procedure. Relies on a related collectionobject with a location and media handling.
  * See https://collectionspace.atlassian.net/browse/DRYD-1279 for all fields
* Test the artwork description report runs for fcart
  * From collection object
  * See https://collectionspace.atlassian.net/browse/DRYD-1280 for all fields
* Test the Full Object with Place Details runs for publicart
  * From collection object with related lmi and place authority
  * See https://collectionspace.atlassian.net/browse/DRYD-1281 for all fields
* Updated reports
  * object with full place should have the place type ~~, and deurn objectname if it's controlled~~
  * accessions should deurn objectname if it's controlled and join all related collection objects for non-core tenants
  * deed of gift should deurn objectname if it's controlled and join all related collection objects for non-core tenants
  * box list should join all related collection objects for non-core tenants
  * deaccessions should deurn objectname if it's controlled
  * incoming loan should deurn object name if it's controlled
  * outgoing loan should deurn object name if it's controlled
  * referral should deurn object name if it's controlled

**Dependencies for merging? Releasing to production?**
I had been working off of the 7.2 release tag because I didn't feel like deploying the SSO changes in my local install yet. Can rebase if that makes testing easier now since it looks like everything is ready.

I still have an open question about the object name field for the new reports, which should be resolved shortly.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested the new reports and updates
