### PR TITLE
DRYD-1370: Join on most recent media

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/accessions.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/accessions.jrxml
@@ -83,12 +83,15 @@
   LEFT JOIN hierarchy opdg_hier ON opdg_hier.parentid = object.id AND opdg_hier.name = 'collectionobjects_common:objectProductionDateGroupList' AND opdg_hier.pos = 0
   LEFT JOIN structureddategroup sdg ON sdg.id = opdg_hier.id
 ), related_media AS (
-  SELECT
+  SELECT DISTINCT ON (object.csid)
     object.csid AS objcsid,
     media.objectcsid AS mediacsid
   FROM related_objects object
   INNER JOIN relations_common media ON media.subjectcsid = object.csid AND media.objectdocumenttype = 'Media'
   INNER JOIN misc ON misc.id = media.id AND misc.lifecyclestate != 'deleted'
+  INNER JOIN hierarchy hier ON hier.name = media.objectcsid
+  INNER JOIN collectionspace_core core ON core.id = hier.id
+  ORDER BY object.csid, core.updatedat DESC
 )
 SELECT
   acq.acquisitionreferencenumber,

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/condition.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/condition.jrxml
@@ -24,7 +24,7 @@
 	</parameter>
 	<queryString language="SQL">
 		<![CDATA[WITH media AS (
-  SELECT
+  SELECT DISTINCT ON (relation.subjectcsid)
     relation.subjectcsid,
     relation.objectcsid AS mediacsid
   FROM media_common media
@@ -32,6 +32,8 @@
   INNER JOIN misc ON misc.id = media.id AND misc.lifecyclestate != 'deleted'
   INNER JOIN relations_common relation ON relation.objectcsid = hier.name
     AND (relation.subjectdocumenttype = 'Conditioncheck' OR relation.subjectdocumenttype = 'CollectionObject')
+  INNER JOIN collectionspace_core core ON core.id = media.id
+  ORDER BY relation.subjectcsid, core.updatedat DESC
 )
 SELECT
   obj.objectnumber,

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/deaccessions.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/deaccessions.jrxml
@@ -106,12 +106,15 @@
   LEFT JOIN hierarchy opdg_hier ON opdg_hier.parentid = object.id AND opdg_hier.name = 'collectionobjects_common:objectProductionDateGroupList' AND opdg_hier.pos = 0
   LEFT JOIN structureddategroup sdg ON sdg.id = opdg_hier.id
 ), related_object_media AS (
-  SELECT
+  SELECT DISTINCT ON (object.csid)
     object.csid AS objcsid,
     media.objectcsid as mediacsid
   FROM related_objects object
   INNER JOIN relations_common media ON media.subjectcsid = object.csid AND media.objectdocumenttype = 'Media'
   INNER JOIN misc ON misc.id = media.id AND misc.lifecyclestate != 'deleted'
+  INNER JOIN hierarchy hier ON hier.name = media.objectcsid
+  INNER JOIN collectionspace_core core ON core.id = hier.id
+  ORDER BY object.csid, core.updatedat DESC
 ), related_acquisitions AS (
   SELECT
     acq.acquisitionreferencenumber AS acquisition,

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/obj_computed_location.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/obj_computed_location.jrxml
@@ -57,10 +57,15 @@ LEFT JOIN hierarchy place_hier ON place_hier.parentid = place.id AND place_hier.
 LEFT JOIN placetermgroup place_term ON place_term.id = place_hier.id
 -- related media
 LEFT JOIN (
-  SELECT relation.*
+  SELECT DISTINCT ON (relation.subjectcsid)
+    relation.objectcsid,
+    relation.subjectcsid
   FROM relations_common relation
   INNER JOIN misc ON misc.id = relation.id AND misc.lifecyclestate != 'deleted'
+  INNER JOIN hierarchy hier ON hier.name = relation.objectcsid
+  INNER JOIN collectionspace_core core ON core.id = hier.id
   WHERE relation.objectdocumenttype = 'Media' AND relation.subjectdocumenttype = 'CollectionObject'
+  ORDER BY relation.subjectcsid, core.updatedat DESC
 ) related_media ON related_media.subjectcsid = hier.name
 $P!{whereclause}]]>
 	</queryString>


### PR DESCRIPTION
**What does this do?**
This updates the joins for `related_media` queries in reports to restrict to a single row of the most recently updated media.

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/jira/software/c/projects/DRYD/issues/DRYD-1370

It was determined that returning all related media was not desirable, and that a single thumbnail/csid was preferred. 

**How should this be tested? Do these changes have associated tests?**
* Rebuild collectionspace
* Create 2 Media Handling for testing
* Create a CollectionObject with relations to both Media Handling procedures
* **Basic Object with Current Location**
  * Search on CollectionObjects and run `Basic Object with Current Location` report
  * Verify the thumbnails are correct for each CollectionObject in the report
* **Accessions Test**
  * Create an Acquisition for the CollectionObject
  * Run the `Accessions` report for the Acquisition and verify the thumbnail is the most recent media
  * _Note: Since Acquisitions can be related to multiple CollectionObjects, trying 2 or 3 could be desirable_
* **Deaccessions Test**
  * Create an ObjectExit for the CollectionObject
  * Run the `Deaccessions` report for the ObjectExit and verify the thumbnail is the most recent media
* **Condition Test**
  * Create a ConditionCheck for the CollectionObject
  * Related one or both of the Media Handling records to the Condition Check
  * Search for CollectionObjects and run the `Condition` report
  * Verify the thumbnails are correct for each CollectionObject

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested the reports on a local install