### PR TITLE
CB-26: Add denormalized field for content fields

### DIFF
--- a/3rdparty/nuxeo/nuxeo-platform-elasticsearch/src/main/java/org/collectionspace/services/nuxeo/elasticsearch/DefaultESDocumentWriter.java
+++ b/3rdparty/nuxeo/nuxeo-platform-elasticsearch/src/main/java/org/collectionspace/services/nuxeo/elasticsearch/DefaultESDocumentWriter.java
@@ -255,7 +255,7 @@ private void denormExhibitionRecords(CoreSession session, String csid, String te
 	}
 
 	/**
-	 * Denormalize the content concept, content event, content person, content organization, and content description
+	 * Denormalize the content concept, content event, content person, and content organization
 	 * fields for a collectionobject so that they are indexed under a single field
 	 *
 	 * @param doc the collectionobject document
@@ -278,13 +278,6 @@ private void denormExhibitionRecords(CoreSession session, String csid, String te
 					denormContentSubject.add(node);
 				}
 			}
-		}
-
-		String description = (String) doc.getProperty("collectionobjects_common", "contentDescription");
-		if (description != null) {
-			final ObjectNode node = objectMapper.createObjectNode();
-			node.put("subject", description);
-			denormContentSubject.add(node);
 		}
 
 		denormValues.putArray("contentSubjectList").addAll(denormContentSubject);

--- a/3rdparty/nuxeo/nuxeo-platform-elasticsearch/src/main/java/org/collectionspace/services/nuxeo/elasticsearch/DefaultESDocumentWriter.java
+++ b/3rdparty/nuxeo/nuxeo-platform-elasticsearch/src/main/java/org/collectionspace/services/nuxeo/elasticsearch/DefaultESDocumentWriter.java
@@ -60,6 +60,7 @@ public class DefaultESDocumentWriter extends JsonESDocumentWriter {
 			denormMediaRecords(session, csid, tenantId, denormValues);
 			denormAcquisitionRecords(session, csid, tenantId, denormValues);
 			denormExhibitionRecords(session, csid, tenantId, denormValues);
+			denormConceptFields(doc, denormValues);
 			denormMaterialFields(doc, denormValues);
 			denormObjectNameFields(doc, denormValues);
 
@@ -251,6 +252,42 @@ private void denormExhibitionRecords(CoreSession session, String csid, String te
 		}
 
 		denormValues.putArray("objectNameList").addAll(denormObjectNames);
+	}
+
+	/**
+	 * Denormalize the content concept, content event, content person, content organization, and content description
+	 * fields for a collectionobject so that they are indexed under a single field
+	 *
+	 * @param doc the collectionobject document
+	 * @param denormValues the json node for denormalized fields
+	 */
+	private void denormConceptFields(final DocumentModel doc, final ObjectNode denormValues) {
+		final List<JsonNode> denormContentSubject = new ArrayList<>();
+		final List<String> fields = Arrays.asList("contentConcepts",
+			"contentEvents",
+			"contentPersons",
+			"contentOrganizations");
+
+		for (String field : fields) {
+			List<String> contentList = (List<String>) doc.getProperty("collectionobjects_common", field);
+
+			for (String content  : contentList) {
+				if (content != null) {
+					final ObjectNode node = objectMapper.createObjectNode();
+					node.put("subject", RefNameUtils.getDisplayName(content));
+					denormContentSubject.add(node);
+				}
+			}
+		}
+
+		String description = (String) doc.getProperty("collectionobjects_common", "contentDescription");
+		if (description != null) {
+			final ObjectNode node = objectMapper.createObjectNode();
+			node.put("subject", description);
+			denormContentSubject.add(node);
+		}
+
+		denormValues.putArray("contentSubjectList").addAll(denormContentSubject);
 	}
 
 	/**

--- a/services/common/src/main/cspace/config/services/tenants/anthro/anthro-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/anthro/anthro-tenant-bindings.delta.xml
@@ -150,6 +150,15 @@
 								}
 							}
 						},
+						"collectionspace_denorm:contentSubjectList": {
+							"type": "object",
+							"properties": {
+								"subject": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
 
 						"collectionobjects_common:objectNumber": {
 							"type": "keyword",

--- a/services/common/src/main/cspace/config/services/tenants/bonsai/bonsai-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/bonsai/bonsai-tenant-bindings.delta.xml
@@ -140,6 +140,15 @@
 								}
 							}
 						},
+						"collectionspace_denorm:contentSubjectList": {
+							"type": "object",
+							"properties": {
+								"subject": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
 
 						"collectionobjects_common:objectNumber": {
 							"type": "keyword",

--- a/services/common/src/main/cspace/config/services/tenants/fcart/fcart-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/fcart/fcart-tenant-bindings.delta.xml
@@ -141,6 +141,15 @@
 								}
 							}
 						},
+						"collectionspace_denorm:contentSubjectList": {
+							"type": "object",
+							"properties": {
+								"subject": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
 
 						"collectionobjects_common:objectNumber": {
 							"type": "keyword",

--- a/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
+++ b/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
@@ -1275,6 +1275,15 @@
 								}
 							}
 						},
+						"collectionspace_denorm:contentSubjectList": {
+							"type": "object",
+							"properties": {
+								"subject": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
 
 						"collectionobjects_common:objectNumber": {
 							"type": "keyword",


### PR DESCRIPTION
**What does this do?**
* Creates aggregate field for indexing content fields

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/jira/software/c/projects/CB/issues/CB-26

This work is to help simplify the public browser logic for displaying these related fields under a single heading. It also resolves the issue of indexed items being in the detail display for an object but not being seen in the filter panel.

**How should this be tested? Do these changes have associated tests?**
* Rebuild collectionspace with elasticsearch enabled
* Create a collectionobject with the content concept, organization, event, persons, and description filled out
* Query elasticsearch for the denormalized field, e.g.
```
[publicbrowser] $ cat subject.json 
{"preference":"result"}
{"query":{"term":{"ecm:primaryType":"CollectionObject"}},"from":0,"size":23,"_source":{"includes":["ecm:name","ecm:primaryType","collectionspace_denorm:contentSubjectList"]},"sort":{"collectionspace_core:createdAt":{"order":"desc"}},"aggs":{"subject":{"terms":{"field":"collectionobjects_denorm:contentSubjectList.subject","order":{"_term":"asc"},"size":300}}}}
[publicbrowser] $ curl -H "Content-Type: application/x-ndjson" -XGET http://localhost:9200/nuxeo_default/doc/_msearch --data-binary @subject.json | jq
```

**Dependencies for merging? Releasing to production?**
Two things before merging:
* I was considering adding an extra field so that we can determine if the subject is able to be linked to in the public browser. I believe the description is the only field which wouldn't be linked to, but I'm still testing the public browser side of things.
  * The link for the description actually appears to work fine, so this doesn't seem necessary anymore
* I noticed the tenant bindings for materials was missing some of the newer denorm fields, e.g. objectNameList. I _think_ we'll want to add that and the contentSubjectList, but didn't make changes yet.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local install