### PR TITLE
DRYD-1396: Fix structured date parser failures on February 29.

### DIFF
--- a/services/structureddate/structureddate/pom.xml
+++ b/services/structureddate/structureddate/pom.xml
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>
-			<version>2.3</version>
+			<version>2.12.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.antlr</groupId>

--- a/services/structureddate/structureddate/src/main/java/org/collectionspace/services/structureddate/DateUtils.java
+++ b/services/structureddate/structureddate/src/main/java/org/collectionspace/services/structureddate/DateUtils.java
@@ -66,7 +66,7 @@ public class DateUtils {
 			era = Date.DEFAULT_ERA;
 		}
 
-		DateTime dateTime = new DateTime(chronology)
+		DateTime dateTime = new DateTime(0, chronology)
 				.withEra((era == Era.BCE) ? DateTimeConstants.BC : DateTimeConstants.AD)
 				.withYearOfEra(year)
 				.withMonthOfYear(month);
@@ -1225,7 +1225,7 @@ public class DateUtils {
 			return interval;
 		}
 
-		MutableDateTime dateTime = new MutableDateTime(chronology);
+		MutableDateTime dateTime = new MutableDateTime(0, chronology);
 		dateTime.era().set((era == Era.BCE) ? DateTimeConstants.BC : DateTimeConstants.AD);
 		dateTime.yearOfEra().set(year);
 		dateTime.monthOfYear().set(1);
@@ -1379,7 +1379,7 @@ public class DateUtils {
 			era = Date.DEFAULT_ERA;
 		}
 
-		MutableDateTime dateTime = new MutableDateTime(chronology);
+		MutableDateTime dateTime = new MutableDateTime(0, chronology);
 		dateTime.era().set((era == Era.BCE) ? DateTimeConstants.BC : DateTimeConstants.AD);
 		dateTime.yearOfEra().set(date.getYear());
 		dateTime.monthOfYear().set(date.getMonth());


### PR DESCRIPTION
**What does this do?**

This fixes failures to parse certain date formats on February 29. When constructing Joda DateTime and MutableDateTime objects, the object is now initialized to the instant 0 (1970-01-01T00:00:00Z). Since the day-of-month is now initialized to 1, this avoids having an intermediate state in which the year gets updated via setter to a non-leap year, but the month and day-of-month are 2 and 29, which was causing an invalid date exception.

This also updates the joda-time library to the latest version, which isn't necessary for the fix.

**Why are we doing this? (with JIRA link)**

Structured date parser tests failed on 2/29/2024. JIRA: https://collectionspace.atlassian.net/browse/DRYD-1396

**How should this be tested? Do these changes have associated tests?**

This is covered by unit tests in the structureddate module. The tests should now pass.

**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee verified that structured date tests now pass.