### PR TITLE
Add placenote to full object with place report

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/full_obj_place.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/full_obj_place.jrxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 6.20.1.final using JasperReports Library version 6.20.1-7584acb244139816654f64e2fd57a00d3e31921e  -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="obj_full_place" pageWidth="3800" pageHeight="800" orientation="Landscape" columnWidth="100" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isIgnorePagination="true" uuid="f6c7eb78-afcd-4bd5-9a53-61ee9a1f43f8">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="obj_full_place" pageWidth="3900" pageHeight="800" orientation="Landscape" columnWidth="100" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isIgnorePagination="true" uuid="f6c7eb78-afcd-4bd5-9a53-61ee9a1f43f8">
 	<property name="com.jaspersoft.studio.data.sql.tables" value=""/>
 	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="nuxeo"/>
 	<property name="com.jaspersoft.studio.data.sql.SQLQueryDesigner.sash.w1" value="193"/>
@@ -41,6 +41,7 @@
 	dimension.dimension,
 	obj.computedcurrentlocation,
 	movement.currentlocationnote,
+	place.placenote,
 	placement.item AS placementtype,
 	place_pa.placementenvironment,
 	placetype.item AS placetype,
@@ -306,6 +307,11 @@ $P!{whereclause}]]>
 		<property name="com.jaspersoft.studio.field.name" value="broaderplace"/>
 		<property name="com.jaspersoft.studio.field.label" value="broaderplace"/>
 		<property name="com.jaspersoft.studio.field.tree.path" value="relations_common"/>
+	</field>
+	<field name="placenote" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="placenote"/>
+		<property name="com.jaspersoft.studio.field.label" value="placenote"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="places_common"/>
 	</field>
 	<background>
 		<band splitType="Stretch"/>
@@ -573,6 +579,13 @@ $P!{whereclause}]]>
 				<textElement markup="styled"/>
 				<text><![CDATA[Hierarchy Broader Place]]></text>
 			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="3700" y="0" width="100" height="44" uuid="7fb09d15-24af-4edd-b15c-0763823aef76">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Place Note]]></text>
+			</staticText>
 		</band>
 	</columnHeader>
 	<detail>
@@ -799,6 +812,12 @@ $P!{whereclause}]]>
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{broaderplace}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="3700" y="0" width="100" height="30" uuid="299168ea-36af-4565-a7fb-3e58dbb8aa1b">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{placenote}]]></textFieldExpression>
 			</textField>
 		</band>
 	</detail>


### PR DESCRIPTION
**What does this do?**
This adds the place note to the full object with place report

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1281

After testing in QA it was requested to add place note as a field to this report.

**How should this be tested? Do these changes have associated tests?**
* Run the publicart ui devserver
* Create a collectionobject with a related place (from the currentcomputedlocation)
* Run the full object with place report
* Verify that the place note exists for the report

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested
