### PR TITLE
CB-22: Index display name of objectProductionPlace in bonsai.

### DIFF
--- a/services/common/src/main/cspace/config/services/tenants/bonsai/bonsai-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/bonsai/bonsai-tenant-bindings.delta.xml
@@ -1,13 +1,277 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <tenant:TenantBindingConfig
-        xmlns:merge='http://xmlmerge.el4j.elca.ch'
-        xmlns:tenant='http://collectionspace.org/services/config/tenant'>
+	xmlns:merge='http://xmlmerge.el4j.elca.ch'
+	xmlns:tenant='http://collectionspace.org/services/config/tenant'>
 
-    <!-- Add your changes, if any, within the following tag pair. -->
-    <!-- The value of the 'id' attribute, below, should match the corresponding -->
-    <!-- value in cspace/config/services/tenants/bonsai-tenant-bindings-proto.xml -->
+	<!-- Add your changes, if any, within the following tag pair. -->
+	<!-- The value of the 'id' attribute, below, should match the corresponding -->
+	<!-- value in cspace/config/services/tenants/bonsai-tenant-bindings-proto.xml -->
 
-    <tenant:tenantBinding id="3000">
-    </tenant:tenantBinding>
+	<tenant:tenantBinding id="3000">
+		<tenant:elasticSearchIndexConfig merge:action="replace">
+			<tenant:mapping merge:action="replace">
+				{
+					// For now, don't index a field unless there's a mapping explicitly defined. This keeps the
+					// index as small as possible. We may want to turn this on in the future, to support arbitrary
+					// searches through Elasticsearch, e.g. NXQL queries for ad hoc reporting in the CSpace UI.
+					"dynamic": false,
+					"_all" : {
+						"enabled": false
+					},
+					"_source": {
+						"includes": [
+							"collectionobjects_common:briefDescriptions",
+							"collectionobjects_common:collection",
+							"collectionobjects_common:colors",
+							"collectionobjects_common:computedCurrentLocation",
+							"collectionobjects_common:contentConcepts",
+							"collectionobjects_common:measuredPartGroupList",
+							"collectionobjects_common:numberOfObjects",
+							"collectionobjects_common:objectHistoryNote",
+							"collectionobjects_common:objectNameList",
+							"collectionobjects_common:objectNumber",
+							"collectionobjects_common:objectProductionDateGroupList",
+							"collectionobjects_common:objectProductionOrganizationGroupList",
+							"collectionobjects_common:objectProductionPersonGroupList",
+							"collectionobjects_common:objectProductionPeopleGroupList",
+							"collectionobjects_common:objectProductionPlaceGroupList",
+							"collectionobjects_common:objectStatusList",
+							"collectionobjects_common:otherNumberList",
+							"collectionobjects_common:ownersContributionNote",
+							"collectionobjects_common:publishToList",
+							"collectionobjects_common:responsibleDepartments",
+							"collectionobjects_common:techniqueGroupList",
+							"collectionobjects_common:titleGroupList",
+							"collectionobjects_common:viewersContributionNote",
+							"collectionspace_core:*",
+							"collectionspace_denorm:*",
+							"ecm:currentLifeCycleState",
+							"ecm:name",
+							"ecm:primaryType",
+							"media_common:blobCsid"
+						]
+					},
+					"properties" : {
+						"all_field": {
+							"type": "text",
+							"analyzer": "fulltext"
+						},
+
+						"ecm:currentLifeCycleState": {
+							"type": "keyword"
+						},
+						"ecm:name": {
+							"type": "keyword"
+						},
+						"ecm:primaryType": {
+							"type": "text",
+							"analyzer" : "doctype_analyzer"
+						},
+
+						"collectionspace_core:createdAt": {
+							"type": "date",
+							"format": "date_time"
+						},
+						"collectionobjects_common:publishToList": {
+							"type": "keyword",
+							"fields": {
+								"shortid": {
+									"type": "keyword",
+									"normalizer": "refname_shortid_normalizer"
+								}
+							}
+						},
+
+						"collectionspace_denorm:title": {
+							"type": "keyword",
+							"normalizer": "sorting_normalizer"
+						},
+						"collectionspace_denorm:hasMedia": {
+							"type": "boolean"
+						},
+						"collectionspace_denorm:mediaAltText": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionspace_denorm:prodYears": {
+							"type": "integer"
+						},
+						"collectionspace_denorm:exhibition": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								},
+								"generalNote": {
+									"type": "text",
+									"copy_to": "all_field"
+								},
+								"curatorialNote": {
+									"type": "text",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+
+						"collectionobjects_common:objectNumber": {
+							"type": "keyword",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:briefDescriptions": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:titleGroupList": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "text",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionPersonGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionPerson": {
+									"type": "keyword",
+									"copy_to": "all_field",
+									"fields": {
+										"displayName": {
+											"type": "keyword",
+											"normalizer": "refname_displayname_normalizer"
+										}
+									}
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionOrganizationGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionOrganization": {
+									"type": "keyword",
+									"copy_to": "all_field",
+									"fields": {
+										"displayName": {
+											"type": "keyword",
+											"normalizer": "refname_displayname_normalizer"
+										}
+									}
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionPeopleGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionPeople": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionDateGroupList": {
+							"type": "object",
+							"properties": {
+								"dateDisplayDate": {
+									"type": "text",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionPlaceGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionPlace": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:colors": {
+							"type": "keyword",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:responsibleDepartments": {
+							"type": "keyword",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:contentConcepts": {
+							"type": "keyword",
+							"copy_to": "all_field",
+							"fields": {
+								"displayName": {
+									"type": "keyword",
+									"normalizer": "refname_displayname_normalizer"
+								}
+							}
+						},
+						"collectionobjects_common:techniqueGroupList": {
+							"type": "object",
+							"properties": {
+								"technique": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectHistoryNote": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:ownersContributionNote": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:viewersContributionNote": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+
+						"media_common:blobCsid": {
+							"type": "keyword"
+						},
+						"media_common:publishToList": {
+							"type": "keyword",
+							"fields": {
+								"shortid": {
+									"type": "keyword",
+									"normalizer": "refname_shortid_normalizer"
+								}
+							}
+						}
+					}
+				}
+			</tenant:mapping>
+		</tenant:elasticSearchIndexConfig>
+
+	</tenant:tenantBinding>
 
 </tenant:TenantBindingConfig>

--- a/services/common/src/main/cspace/config/services/tenants/bonsai/bonsai-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/bonsai/bonsai-tenant-bindings.delta.xml
@@ -211,7 +211,13 @@
 							"properties": {
 								"objectProductionPlace": {
 									"type": "keyword",
-									"copy_to": "all_field"
+									"copy_to": "all_field",
+									"fields": {
+										"displayName": {
+											"type": "keyword",
+											"normalizer": "refname_displayname_normalizer"
+										}
+									}
 								}
 							}
 						},


### PR DESCRIPTION
**What does this do?**

This indexes the display name of the objectProductionPlace field in the bonsai profile, so that the display name can be used as a facet in the public browser, instead of the full ref name.

**Why are we doing this? (with JIRA link)**

In the bonsai profile, objectProductionPlace is customized to be an authority-controlled field, instead of free text. This was causing ref names to appear as facets in the public browser.

JIRA: https://collectionspace.atlassian.net/browse/CB-22

**How should this be tested? Do these changes have associated tests?**

In the public browser, with https://github.com/collectionspace/cspace-public-browser.js/pull/27 applied, the values in the Production Place facet should no longer appear as ref names (URNs).

**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran this locally.