### PR TITLE
CB-22: Index display name of objectProductionPlace in anthro.

### DIFF
--- a/services/common/src/main/cspace/config/services/tenants/anthro/anthro-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/anthro/anthro-tenant-bindings.delta.xml
@@ -210,7 +210,13 @@
 							"properties": {
 								"objectProductionPlace": {
 									"type": "keyword",
-									"copy_to": "all_field"
+									"copy_to": "all_field",
+									"fields": {
+										"displayName": {
+											"type": "keyword",
+											"normalizer": "refname_displayname_normalizer"
+										}
+									}
 								}
 							}
 						},


### PR DESCRIPTION
**What does this do?**

This indexes the display name of the objectProductionPlace field in the anthro profile, so that the display name can be used as a facet in the public browser, instead of the full ref name.

**Why are we doing this? (with JIRA link)**

In the anthro profile, objectProductionPlace is customized to be an authority-controlled field, instead of free text. This was causing ref names to appear as facets in the public browser.

JIRA: https://collectionspace.atlassian.net/browse/CB-22

**How should this be tested? Do these changes have associated tests?**

In the public browser, with https://github.com/collectionspace/cspace-public-browser.js/pull/24 applied, the values in the Production Place facet should no longer appear as ref names (URNs).

**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran this locally.
