### PR TITLE
DRYD-1315: Simplify keyword search preprocessing.

### DIFF
--- a/services/common/src/main/java/org/collectionspace/services/common/query/nuxeo/QueryManagerNuxeoImpl.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/query/nuxeo/QueryManagerNuxeoImpl.java
@@ -62,8 +62,7 @@ public class QueryManagerNuxeoImpl implements IQueryManager {
 	private static Pattern unescapedSingleQuote = Pattern.compile("(?<!\\\\)'");
 	//private static Pattern kwdSearchProblemChars = Pattern.compile("[\\:\\(\\)\\*\\%]");
 	// HACK to work around Nuxeo regression that tokenizes on '.'.
-	private static Pattern kwdSearchProblemChars = Pattern.compile("[\\:\\(\\)\\*\\%\\.]");
-	private static Pattern kwdSearchHyphen = Pattern.compile(" - ");
+	private static Pattern kwdSearchProblemChars = Pattern.compile("[\\-\\:\\(\\)\\*\\%\\./]");
 	private static Pattern advSearchSqlWildcard = Pattern.compile(".*?[I]*LIKE\\s*\\\"\\%\\\".*?");
 	// Base Nuxeo document type for all CollectionSpace documents/resources
 	public static String COLLECTIONSPACE_DOCUMENT_TYPE = "CollectionSpaceDocument";
@@ -182,7 +181,7 @@ public class QueryManagerNuxeoImpl implements IQueryManager {
 			// Replace problem chars with spaces. Patches CSPACE-4147,
 			// CSPACE-4106
 			escapedAndTrimmed = kwdSearchProblemChars.matcher(escapedAndTrimmed).replaceAll(" ").trim();
-			escapedAndTrimmed = kwdSearchHyphen.matcher(escapedAndTrimmed).replaceAll(" ").trim();
+
 			if(escapedAndTrimmed.isEmpty()) {
 				if (logger.isDebugEnabled() == true) {
 					logger.debug("Phrase reduced to empty after replacements: " + phrase);


### PR DESCRIPTION
**What does this do?**

This simplifies the preprocessing of keyword search terms that cspace performs before passing the terms on to the Nuxeo search API.

The preprocessing performed is now:

1. Replace all punctuation except for `"` and `*` with space
1. Replace `not {term}` with `-{term}`

This results in the following functional changes:

- `'` can no longer be used to enclose a phrase search (but `"` still can).
- `-` can no longer be used to negate a search term (but `not` still can).
- `%` can no longer be used for a prefix search (but `*` still can).
- `\` can no longer be used to escape (the remaining `*` and `"`) operators (but there was no practical use for this anyway, since punctuation was never indexed).

**Why are we doing this? (with JIRA link)**

This makes keyword searches on record numbers like "2014.1.14" and "12-1234" work without needing to replace the punctuation with spaces.

JIRA: https://collectionspace.atlassian.net/browse/DRYD-1315

**How should this be tested? Do these changes have associated tests?**

- Create object records with identification numbers "2014.1.1" and "1-1234". 
- Perform a keyword search on `2014.1.1`. It should locate the correct record.
- Perform a keyword search on `1-1234`. It should locate the correct record.
- Create/update records, adding text to various fields.
- Try various keyword searches with negated terms (using `"not {term}"`), quoted phrases (using `"{phrase}"`), prefix searches (using `{prefix}*`)", `and` and `or` conjunctions, and various combinations thereof. They should produce reasonable results.

**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

The user manual will probably need to be updated.

**Did someone actually run this code to verify it works?**

@ray-lee ran this locally.