### PR TITLE
CB-20: Use controlled object name in computed title

### DIFF
--- a/3rdparty/nuxeo/nuxeo-platform-elasticsearch/src/main/java/org/collectionspace/services/nuxeo/elasticsearch/DefaultESDocumentWriter.java
+++ b/3rdparty/nuxeo/nuxeo-platform-elasticsearch/src/main/java/org/collectionspace/services/nuxeo/elasticsearch/DefaultESDocumentWriter.java
@@ -212,7 +212,10 @@ private void denormExhibitionRecords(CoreSession session, String csid, String te
 
 		if (objectNameGroups.size() > 0) {
 			Map<String, Object> primaryObjectNameGroup = objectNameGroups.get(0);
-			primaryObjectName = (String) primaryObjectNameGroup.get("objectName");
+			primaryObjectName = (String) primaryObjectNameGroup.get("objectNameControlled");
+			if (primaryObjectName == null) {
+				primaryObjectName = (String) primaryObjectNameGroup.get("objectName");
+			}
 
 			// The object might be a refname in some profiles/tenants. If it is, use only the display name.
 


### PR DESCRIPTION
**What does this do?**
* Add objectNameControlled to denorm'd title

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/CB-20

The controlled version of the object name was added in 7.2, but the elasticsearch index wasn't updated to include it in the title. This updates it so that the controlled object name is second in precedence behind the title.

**How should this be tested? Do these changes have associated tests?**
* Deploy the changes and run collectionspace
* Create three collection objects (published to the publicbrowser):
  * One with a title, controlled object name, and object name
  * One with a controlled object name and object name
  * One with an object name
* Query the elasticsearch index and check that the `collectionspace_denorm:title` is correct for each object

**Dependencies for merging? Releasing to production?**
Not sure how the index gets updated but the titles will likely be inconsistent until then

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally
