### PR TITLE
DRYD-1378: Updates for objectCountGroup

### DIFF
--- a/services/IntegrationTests/src/test/resources/test-data/xmlreplay/collectionobject/repfield_whitesp1.xml
+++ b/services/IntegrationTests/src/test/resources/test-data/xmlreplay/collectionobject/repfield_whitesp1.xml
@@ -4,6 +4,7 @@
 <briefDescriptions> <briefDescription> briefDescription</briefDescription></briefDescriptions>
 <distinguishingFeatures>distFeatures</distinguishingFeatures>
 <numberOfObjects>1</numberOfObjects>
+<objectCountGroupList> <objectCountGroup><objectCount>1</objectCount></objectCountGroup></objectCountGroupList>
 <!-- test whitespace as first child node -->
 <responsibleDepartments> <responsibleDepartment> responsibleDept1</responsibleDepartment><responsibleDepartment>responsibleDept2</responsibleDepartment></responsibleDepartments>
 <titleGroupList><titleGroup><title>title</title></titleGroup></titleGroupList>

--- a/services/IntegrationTests/src/test/resources/test-data/xmlreplay/collectionobject/repfield_whitesp2.xml
+++ b/services/IntegrationTests/src/test/resources/test-data/xmlreplay/collectionobject/repfield_whitesp2.xml
@@ -8,6 +8,11 @@
 </briefDescriptions>
 <distinguishingFeatures>distFeatures</distinguishingFeatures>
 <numberOfObjects>1</numberOfObjects>
+<objectCountGroupList>
+<objectCountGroup>
+<objectCount>1</objectCount>
+</objectCountGroup>
+</objectCountGroupList>
 <!-- test newline whitespace -->
 <responsibleDepartments>
 <responsibleDepartment>responsibleDept1</responsibleDepartment>

--- a/services/IntegrationTests/src/test/resources/test-data/xmlreplay/collectionobject/repfield_whitesp3.xml
+++ b/services/IntegrationTests/src/test/resources/test-data/xmlreplay/collectionobject/repfield_whitesp3.xml
@@ -10,6 +10,13 @@
 
 <distinguishingFeatures>distFeatures</distinguishingFeatures>
 <numberOfObjects>1</numberOfObjects>
+
+<objectCountGroupList>
+<objectCountGroup>
+<objectCount>1</objectCount>
+</objectCountGroup>
+</objectCountGroupList>
+
 <!-- test newline whitespace -->
 <responsibleDepartments>
 <!-- test childnode as whitespace -->

--- a/services/IntegrationTests/src/test/resources/test-data/xmlreplay/collectionobject/repfield_whitesp4.xml
+++ b/services/IntegrationTests/src/test/resources/test-data/xmlreplay/collectionobject/repfield_whitesp4.xml
@@ -8,6 +8,11 @@
 </briefDescriptions>
 <distinguishingFeatures>distFeatures</distinguishingFeatures>
 <numberOfObjects>1</numberOfObjects>
+<objectCountGroupList>
+    <objectCountGroup>
+        <objectCount>1</objectCount>
+    </objectCountGroup>
+</objectCountGroupList>
 <!-- test newline and tab whitespace -->
 <responsibleDepartments>
     <responsibleDepartment>responsibleDept1</responsibleDepartment>

--- a/services/IntegrationTests/src/test/resources/test-data/xmlreplay/collectionobject/testCambridge.xml
+++ b/services/IntegrationTests/src/test/resources/test-data/xmlreplay/collectionobject/testCambridge.xml
@@ -5,6 +5,11 @@
   <comments>comments</comments>
   <distinguishingFeatures>distFeatures</distinguishingFeatures>
   <numberOfObjects>1</numberOfObjects>
+  <objectCountGroupList>
+    <objectCountGroup>
+      <objectCount>1</objectCount>
+    </objectCountGroup>
+  </objectCountGroupList>
   <responsibleDepartments>
   </responsibleDepartments>
   <titleGroupList>

--- a/services/collectionobject/client/src/test/java/org/collectionspace/services/client/test/CollectionObjectServiceTest.java
+++ b/services/collectionobject/client/src/test/java/org/collectionspace/services/client/test/CollectionObjectServiceTest.java
@@ -28,21 +28,6 @@ import java.util.List;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-//import org.collectionspace.services.client.AbstractServiceClientImpl;
 import org.collectionspace.services.client.CollectionObjectClient;
 import org.collectionspace.services.client.CollectionObjectFactory;
 import org.collectionspace.services.client.CollectionSpaceClient;

--- a/services/collectionobject/client/src/test/resources/test-data/repfield_whitesp1.xml
+++ b/services/collectionobject/client/src/test/resources/test-data/repfield_whitesp1.xml
@@ -5,6 +5,7 @@
 <briefDescriptions> <briefDescription> briefDescription</briefDescription></briefDescriptions>
 <distinguishingFeatures>distFeatures</distinguishingFeatures>
 <numberOfObjects>numberOfObjects</numberOfObjects>
+<objectCountGroupList> <objectCountGroup><objectCount>1</objectCount></objectCountGroup></objectCountGroupList>
 <!-- test whitespace as first child node -->
 <responsibleDepartments> <responsibleDepartment> responsibleDept1</responsibleDepartment><responsibleDepartment>responsibleDept2</responsibleDepartment></responsibleDepartments>
 </ns2:collectionobjects_common> 

--- a/services/collectionobject/client/src/test/resources/test-data/repfield_whitesp2.xml
+++ b/services/collectionobject/client/src/test/resources/test-data/repfield_whitesp2.xml
@@ -8,6 +8,11 @@
 </briefDescriptions>
 <distinguishingFeatures>distFeatures</distinguishingFeatures>
 <numberOfObjects>numberOfObjects</numberOfObjects>
+<objectCountGroupList>
+<objectCountGroup>
+<objectCount>1</objectCount>
+</objectCountGroup>
+</objectCountGroupList>
 <!-- test newline whitespace -->
 <responsibleDepartments>
 <responsibleDepartment>responsibleDept1</responsibleDepartment>

--- a/services/collectionobject/client/src/test/resources/test-data/repfield_whitesp3.xml
+++ b/services/collectionobject/client/src/test/resources/test-data/repfield_whitesp3.xml
@@ -10,6 +10,13 @@
 
 <distinguishingFeatures>distFeatures</distinguishingFeatures>
 <numberOfObjects>numberOfObjects</numberOfObjects>
+
+<objectCountGroupList>
+<objectCountGroup>
+<objectCount>1</objectCount>
+</objectCountGroup>
+</objectCountGroupList>
+
 <!-- test newline whitespace -->
 <responsibleDepartments>
 <!-- test childnode as whitespace -->

--- a/services/collectionobject/client/src/test/resources/test-data/repfield_whitesp4.xml
+++ b/services/collectionobject/client/src/test/resources/test-data/repfield_whitesp4.xml
@@ -8,6 +8,11 @@
 </briefDescriptions>
 <distinguishingFeatures>distFeatures</distinguishingFeatures>
 <numberOfObjects>numberOfObjects</numberOfObjects>
+<objectCountGroupList>
+    <objectCountGroup>
+        <objectCount>1</objectCount>
+    </objectCountGroup>
+</objectCountGroupList>
 <!-- test newline and tab whitespace -->
 <responsibleDepartments>
     <responsibleDepartment>responsibleDept1</responsibleDepartment>

--- a/services/collectionobject/client/src/test/resources/test-data/testCambridge.xml
+++ b/services/collectionobject/client/src/test/resources/test-data/testCambridge.xml
@@ -11,4 +11,9 @@
   <objectNumber>objectNumber</objectNumber>
   <distinguishingFeatures>distFeatures</distinguishingFeatures>
   <numberOfObjects>numberOfObjects</numberOfObjects>
-</ns2:collectionobjects_common> 
+  <objectCountGroupList>
+    <objectCountGroup>
+      <objectCount>1</objectCount>
+    </objectCountGroup>
+  </objectCountGroupList>
+</ns2:collectionobjects_common>

--- a/services/collectionobject/jaxb/src/main/resources/collectionobjects_common.xsd
+++ b/services/collectionobject/jaxb/src/main/resources/collectionobjects_common.xsd
@@ -42,6 +42,7 @@
                 <xs:element name="comments" type="commentList"/>
                 <xs:element name="distinguishingFeatures" type="xs:string"/>
                 <xs:element name="numberOfObjects" type="xs:integer"/>
+                <xs:element name="objectCountGroupList" type="objectCountGroupList" />
                 <xs:element name="objectNameList" type="ns:objectNameList"/>
                 <xs:element name="responsibleDepartments" type="responsibleDepartmentList"/>
                 <xs:element name="collection" type="xs:string"/>
@@ -172,6 +173,22 @@
             </xs:sequence>
         </xs:complexType>
     </xs:element>
+
+    <xs:complexType name="objectCountGroupList">
+        <xs:sequence>
+            <xs:element name="objectCountGroup" type="objectCountGroup" minOccurs="0"
+                        maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="objectCountGroup">
+        <xs:sequence>
+            <xs:element name="objectCount" type="xs:integer" />
+            <xs:element name="objectCountType" type="xs:string" />
+            <xs:element name="objectCountCountedBy" type="xs:string" />
+            <xs:element name="objectCountDate" type="xs:date" />
+            <xs:element name="objectCountNote" type="xs:string" />
+        </xs:sequence>
+    </xs:complexType>
 
     <xs:complexType name="otherNumberList">
         <xs:sequence>

--- a/services/common/src/main/cspace/config/services/tenants/anthro/anthro-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/anthro/anthro-tenant-bindings.delta.xml
@@ -34,6 +34,7 @@
 							"collectionobjects_common:materialGroupList",
 							"collectionobjects_common:measuredPartGroupList",
 							"collectionobjects_common:numberOfObjects",
+							"collectionobjects_common:objectCountGroupList",
 							"collectionobjects_common:objectHistoryNote",
 							"collectionobjects_common:objectNameList",
 							"collectionobjects_common:objectNumber",

--- a/services/common/src/main/cspace/config/services/tenants/bonsai/bonsai-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/bonsai/bonsai-tenant-bindings.delta.xml
@@ -28,6 +28,7 @@
 							"collectionobjects_common:materialGroupList",
 							"collectionobjects_common:measuredPartGroupList",
 							"collectionobjects_common:numberOfObjects",
+							"collectionobjects_common:objectCountGroupList",
 							"collectionobjects_common:objectHistoryNote",
 							"collectionobjects_common:objectNameList",
 							"collectionobjects_common:objectNumber",

--- a/services/common/src/main/cspace/config/services/tenants/fcart/fcart-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/fcart/fcart-tenant-bindings.delta.xml
@@ -28,6 +28,7 @@
 							"collectionobjects_common:materialGroupList",
 							"collectionobjects_common:measuredPartGroupList",
 							"collectionobjects_common:numberOfObjects",
+							"collectionobjects_common:objectCountGroupList",
 							"collectionobjects_common:objectHistoryNote",
 							"collectionobjects_common:objectNameList",
 							"collectionobjects_common:objectNumber",

--- a/services/common/src/main/cspace/config/services/tenants/materials/materials-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/materials/materials-tenant-bindings.delta.xml
@@ -89,6 +89,7 @@
                     "collectionobjects_materials:materialGenericColors",
                     "collectionobjects_materials:materialFinishGroupList",
                     "collectionobjects_common:numberOfObjects",
+                    "collectionobjects_common:objectCountGroupList",
                     "collectionobjects_common:briefDescriptions",
                     "collectionobjects_common:measuredPartGroupList",
                     "collectionobjects_common:viewersContributionNote",

--- a/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
+++ b/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
@@ -1159,6 +1159,7 @@
 							"collectionobjects_common:materialGroupList",
 							"collectionobjects_common:measuredPartGroupList",
 							"collectionobjects_common:numberOfObjects",
+							"collectionobjects_common:objectCountGroupList",
 							"collectionobjects_common:objectHistoryNote",
 							"collectionobjects_common:objectNameList",
 							"collectionobjects_common:objectNumber",

--- a/services/imports/service/src/test/resources/requests/collectionobject-request.xml
+++ b/services/imports/service/src/test/resources/requests/collectionobject-request.xml
@@ -81,6 +81,11 @@
               <contentConcept></contentConcept>
             </collectionobjects_common:contentConcepts>
             <collectionobjects_common:numberOfObjects>1</collectionobjects_common:numberOfObjects>
+            <collectionobjects_common:objectCountGroupList>
+              <collectionobjects_common:objectCountGroup>
+                <collectionobjects_common:objectCount>1</collectionobjects_common:objectCount>
+              </collectionobjects_common:objectCountGroup>
+            </collectionobjects_common:objectCountGroupList>
             <collectionobjects_common:ownershipExchangePriceCurrency>poundsterling</collectionobjects_common:ownershipExchangePriceCurrency>
             <collectionobjects_common:contentOtherGroupList>
               <contentOtherGroup>


### PR DESCRIPTION
**What does this do?**
* Add objectCountGroupList to the collectionobject jaxb schema
* Add objectCountGroupList to es included fields
* Add objectCountGroupList to xml templates for testing
* Whitespace cleanup in CollectionObjectServiceTest

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1378

This adds objectCountGroupList and related fields where `numberOfObjects` is used in the services layer. It does not remove numberOfObjects but lets them live side by side until the migration is complete.

**How should this be tested? Do these changes have associated tests?**
* Rebuild collectionspace
* Run the integration tests

**Dependencies for merging? Releasing to production?**
Some of the xml files do not appear to be used, so some of this is more for completeness than anything else (e.g. `services/imports/.../collectionobject-request.xml`). 

I'm also not 100% certain how numberOfObjects is used in the material public browser. I was going to dig into it more with the public browser ticket.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local server. I have an integration test which is failing that I'm looking into, though appears at a glance to be unrelated.