### PR TITLE
CB-23: Add denormalized objectName to capture controlled terms

### DIFF
--- a/3rdparty/nuxeo/nuxeo-platform-elasticsearch/src/main/java/org/collectionspace/services/nuxeo/elasticsearch/DefaultESDocumentWriter.java
+++ b/3rdparty/nuxeo/nuxeo-platform-elasticsearch/src/main/java/org/collectionspace/services/nuxeo/elasticsearch/DefaultESDocumentWriter.java
@@ -233,24 +233,24 @@ private void denormExhibitionRecords(CoreSession session, String csid, String te
 		List<Map<String, Object>> objectNameList =
 			(List<Map<String, Object>>) doc.getProperty("collectionobjects_common", "objectNameList");
 
-		List<JsonNode> denormMaterials = new ArrayList<>();
+		List<JsonNode> denormObjectNames = new ArrayList<>();
 		for (Map<String, Object> objectNameGroup  : objectNameList) {
 			String controlledName = (String) objectNameGroup.get("objectNameControlled");
 			if (controlledName != null) {
 				final ObjectNode node = objectMapper.createObjectNode();
 				node.put("objectName", RefNameUtils.getDisplayName(controlledName));
-				denormMaterials.add(node);
+				denormObjectNames.add(node);
 			}
 
 			String objectName = (String) objectNameGroup.get("objectName");
 			if (objectName != null) {
 				final ObjectNode node = objectMapper.createObjectNode();
 				node.put("objectName", objectName);
-				denormMaterials.add(node);
+				denormObjectNames.add(node);
 			}
 		}
 
-		denormValues.putArray("objectNameList").addAll(denormMaterials);
+		denormValues.putArray("objectNameList").addAll(denormObjectNames);
 	}
 
 	/**

--- a/3rdparty/nuxeo/nuxeo-platform-elasticsearch/src/main/java/org/collectionspace/services/nuxeo/elasticsearch/DefaultESDocumentWriter.java
+++ b/3rdparty/nuxeo/nuxeo-platform-elasticsearch/src/main/java/org/collectionspace/services/nuxeo/elasticsearch/DefaultESDocumentWriter.java
@@ -61,6 +61,7 @@ public class DefaultESDocumentWriter extends JsonESDocumentWriter {
 			denormAcquisitionRecords(session, csid, tenantId, denormValues);
 			denormExhibitionRecords(session, csid, tenantId, denormValues);
 			denormMaterialFields(doc, denormValues);
+			denormObjectNameFields(doc, denormValues);
 
 			// Compute the title of the record for the public browser, and store it so that it can
 			// be used for sorting ES query results.
@@ -219,6 +220,37 @@ private void denormExhibitionRecords(CoreSession session, String csid, String te
 		}
 
 		denormValues.putArray("materialGroupList").addAll(denormMaterials);
+	}
+
+	/**
+	 * Denormalize the object name group list for a collectionobject in order to index the controlled and
+	 * uncontrolled terms
+	 *
+	 * @param doc the collectionobject document
+	 * @param denormValues the json node for denormalized fields
+	 */
+	private void denormObjectNameFields(DocumentModel doc, ObjectNode denormValues) {
+		List<Map<String, Object>> objectNameList =
+			(List<Map<String, Object>>) doc.getProperty("collectionobjects_common", "objectNameList");
+
+		List<JsonNode> denormMaterials = new ArrayList<>();
+		for (Map<String, Object> objectNameGroup  : objectNameList) {
+			String controlledName = (String) objectNameGroup.get("objectNameControlled");
+			if (controlledName != null) {
+				final ObjectNode node = objectMapper.createObjectNode();
+				node.put("objectName", RefNameUtils.getDisplayName(controlledName));
+				denormMaterials.add(node);
+			}
+
+			String objectName = (String) objectNameGroup.get("objectName");
+			if (objectName != null) {
+				final ObjectNode node = objectMapper.createObjectNode();
+				node.put("objectName", objectName);
+				denormMaterials.add(node);
+			}
+		}
+
+		denormValues.putArray("objectNameList").addAll(denormMaterials);
 	}
 
 	/**

--- a/services/common/src/main/cspace/config/services/tenants/anthro/anthro-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/anthro/anthro-tenant-bindings.delta.xml
@@ -132,6 +132,15 @@
 								}
 							}
 						},
+						"collectionspace_denorm:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
 
 						"collectionobjects_common:objectNumber": {
 							"type": "keyword",

--- a/services/common/src/main/cspace/config/services/tenants/fcart/fcart-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/fcart/fcart-tenant-bindings.delta.xml
@@ -123,6 +123,15 @@
 								}
 							}
 						},
+						"collectionspace_denorm:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
 
 						"collectionobjects_common:objectNumber": {
 							"type": "keyword",

--- a/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
+++ b/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
@@ -1238,6 +1238,15 @@
 								}
 							}
 						},
+						"collectionspace_denorm:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
 
 						"collectionobjects_common:objectNumber": {
 							"type": "keyword",


### PR DESCRIPTION
**What does this do?**
Adds denormalized objectNameList to elasticsearch for capturing controlled and uncontrolled terms

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/CB-23

We added controlled terms for object names but never updating to have them indexed in elasticsearch. This updates it so that both fields are captured 

**How should this be tested? Do these changes have associated tests?**
* Rebuild collectionspace and enable elasticsearch
* Create a collectionobject with multiple controlled and uncontrolled objectnames
* Query elasticsearch and see all the terms returned, e.g.
```
[elastic] $ cat msearch
{"preference":"result"}
{"query":{"term":{"ecm:primaryType":"CollectionObject"}},"from":0,"size":33,"_source":{"includes":["ecm:name","ecm:primaryType","collectionspace_denorm:objectNameList","collectionspace_denorm:materialGroupList","collectionspace_denorm:title"]},"sort":{"collectionspace_core:createdAt":{"order":"desc"}},"aggs":{"objectName":{"terms":{"field":"collectionspace_denorm:objectNameList.objectName","order":{"_term":"asc"},"size":300}},"objectProductionPerson":{"terms":{"field":"collectionobjects_common:objectProductionPersonGroupList.objectProductionPerson.displayName","order":{"_term":"asc"},"size":300}},"objectProductionOrganization":{"terms":{"field":"collectionobjects_common:objectProductionOrganizationGroupList.objectProductionOrganization.displayName","order":{"_term":"asc"},"size":300}},"objectProductionPeople":{"terms":{"field":"collectionobjects_common:objectProductionPeopleGroupList.objectProductionPeople","order":{"_term":"asc"},"size":300}},"prodYears":{"histogram":{"field":"collectionspace_denorm:prodYears","interval":10,"min_doc_count":1}},"objectProductionPlace":{"terms":{"field":"collectionobjects_common:objectProductionPlaceGroupList.objectProductionPlace","order":{"_term":"asc"},"size":300}},"material":{"terms":{"field":"collectionspace_denorm:materialGroupList.material","order":{"_term":"asc"},"size":300}},"color":{"terms":{"field":"collectionobjects_common:colors","order":{"_term":"asc"},"size":300}},"responsibleDepartment":{"terms":{"field":"collectionobjects_common:responsibleDepartments","order":{"_term":"asc"},"size":300}},"exhibitionTitle":{"terms":{"field":"collectionspace_denorm:exhibition.title","order":{"_term":"asc"},"size":300}},"contentConcept":{"terms":{"field":"collectionobjects_common:contentConcepts.displayName","order":{"_count":"desc"},"size":300}},"technique":{"terms":{"field":"collectionobjects_common:techniqueGroupList.technique","order":{"_term":"asc"},"size":300}},"hasMedia":{"terms":{"field":"collectionspace_denorm:hasMedia","order":{"_term":"asc"},"size":300}}}}
[elastic] $ curl -H "Content-Type: application/x-ndjson" -XGET http://localhost:9200/nuxeo_default/doc/_msearch --data-binary "@msearch" | jq . | less
```

**Dependencies for merging? Releasing to production?**
I opted not to remove the `"collectionobjects_common:objectNameList"` from the tenant config, as I noticed it was also used in the subtitle for the public browser. I imagine this should also be updated but didn't make any change yet.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally