### PR TITLE
DRYD-1373: Update reports that use numberofobjects

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/Acq_List_Basic.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/Acq_List_Basic.jrxml
@@ -32,7 +32,7 @@
 						ptg.termdisplayname opperson,
 						objectproductionpeople,
 						datedisplaydate,
-						numberofobjects,
+						objectCountGroup.objectcount numberofobjects,
 						dimensionsummary,
 						computedcurrentlocation
 	FROM acquisitions_common ac
@@ -63,6 +63,8 @@
 	LEFT OUTER JOIN measuredpartgroup mpg ON (mpg.id = h10.id)
 	LEFT OUTER JOIN collectionspace_core core ON (coc.id = core.id)
 	LEFT OUTER JOIN misc misc ON (misc.id = coc.id)
+	LEFT OUTER JOIN hierarchy countHierarchy ON (coc.id = countHierarchy.parentid AND countHierarchy.primarytype='objectCountGroup' AND countHierarchy.pos=0)
+	LEFT OUTER JOIN objectcountgroup objectCountGroup ON (countHierarchy.id = objectCountGroup.id)
 	WHERE core.tenantid = $P{tenantid} AND misc.lifecyclestate != 'deleted'
 	AND h1.name = $P{csid}]]>
 	</queryString>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/CC_List_Basic.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/CC_List_Basic.jrxml
@@ -32,7 +32,7 @@
 						ptg.termdisplayname opperson,
 						objectproductionpeople,
 						datedisplaydate,
-						numberofobjects,
+						objectCountGroup.objectcount numberofobjects,
 						dimensionsummary,
 						computedcurrentlocation
 	FROM conditionchecks_common cc
@@ -63,6 +63,8 @@
 	LEFT OUTER JOIN measuredpartgroup mpg ON (mpg.id = h10.id)
 	LEFT OUTER JOIN collectionspace_core core ON (coc.id = core.id)
 	LEFT OUTER JOIN misc misc ON (misc.id = coc.id)
+	LEFT OUTER JOIN hierarchy countHierarchy ON (coc.id = countHierarchy.parentid AND countHierarchy.primarytype='objectCountGroup' AND countHierarchy.pos=0)
+	LEFT OUTER JOIN objectcountgroup objectCountGroup ON (countHierarchy.id = objectCountGroup.id)
 	WHERE core.tenantid = $P{tenantid} AND misc.lifecyclestate != 'deleted'
 	AND h1.name = $P{csid}]]>
 	</queryString>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/Exhibition_List_Basic.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/Exhibition_List_Basic.jrxml
@@ -33,7 +33,7 @@
 						ptg.termdisplayname opperson,
 						objectproductionpeople,
 						datedisplaydate,
-						numberofobjects,
+						objectCountGroup.objectcount numberofobjects,
 						dimensionsummary,
 						computedcurrentlocation
 	FROM exhibitions_common ec
@@ -64,6 +64,8 @@
 	LEFT OUTER JOIN measuredpartgroup mpg ON (mpg.id = h10.id)
 	LEFT OUTER JOIN collectionspace_core core ON (coc.id = core.id)
 	LEFT OUTER JOIN misc misc ON (misc.id = coc.id)
+	LEFT OUTER JOIN hierarchy countHierarchy ON (coc.id = countHierarchy.parentid AND countHierarchy.primarytype='objectCountGroup' AND countHierarchy.pos=0)
+	LEFT OUTER JOIN objectcountgroup objectCountGroup ON (countHierarchy.id = objectCountGroup.id)
 	WHERE core.tenantid = $P{tenantid} AND misc.lifecyclestate != 'deleted'
 	AND h1.name = $P{csid}]]>
 	</queryString>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/Group_List_Basic.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/Group_List_Basic.jrxml
@@ -65,7 +65,7 @@
 						objectproductionperson,
 						objectproductionpeople,
 						datedisplaydate,
-						numberofobjects,
+						objectCountGroup.objectcount numberofobjects,
 						dimensionsummary,
 						computedcurrentlocation
 	FROM collectionobjects_common coc
@@ -87,6 +87,8 @@
 	LEFT OUTER JOIN structureddategroup sdg ON (sdg.id = h9.id)
 	LEFT OUTER JOIN hierarchy h10 ON (coc.id = h10.parentid AND h10.primarytype='measuredPartGroup' AND h10.pos=0)
 	LEFT OUTER JOIN measuredpartgroup mpg ON (mpg.id = h10.id)
+	LEFT OUTER JOIN hierarchy countHierarchy ON (coc.id = countHierarchy.parentid AND countHierarchy.primarytype='objectCountGroup' AND countHierarchy.pos=0)
+	LEFT OUTER JOIN objectcountgroup objectCountGroup ON (countHierarchy.id = objectCountGroup.id)
 	$P!{whereclause}]]>
 	</queryString>
 	<field name="objectnumber" class="java.lang.String"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/LoansIn_List_Basic.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/LoansIn_List_Basic.jrxml
@@ -33,7 +33,7 @@
 						ptg.termdisplayname opperson,
 						objectproductionpeople,
 						datedisplaydate,
-						numberofobjects,
+						objectCountGroup.objectcount numberofobjects,
 						dimensionsummary,
 						computedcurrentlocation
 	FROM loansin_common lic
@@ -64,6 +64,8 @@
 	LEFT OUTER JOIN measuredpartgroup mpg ON (mpg.id = h10.id)
 	LEFT OUTER JOIN collectionspace_core core ON (coc.id = core.id)
 	LEFT OUTER JOIN misc misc ON (misc.id = coc.id)
+	LEFT OUTER JOIN hierarchy countHierarchy ON (coc.id = countHierarchy.parentid AND countHierarchy.primarytype='objectCountGroup' AND countHierarchy.pos=0)
+	LEFT OUTER JOIN objectcountgroup objectCountGroup ON (countHierarchy.id = objectCountGroup.id)
 	WHERE core.tenantid = $P{tenantid} AND misc.lifecyclestate != 'deleted'
 	AND h1.name = $P{csid}]]>
 	</queryString>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/LoansOut_List_Basic.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/LoansOut_List_Basic.jrxml
@@ -33,7 +33,7 @@
 						ptg.termdisplayname opperson,
 						objectproductionpeople,
 						datedisplaydate,
-						numberofobjects,
+						objectCountGroup.objectcount numberofobjects,
 						dimensionsummary,
 						computedcurrentlocation
 	FROM loansout_common loc
@@ -64,6 +64,8 @@
 	LEFT OUTER JOIN measuredpartgroup mpg ON (mpg.id = h10.id)
 	LEFT OUTER JOIN collectionspace_core core ON (coc.id = core.id)
 	LEFT OUTER JOIN misc misc ON (misc.id = coc.id)
+	LEFT OUTER JOIN hierarchy countHierarchy ON (coc.id = countHierarchy.parentid AND countHierarchy.primarytype='objectCountGroup' AND countHierarchy.pos=0)
+	LEFT OUTER JOIN objectcountgroup objectCountGroup ON (countHierarchy.id = objectCountGroup.id)
 	WHERE core.tenantid = $P{tenantid} AND misc.lifecyclestate != 'deleted'
 	AND h1.name = $P{csid}]]>
 	</queryString>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/catalogue_sheet.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/catalogue_sheet.jrxml
@@ -9,7 +9,7 @@
 		<defaultValueExpression><![CDATA["341e66cc-4848-4211-afe2"]]></defaultValueExpression>
 	</parameter>
 	<queryString>
-		<![CDATA[select co_c.objectnumber, co_c.numberofobjects, co_c.collection, ltg.termname,
+		<![CDATA[select co_c.objectnumber, objectCountGroup.objectcount numberofobjects, co_c.collection, ltg.termname,
 		 co_c.editionnumber, vic.displayname, co_fa.materialtechniquedescription, tg.title, dg.datedisplaydate, string_agg(distinct oppeepg.objectproductionpeople,', '),
 		 string_agg(distinct ptg.termdisplayname,', '), string_agg(distinct oporgg.objectproductionorganization,', '), string_agg(distinct mg.material,', '), string_agg(distinct tqg.technique,', '),
 		 co_c2.objectnumber, concat(mpg.measuredpart, ' -- ',string_agg(distinct concat(dsg.dimension, ': ',dsg.value, ' ', dsg.measurementunit), '; '))
@@ -47,6 +47,8 @@ left join hierarchy as h13 on (co_c.id = h13.parentid and h13.primarytype = 'mea
 left join measuredpartgroup as mpg on (mpg.id = h13.id)
 left join hierarchy as h14 on (h13.id = h14.parentid and h14.primarytype = 'dimensionSubGroup')
 left join dimensionsubgroup as dsg on (h14.id = dsg.id)
+LEFT OUTER JOIN hierarchy countHierarchy ON (co_c.id = countHierarchy.parentid AND countHierarchy.primarytype='objectCountGroup' AND countHierarchy.pos=0)
+LEFT OUTER JOIN objectcountgroup objectCountGroup ON (countHierarchy.id = objectCountGroup.id)
 WHERE h0.name = $P{csid}
 GROUP BY co_c.objectnumber, co_c.numberofobjects, co_c.collection, ltg.termname,
 		 co_c.editionnumber, co_fa.cataloglevel, tg.title, dg.datedisplaydate, oppeepg.objectproductionpeople, co_fa.materialtechniquedescription, vic.displayname,

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/full_obj_place.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/full_obj_place.jrxml
@@ -31,7 +31,7 @@
 	obj.recordstatus,
 	publishto.item AS publishto,
 	installationtype.item AS installationtype,
-	obj.numberofobjects,
+	objectCountGroup.objectcount AS numberofobjects,
 	worktype.objectname AS worktype,
 	material.material, -- deurn
 	bd.item AS briefdescription,
@@ -81,6 +81,8 @@ LEFT JOIN hierarchy material_hier on material_hier.parentid = obj.id and materia
 LEFT JOIN materialgroup material on material.id = material_hier.id
 LEFT JOIN collectionobjects_publicart_publicartcollections collections ON collections.id = obj.id AND collections.pos = 0
 LEFT JOIN collectionobjects_common_owners owners ON owners.id = obj.id AND owners.pos = 0
+LEFT JOIN hierarchy count_hier ON obj.id = count_hier.parentid AND count_hier.primarytype='objectCountGroup' AND count_hier.pos=0
+LEFT JOIN objectcountgroup objectCountGroup ON count_hier.id = objectCountGroup.id
 -- aggregate for the dimension
 LEFT JOIN (
 	SELECT

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/systematicInventory.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/systematicInventory.jrxml
@@ -22,12 +22,14 @@
 regexp_replace(c.computedcurrentlocation, '^.*\)''(.*)''$', '\1') as storageLocation,
 replace(regexp_replace(c.computedcurrentlocation, '^.*\)''(.*)''$', '\1'), ' ', '0') as locationkey,
 c.objectnumber objectNumber,
-c.numberofobjects objectCount,
+objectCountGroup.objectcount objectCount,
 ong.objectName objectName
 FROM collectionobjects_common c
 left outer join hierarchy h1 on (c.id = h1.parentid and h1.pos=0 and h1.name='collectionobjects_common:objectNameList')
 left outer join objectnamegroup ong on (ong.id=h1.id)
 join misc ms on (c.id=ms.id and ms.lifecyclestate <> 'deleted')
+left join hierarchy count_hier ON (c.id = count_hier.parentid AND count_hier.primarytype='objectCountGroup' AND count_hier.pos=0)
+left join objectcountgroup objectCountGroup ON count_hier.id = objectCountGroup.id
 WHERE replace(regexp_replace(c.computedcurrentlocation, '^.*\)''(.*)''$', '\1'), ' ', '0') >= replace(regexp_replace($P{startLocation}, '^.*\)''(.*)''$', '\1'), ' ', '0')
   and replace(regexp_replace(c.computedcurrentlocation, '^.*\)''(.*)''$', '\1'), ' ', '0') <= replace(regexp_replace($P{endLocation}, '^.*\)''(.*)''$', '\1'), ' ', '0')
 order by locationkey, objectnumber, objectName desc]]>


### PR DESCRIPTION
**What does this do?**
This removes the usage of `numberofobjects` in reports and performs a join on the new `objectcountgroup` table in order to use `objectcount`.

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1373

As part of replacing the `numberofobjects` field, we need to update references to it in various places. This step is for updating the reports which rely on that field so that they can continue to be used with the correct information.

**How should this be tested? Do these changes have associated tests?**
* Deploy collectionspace
* Create a CollectionObject with one or more `objectCount`s.
* Run the following reports:
  * Acquisition, Acquisition Basic List - requires a related collectionobject
  * Condition Check, ConditionCheck Basic List - requires a related collectionobject
  * Exhibition, Exhibition Basic List - requires a related collectionobject
  * Loan In, Loan In Basic List - requires a related collectionobject
  * Loan Out, Loan Out Basic List - requires a related collectionobject
  * CollectionObject, Group Basic List
* In the publicart profile run the following report
  * CollectionObject, Full Object with Place Details 

**Dependencies for merging? Releasing to production?**
I wasn't sure on the context for running the `catalogue_sheet` and `systematicInventory` reports. The xml for `catalogue_sheet` is missing thought looking at the report I could likely just do it on a single collectionobject.

The `systematicInvetory` only has `supportsNoContext` set, which I wasn't sure about.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter ran the reports with an objectcount set
