### PR TITLE
DRYD-1249: UCB Structured Date Contrib

### DIFF
--- a/services/structureddate/structureddate/src/main/antlr4/org/collectionspace/services/structureddate/antlr/StructuredDate.g4
+++ b/services/structureddate/structureddate/src/main/antlr4/org/collectionspace/services/structureddate/antlr/StructuredDate.g4
@@ -63,7 +63,7 @@ date:                  numDate
 |                      dayFirstDate
 |                      dayOrYearFirstDate
 |                      invStrDateEraLastDate
-|                      romanDate
+|                      romanStringDate
 ;
 
 month:                 monthYear
@@ -97,8 +97,7 @@ century:               ( strCentury | numCentury ) era? ;
 
 millennium:            nth MILLENNIUM era? ;
 
-partialEraRange:      num strMonth num era (DASH|HYPHEN) num strMonth num ;
-romanDate:             num (HYPHEN | SLASH) romanMonth (HYPHEN | SLASH) numYear era? ;
+partialEraRange:       num strMonth num era (DASH|HYPHEN) num strMonth num ;
 strDate:               strMonth ( numDayOfMonth | nth ) COMMA? numYear era?;
 invStrDate:            era num COMMA? strMonth num
 |                      era? num COMMA strMonth num ;
@@ -136,7 +135,9 @@ numMonth:              NUMBER ;
 numDayOfMonth:         NUMBER ;
 num:                   NUMBER ;
 unknownDate:           UNKNOWN ;
-romanMonth:            ROMANMONTH ; 
+romanMonth:            ROMANMONTH ;
+romanStringDate:  num ( DOT | DASH | HYPHEN ) ( MONTH | SHORTMONTH | ROMANMONTH ) ( DOT | DASH | HYPHEN ) num era?
+|                 ( MONTH | SHORTMONTH | ROMANMONTH ) ( DOT | DASH | HYPHEN ) num ( DOT | DASH | HYPHEN ) num era? ;
 
 /*
  * Lexer rules

--- a/services/structureddate/structureddate/src/main/java/org/collectionspace/services/structureddate/antlr/ANTLRStructuredDateEvaluator.java
+++ b/services/structureddate/structureddate/src/main/java/org/collectionspace/services/structureddate/antlr/ANTLRStructuredDateEvaluator.java
@@ -587,10 +587,10 @@ public class ANTLRStructuredDateEvaluator extends StructuredDateBaseListener imp
 		stack.push(dayOfMonth);
 
 		if (dayOfMonth > 31 || dayOfMonth <= 0) {
-			throw new StructuredDateFormatException("unexpected day of month '" + Integer.toString(dayOfMonth) + "'");
+			throw new StructuredDateFormatException("unexpected day of month '" + dayOfMonth + "'");
 		}
 		if (year == 0) {
-			throw new StructuredDateFormatException("unexpected year '" + Integer.toString(year) + "'");
+			throw new StructuredDateFormatException("unexpected year '" + year + "'");
 		}
 	}
 

--- a/services/structureddate/structureddate/src/main/java/org/collectionspace/services/structureddate/antlr/ANTLRStructuredDateEvaluator.java
+++ b/services/structureddate/structureddate/src/main/java/org/collectionspace/services/structureddate/antlr/ANTLRStructuredDateEvaluator.java
@@ -1,7 +1,5 @@
 package org.collectionspace.services.structureddate.antlr;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.Stack;
 
 import org.antlr.v4.runtime.ANTLRInputStream;
@@ -35,9 +33,9 @@ import org.collectionspace.services.structureddate.DeferredQuarterCenturyEndDate
 import org.collectionspace.services.structureddate.DeferredQuarterCenturyStartDate;
 import org.collectionspace.services.structureddate.Era;
 import org.collectionspace.services.structureddate.Part;
-import org.collectionspace.services.structureddate.StructuredDateInternal;
 import org.collectionspace.services.structureddate.StructuredDateEvaluator;
 import org.collectionspace.services.structureddate.StructuredDateFormatException;
+import org.collectionspace.services.structureddate.StructuredDateInternal;
 import org.collectionspace.services.structureddate.antlr.StructuredDateParser.AllOrPartOfContext;
 import org.collectionspace.services.structureddate.antlr.StructuredDateParser.BeforeOrAfterDateContext;
 import org.collectionspace.services.structureddate.antlr.StructuredDateParser.CenturyContext;
@@ -78,11 +76,11 @@ import org.collectionspace.services.structureddate.antlr.StructuredDateParser.Pa
 import org.collectionspace.services.structureddate.antlr.StructuredDateParser.PartialDecadeContext;
 import org.collectionspace.services.structureddate.antlr.StructuredDateParser.PartialEraRangeContext;
 import org.collectionspace.services.structureddate.antlr.StructuredDateParser.PartialYearContext;
-import org.collectionspace.services.structureddate.antlr.StructuredDateParser.RomanDateContext;
 import org.collectionspace.services.structureddate.antlr.StructuredDateParser.QuarterCenturyContext;
 import org.collectionspace.services.structureddate.antlr.StructuredDateParser.QuarterInYearRangeContext;
 import org.collectionspace.services.structureddate.antlr.StructuredDateParser.QuarterYearContext;
 import org.collectionspace.services.structureddate.antlr.StructuredDateParser.RomanMonthContext;
+import org.collectionspace.services.structureddate.antlr.StructuredDateParser.RomanStringDateContext;
 import org.collectionspace.services.structureddate.antlr.StructuredDateParser.SeasonYearContext;
 import org.collectionspace.services.structureddate.antlr.StructuredDateParser.StrCenturyContext;
 import org.collectionspace.services.structureddate.antlr.StructuredDateParser.StrDateContext;
@@ -1248,25 +1246,52 @@ public class ANTLRStructuredDateEvaluator extends StructuredDateBaseListener imp
 	}
 
 	@Override
-	public void exitRomanMonth(RomanMonthContext ctx) {
-		int num = DateUtils.romanToDecimal(ctx.ROMANMONTH().getText());
+	public void exitRomanStringDate(RomanStringDateContext ctx) {
+		if (ctx.exception != null) {
+			return;
+		}
 
-		stack.push(num);
-	}
+		// Need to find out whether it is a MONTH, SHORTMONTH, ROMANMONTH here in order to disambiguate the order
+		// Find if there is a month or SHORTMONTH
+		Integer month = (ctx.MONTH() != null && ctx.SHORTMONTH() == null && ctx.ROMANMONTH() == null) ?
+						(Integer) DateUtils.getMonthByName(ctx.MONTH().getText()) :
+						null;
 
-	@Override
-	public void exitRomanDate(RomanDateContext ctx) {
-		if (ctx.exception != null) return;
+		// it was not a MONTH, so it will either be a SHORTMONTH or ROMANMONTH
+		if (month == null) {
+			month = ctx.ROMANMONTH() == null ?
+					(Integer) DateUtils.getMonthByName(ctx.SHORTMONTH().getText()) :
+					(Integer) DateUtils.romanToDecimal(ctx.ROMANMONTH().getText());
+		}
 
+		// Expect the canonical year-month-day-era ordering
 		Era era = (ctx.era() == null) ? null : (Era) stack.pop();
-		Integer year = (Integer) stack.pop();
-		Integer month = (Integer) stack.pop();
-		Integer day = (Integer) stack.pop();
+
+		Integer num1 = (Integer) stack.pop();
+		Integer num2 = (Integer) stack.pop();
+
+		Integer year = num1;
+		Integer day = num2;
+
+
+		if (DateUtils.isValidDate(num1, month, num2, era)) {
+			// it is a valid year-month-day-era, proceed
+		} else if (DateUtils.isValidDate(num2, month, num1, era)) {
+			// check if its day-month-year-era otherwise
+			year = num2;
+			day = num1;
+		}
 
 		stack.push(year);
 		stack.push(month);
 		stack.push(day);
 		stack.push(era);
+	}
+
+	@Override
+	public void exitRomanMonth(RomanMonthContext ctx) {
+		int num = DateUtils.romanToDecimal(ctx.ROMANMONTH().getText());
+		stack.push(num);
 	}
 
 	@Override

--- a/services/structureddate/structureddate/src/main/java/org/collectionspace/services/structureddate/antlr/ANTLRStructuredDateEvaluator.java
+++ b/services/structureddate/structureddate/src/main/java/org/collectionspace/services/structureddate/antlr/ANTLRStructuredDateEvaluator.java
@@ -181,7 +181,7 @@ public class ANTLRStructuredDateEvaluator extends StructuredDateBaseListener imp
 		Date latestDate = (Date) stack.pop();
 		Date earliestDate = (Date) stack.pop();
 
-		if (earliestDate.getYear() != null || earliestDate.getYear() != null) {
+		if (earliestDate.getYear() != null) {
 			int compareResult = DateUtils.compareDates(earliestDate, latestDate);
 			if (compareResult == 1) {
 				Date temp;

--- a/services/structureddate/structureddate/src/test/java/org/collectionspace/services/structureddate/StructuredDateEvaluatorTest.java
+++ b/services/structureddate/structureddate/src/test/java/org/collectionspace/services/structureddate/StructuredDateEvaluatorTest.java
@@ -47,6 +47,7 @@ public class StructuredDateEvaluatorTest {
 			}
 
 			Assert.assertEquals(actualStructuredDate, expectedStructuredDate);
+			logger.debug("{} was successfully parsed.", displayDate);
 		}
 	}
 

--- a/services/structureddate/structureddate/src/test/resources/test-dates.yaml
+++ b/services/structureddate/structureddate/src/test/resources/test-dates.yaml
@@ -1296,7 +1296,35 @@
   ' ([1997 }]] )':                       # enclosing mixed brackets
                                          earliestSingleDate: [1997,  1,  1, CE]
                                          latestDate:         [1997, 12, 31, CE]
+  '2021.sep.03':
+                                         earliestSingleDate: [2021,  9, 3, CE]
 
+  '2021-oct-4':
+                                         earliestSingleDate: [2021,  10, 4, CE]
+
+  '2021-november-5':
+                                         earliestSingleDate: [2021,  11, 5, CE]
+
+  '2021.december.6':
+                                         earliestSingleDate: [2021,  12, 6, CE]
+
+  '1908-IX-01':
+                                         earliestSingleDate: [1908,  9, 1, CE]
+
+  'IX-01-1908':
+                                         earliestSingleDate: [1908,  9, 1, CE]
+
+  '01-IX-1908':
+                                         earliestSingleDate: [1908,  9, 1, CE]
+
+  '1908.IX.01':
+                                         earliestSingleDate: [1908,  9, 1, CE]
+
+  'IX.01.1908':
+                                         earliestSingleDate: [1908,  9, 1, CE]
+
+  '01.IX.1908':
+                                         earliestSingleDate: [1908,  9, 1, CE]
 
 # -------------------------------------------------------------------------------------------------------
 # Invalid dates


### PR DESCRIPTION
**What does this do?**
* Updates to exitRomanStringDate
* Add additional test dates
* Remove duplicate condition

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1249

This is part of the UCB contributions and brings in changes to structured date from their branch. It makes changes to `romanDate` which is now mapped to `romanStringDate`. There was also a duplicate condition which I removed.

**How should this be tested? Do these changes have associated tests?**
I'm not too familiar with structured dates and what's expected of them so I only did some basic testing:
* Build collectionspace
* Run integration tests
* Create a structured date
  * This should probably be done with a roman formatted date as well

**Dependencies for merging? Releasing to production?**
?

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter built and ran integration tests