### PR TITLE
CB-21: Include controlled terms for material display

### DIFF
--- a/3rdparty/nuxeo/nuxeo-platform-elasticsearch/src/main/java/org/collectionspace/services/nuxeo/elasticsearch/DefaultESDocumentWriter.java
+++ b/3rdparty/nuxeo/nuxeo-platform-elasticsearch/src/main/java/org/collectionspace/services/nuxeo/elasticsearch/DefaultESDocumentWriter.java
@@ -60,6 +60,7 @@ public class DefaultESDocumentWriter extends JsonESDocumentWriter {
 			denormMediaRecords(session, csid, tenantId, denormValues);
 			denormAcquisitionRecords(session, csid, tenantId, denormValues);
 			denormExhibitionRecords(session, csid, tenantId, denormValues);
+			denormMaterialRecords(doc, denormValues);
 
 			// Compute the title of the record for the public browser, and store it so that it can
 			// be used for sorting ES query results.
@@ -189,6 +190,37 @@ private void denormExhibitionRecords(CoreSession session, String csid, String te
 
 	denormValues.putArray("exhibition").addAll(exhibitions);
 }
+
+	/**
+	 * Denormalize the material group list for a collectionobject in order to index the controlled or uncontrolled term
+	 *
+	 * @param doc the collectionobject document
+	 * @param denormValues the json node for denormalized fields
+	 */
+	private void denormMaterialRecords(DocumentModel doc, ObjectNode denormValues) {
+		List<Map<String, Object>> materialGroupList =
+			(List<Map<String, Object>>) doc.getProperty("collectionobjects_common", "materialGroupList");
+
+		List<JsonNode> denormMaterials = new ArrayList<>();
+		for (Map<String, Object> materialGroup : materialGroupList) {
+			String material;
+
+			String controlledMaterial = (String) materialGroup.get("materialControlled");
+			if (controlledMaterial != null) {
+				material = RefNameUtils.getDisplayName(controlledMaterial);
+			} else {
+				material = (String) materialGroup.get("material");
+			}
+
+			if (material != null) {
+				final ObjectNode node = objectMapper.createObjectNode();
+				node.put("material", material);
+				denormMaterials.add(node);
+			}
+		}
+
+		denormValues.putArray("materialGroupList").addAll(denormMaterials);
+	}
 
 	/**
 	 * Compute a title for the public browser. This needs to be indexed in ES so that it can

--- a/3rdparty/nuxeo/nuxeo-platform-elasticsearch/src/main/java/org/collectionspace/services/nuxeo/elasticsearch/DefaultESDocumentWriter.java
+++ b/3rdparty/nuxeo/nuxeo-platform-elasticsearch/src/main/java/org/collectionspace/services/nuxeo/elasticsearch/DefaultESDocumentWriter.java
@@ -60,7 +60,7 @@ public class DefaultESDocumentWriter extends JsonESDocumentWriter {
 			denormMediaRecords(session, csid, tenantId, denormValues);
 			denormAcquisitionRecords(session, csid, tenantId, denormValues);
 			denormExhibitionRecords(session, csid, tenantId, denormValues);
-			denormMaterialRecords(doc, denormValues);
+			denormMaterialFields(doc, denormValues);
 
 			// Compute the title of the record for the public browser, and store it so that it can
 			// be used for sorting ES query results.
@@ -197,7 +197,7 @@ private void denormExhibitionRecords(CoreSession session, String csid, String te
 	 * @param doc the collectionobject document
 	 * @param denormValues the json node for denormalized fields
 	 */
-	private void denormMaterialRecords(DocumentModel doc, ObjectNode denormValues) {
+	private void denormMaterialFields(DocumentModel doc, ObjectNode denormValues) {
 		List<Map<String, Object>> materialGroupList =
 			(List<Map<String, Object>>) doc.getProperty("collectionobjects_common", "materialGroupList");
 

--- a/3rdparty/nuxeo/nuxeo-platform-elasticsearch/src/main/java/org/collectionspace/services/nuxeo/elasticsearch/DefaultESDocumentWriter.java
+++ b/3rdparty/nuxeo/nuxeo-platform-elasticsearch/src/main/java/org/collectionspace/services/nuxeo/elasticsearch/DefaultESDocumentWriter.java
@@ -203,15 +203,14 @@ private void denormExhibitionRecords(CoreSession session, String csid, String te
 
 		List<JsonNode> denormMaterials = new ArrayList<>();
 		for (Map<String, Object> materialGroup : materialGroupList) {
-			String material;
-
 			String controlledMaterial = (String) materialGroup.get("materialControlled");
 			if (controlledMaterial != null) {
-				material = RefNameUtils.getDisplayName(controlledMaterial);
-			} else {
-				material = (String) materialGroup.get("material");
+				final ObjectNode node = objectMapper.createObjectNode();
+				node.put("material", RefNameUtils.getDisplayName(controlledMaterial));
+				denormMaterials.add(node);
 			}
 
+			String material = (String) materialGroup.get("material");
 			if (material != null) {
 				final ObjectNode node = objectMapper.createObjectNode();
 				node.put("material", material);

--- a/services/common/src/main/cspace/config/services/tenants/anthro/anthro-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/anthro/anthro-tenant-bindings.delta.xml
@@ -128,8 +128,7 @@
 							"properties": {
 								"material": {
 									"type": "keyword",
-									"copy_to": "all_field",
-									"normalizer": "sorting_normalizer"
+									"copy_to": "all_field"
 								}
 							}
 						},

--- a/services/common/src/main/cspace/config/services/tenants/anthro/anthro-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/anthro/anthro-tenant-bindings.delta.xml
@@ -31,7 +31,6 @@
 							"collectionobjects_common:contentConcepts",
 							"collectionobjects_common:fieldCollectionDateGroup",
 							"collectionobjects_common:fieldCollectors",
-							"collectionobjects_common:materialGroupList",
 							"collectionobjects_common:measuredPartGroupList",
 							"collectionobjects_common:numberOfObjects",
 							"collectionobjects_common:objectHistoryNote",
@@ -124,6 +123,16 @@
 								}
 							}
 						},
+						"collectionspace_denorm:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field",
+									"normalizer": "sorting_normalizer"
+								}
+							}
+						},
 
 						"collectionobjects_common:objectNumber": {
 							"type": "keyword",
@@ -209,15 +218,6 @@
 							"type": "object",
 							"properties": {
 								"objectProductionPlace": {
-									"type": "keyword",
-									"copy_to": "all_field"
-								}
-							}
-						},
-						"collectionobjects_common:materialGroupList": {
-							"type": "object",
-							"properties": {
-								"material": {
 									"type": "keyword",
 									"copy_to": "all_field"
 								}

--- a/services/common/src/main/cspace/config/services/tenants/fcart/fcart-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/fcart/fcart-tenant-bindings.delta.xml
@@ -119,8 +119,7 @@
 							"properties": {
 								"material": {
 									"type": "keyword",
-									"copy_to": "all_field",
-									"normalizer": "sorting_normalizer"
+									"copy_to": "all_field"
 								}
 							}
 						},

--- a/services/common/src/main/cspace/config/services/tenants/fcart/fcart-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/fcart/fcart-tenant-bindings.delta.xml
@@ -25,7 +25,6 @@
 							"collectionobjects_common:colors",
 							"collectionobjects_common:computedCurrentLocation",
 							"collectionobjects_common:contentConcepts",
-							"collectionobjects_common:materialGroupList",
 							"collectionobjects_common:measuredPartGroupList",
 							"collectionobjects_common:numberOfObjects",
 							"collectionobjects_common:objectHistoryNote",
@@ -112,6 +111,16 @@
 								"curatorialNote": {
 									"type": "text",
 									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field",
+									"normalizer": "sorting_normalizer"
 								}
 							}
 						},
@@ -202,15 +211,6 @@
 											"normalizer": "refname_displayname_normalizer"
 										}
 									}
-								}
-							}
-						},
-						"collectionobjects_common:materialGroupList": {
-							"type": "object",
-							"properties": {
-								"material": {
-									"type": "keyword",
-									"copy_to": "all_field"
 								}
 							}
 						},

--- a/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
+++ b/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
@@ -1234,8 +1234,7 @@
 							"properties": {
 								"material": {
 									"type": "keyword",
-									"copy_to": "all_field",
-									"normalizer": "sorting_normalizer"
+									"copy_to": "all_field"
 								}
 							}
 						},

--- a/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
+++ b/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
@@ -1141,7 +1141,6 @@
 							"collectionobjects_common:colors",
 							"collectionobjects_common:computedCurrentLocation",
 							"collectionobjects_common:contentConcepts",
-							"collectionobjects_common:materialGroupList",
 							"collectionobjects_common:measuredPartGroupList",
 							"collectionobjects_common:numberOfObjects",
 							"collectionobjects_common:objectHistoryNote",
@@ -1319,15 +1318,6 @@
 							"type": "object",
 							"properties": {
 								"objectProductionPlace": {
-									"type": "keyword",
-									"copy_to": "all_field"
-								}
-							}
-						},
-						"collectionobjects_common:materialGroupList": {
-							"type": "object",
-							"properties": {
-								"material": {
 									"type": "keyword",
 									"copy_to": "all_field"
 								}

--- a/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
+++ b/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
@@ -1230,6 +1230,16 @@
 								}
 							}
 						},
+						"collectionspace_denorm:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field",
+									"normalizer": "sorting_normalizer"
+								}
+							}
+						},
 
 						"collectionobjects_common:objectNumber": {
 							"type": "keyword",


### PR DESCRIPTION
**What does this do?**
* Adds a denormalized materialGroupList to capture controlled materials
* Remove old materialGroupList index

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/CB-21

This updates the elasticsearch index to capture the controlled version of a material if present. The field was added in 7.2, so this allows the public browser to be up to date with the latest fields.

**How should this be tested? Do these changes have associated tests?**

- Deploy the changes and run collectionspace
- Create a few collection objects (published to the publicbrowser):
  - One with a controlled material and material
  - One with an uncontrolled material
- Query the elasticsearch index and check that the collectionspace_denorm:materilGropuList is correct for each object, e.g.
```
[elastic] $ cat denorm_query.json
{
  "query": {
    "term": {
      "ecm:primaryType": "CollectionObject"
    }
  },
  "from": 0,
  "size": 23,
  "_source": {
    "includes": [
      "ecm:name",
      "ecm:primaryType",
      "collectionspace_denorm:materialGroupList",
      "collectionspace_denorm:title"
    ]
  },
  "sort": {
    "collectionspace_core:createdAt": {
      "order": "desc"
    }
  },
  "aggs": {
    "material": {
      "terms": {
        "field": "collectionspace_denorm:materialGroupList.material",
        "order": {
          "_term": "asc"
        },
        "size": 300
      }
    }
  }
}
[elastic] $ curl --json @denorm_query.json http://localhost:9200/nuxeo_default/doc/_msearch | jq .
```

**Dependencies for merging? Releasing to production?**
Similar to the other public browser PR, I'm not sure how re-indexing will work. With this changing the index it is something that will need to be done so that all materials will display correctly in the filter as well as the display for an object.

I also wasn't sure if we should remove the old `materialGroupList` index or leave it. I've removed it for the tenants which will use the `collectionspace_denorm:materialGroupList` and left it in the material profile. I'm realizing now I should test against the material tenant as well to make sure everything is still working as expected.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested the core tenant locally