### PR TITLE
DRYD-1328: Use distinct in order to get media for all rows

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tombstone_with_budget.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tombstone_with_budget.jrxml
@@ -151,14 +151,13 @@ LEFT JOIN materials material on material.objcsid = obj.objcsid
 LEFT JOIN dimensions dimension on dimension.objcsid = obj.objcsid
 LEFT JOIN dates date on date.objcsid = obj.objcsid
 LEFT JOIN (
-  SELECT relation.subjectcsid, relation.objectcsid
+  SELECT DISTINCT ON (relation.subjectcsid) relation.subjectcsid, relation.objectcsid
   FROM relations_common relation
   INNER JOIN misc ON misc.id = relation.id AND misc.lifecyclestate != 'deleted'
   INNER JOIN hierarchy hier ON hier.name = relation.objectcsid
   INNER JOIN collectionspace_core core ON core.id = hier.id
   WHERE relation.objectdocumenttype = 'Media' AND relation.subjectdocumenttype = 'CollectionObject'
-  ORDER BY core.updatedat DESC
-  LIMIT 1
+  ORDER BY relation.subjectcsid, core.updatedat DESC
 ) media ON media.subjectcsid = obj.objcsid
 LEFT JOIN (
   SELECT

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tombstone_with_creator.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tombstone_with_creator.jrxml
@@ -101,14 +101,13 @@ LEFT JOIN (
   GROUP BY material_hier.parentid
 ) material ON material.parentid = obj.id
 LEFT JOIN (
-  SELECT relation.subjectcsid, relation.objectcsid
+  SELECT DISTINCT ON (relation.subjectcsid) relation.subjectcsid, relation.objectcsid
   FROM relations_common relation
   INNER JOIN misc ON misc.id = relation.id AND misc.lifecyclestate != 'deleted'
   INNER JOIN hierarchy hier ON hier.name = relation.objectcsid
   INNER JOIN collectionspace_core core ON core.id = hier.id
   WHERE relation.objectdocumenttype = 'Media' AND relation.subjectdocumenttype = 'CollectionObject'
-  ORDER BY core.updatedat DESC
-  LIMIT 1
+  ORDER BY relation.subjectcsid, core.updatedat DESC
 ) media ON media.subjectcsid = hier.name
 $P!{whereclause}]]>
   </queryString>


### PR DESCRIPTION
**What does this do?**
* Use distinct in order to get media for all csids

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1328

This was a bug identified when selecting multiple collection objects from the tombstone with budget and tombstone with creator reports. It is caused by the subquery returning a single row instead of one row per object because of using `LIMIT`. To fix this I updated the query to use `DISTINCT` on each csid.

**How should this be tested? Do these changes have associated tests?**
* Rebuild collectionspace with the publicart tenant enabled
* Start collectionspace and run the publicart ui
* Create multiple collectionobjects with associated media
* Search for collectionobjects
  * Using a selection of them, run the `Tombstone with Budget` report with pdf output
  * See that each collectionobject has a thumbnail
  * Using a selection of them, run the `Tombstone with Creator` report with pdf output
  * See that each collectionobject has a thumbnail

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally