### PR TITLE
Artwork Description Report Updates

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/artwork_description.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/artwork_description.jrxml
@@ -16,11 +16,12 @@
 		<defaultValueExpression><![CDATA["1"]]></defaultValueExpression>
 	</parameter>
   <parameter name="csidlist" class="java.lang.String" isForPrompting="false" />
+	<parameter name="csid" class="java.lang.String" isForPrompting="false"/>
   <parameter name="csids" class="java.lang.String" isForPrompting="false">
     <defaultValueExpression><![CDATA[$P{csidlist} != null ? ("'" + $P{csidlist}.replaceAll(",", "','") + "'") : "NOVALUE"]]></defaultValueExpression>
   </parameter>
   <parameter name="whereclause" class="java.lang.String" isForPrompting="false">
-    <defaultValueExpression><![CDATA[$P{csids} != "NOVALUE" ? ( "WHERE hier.name IN (" + $P{csids} + ")" ) : ""]]></defaultValueExpression>
+    <defaultValueExpression><![CDATA[$P{csids} != "NOVALUE" ? ( "WHERE hier.name IN (" + $P{csids} + ")" ) : ($P{csid} != null ? "WHERE hier.name = '" + $P{csid} + "'" : "") ]]></defaultValueExpression>
   </parameter>
 	<queryString language="SQL">
 		<![CDATA[WITH dimensions AS (

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/artwork_description.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/artwork_description.jrxml
@@ -112,10 +112,15 @@ LEFT JOIN (
 	GROUP BY dimensions.parentid
 ) dimension on dimension.parentid = obj.id
 LEFT JOIN (
-	SELECT relation.*
+	SELECT DISTINCT ON (relation.subjectcsid)
+		relation.subjectcsid,
+		relation.objectcsid
 	FROM relations_common relation
 	INNER JOIN misc ON misc.id = relation.id AND misc.lifecyclestate != 'deleted'
+  INNER JOIN hierarchy hier ON hier.name = relation.objectcsid
+  INNER JOIN collectionspace_core core ON core.id = hier.id
 	WHERE relation.objectdocumenttype = 'Media' AND relation.subjectdocumenttype = 'CollectionObject'
+  ORDER BY relation.subjectcsid, core.updatedat DESC
 ) media ON media.subjectcsid = hier.name
 $P!{whereclause}]]>
 	</queryString>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/artwork_description.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/artwork_description.jrxml
@@ -20,10 +20,20 @@
 		<defaultValueExpression><![CDATA[$P{csid} != null ?  "WHERE hier.name = '" + $P{csid} + "'"  : ""]]></defaultValueExpression>
 	</parameter>
 	<queryString language="SQL">
-		<![CDATA[SELECT
+		<![CDATA[WITH dimensions AS (
+	SELECT
+		measured_hier.parentid,
+		string_agg(concat(dimension.dimension, ' ', dimension.value::text, ' ', dimension.measurementunit), ' | ') AS dimension
+	FROM hierarchy measured_hier
+	INNER JOIN measuredpartgroup measuredpart on measuredpart.id = measured_hier.id
+	INNER JOIN hierarchy dimension_hier on dimension_hier.parentid = measured_hier.id and dimension_hier.primarytype = 'dimensionSubGroup'
+	LEFT JOIN dimensionsubgroup dimension on dimension.id = dimension_hier.id
+	WHERE measured_hier.primarytype = 'measuredPartGroup'
+	GROUP BY measured_hier.id, measured_hier.parentid
+) SELECT
 	obj.objectnumber,
 	ong.objectname,
-	tg.title,
+	titlegroup.title,
 	person.objectproductionperson,
 	sdg.datedisplaydate,
 	fineart.materialtechniquedescription,
@@ -36,27 +46,66 @@ INNER JOIN hierarchy hier on hier.id = obj.id
 INNER JOIN misc ON misc.id = obj.id and misc.lifecyclestate != 'deleted'
 INNER JOIN collectionspace_core core ON misc.id = core.id AND core.tenantid = $P{tenantid}
 LEFT JOIN collectionobjects_fineart fineart ON fineart.id = obj.id
-LEFT JOIN hierarchy ong_hier ON ong_hier.parentid = obj.id AND ong_hier.primarytype = 'objectNameGroup' AND ong_hier.pos = 0
-LEFT JOIN objectnamegroup ong ON ong.id = ong_hier.id
-LEFT JOIN hierarchy title_hier ON title_hier.parentid = obj.id AND title_hier.primarytype = 'titleGroup' AND title_hier.pos = 0
-LEFT JOIN titlegroup tg ON tg.id = title_hier.id
-LEFT JOIN hierarchy person_hier ON person_hier.parentid = obj.id AND person_hier.primarytype = 'objectProductionPersonGroup' AND person_hier.pos = 0
-LEFT JOIN objectproductionpersongroup person ON person.id = person_hier.id
-LEFT JOIN hierarchy sdg_hier ON sdg_hier.parentid = obj.id AND sdg_hier.primarytype = 'structuredDateGroup' AND sdg_hier.name = 'collectionobjects_common:objectProductionDateGroupList' AND sdg_hier.pos = 0
-LEFT JOIN structureddategroup sdg ON sdg.id = sdg_hier.id
-LEFT JOIN hierarchy material_hier on material_hier.parentid = obj.id and material_hier.primarytype = 'materialGroup' and material_hier.pos = 0
-LEFT JOIN materialgroup material on material.id = material_hier.id
-LEFT JOIN hierarchy technique_hier on technique_hier.parentid = obj.id and technique_hier.primarytype = 'techniqueGroup' and technique_hier.pos = 0
-LEFT JOIN techniquegroup technique on technique.id = technique_hier.id
 LEFT JOIN (
  SELECT
-	measured_hier.parentid,
-	string_agg(concat(dimension.dimension, ' ', dimension.value::text, ' ', dimension.measurementunit), ' | ') AS dimension
-	FROM hierarchy measured_hier
-	INNER JOIN hierarchy dimension_hier on dimension_hier.parentid = measured_hier.id and dimension_hier.primarytype = 'dimensionSubGroup'
-	LEFT JOIN dimensionsubgroup dimension on dimension.id = dimension_hier.id
-	WHERE measured_hier.primarytype = 'measuredPartGroup'
-	GROUP BY measured_hier.parentid
+	hierarchy.parentid,
+	string_agg(ong.objectname, ';') AS objectname
+	FROM hierarchy
+	INNER JOIN objectnamegroup ong ON ong.id = hierarchy.id
+	WHERE hierarchy.primarytype = 'objectNameGroup'
+	GROUP BY hierarchy.parentid
+) ong on ong.parentid = obj.id
+LEFT JOIN (
+ SELECT
+	hierarchy.parentid,
+	string_agg(title.title, ';') AS title
+	FROM hierarchy
+	INNER JOIN titlegroup title ON title.id = hierarchy.id
+	WHERE hierarchy.primarytype = 'titleGroup'
+	GROUP BY hierarchy.parentid
+) titlegroup on titlegroup.parentid = obj.id
+LEFT JOIN (
+ SELECT
+	hierarchy.parentid,
+	string_agg(regexp_replace(person.objectproductionperson, '^.*\)''(.*)''$', '\1'), ';') AS objectproductionperson
+	FROM hierarchy
+	INNER JOIN objectproductionpersongroup person ON person.id = hierarchy.id
+	WHERE hierarchy.primarytype = 'objectProductionPersonGroup'
+	GROUP BY hierarchy.parentid
+) person on person.parentid = obj.id
+LEFT JOIN (
+ SELECT
+	hierarchy.parentid,
+	string_agg(sdg.datedisplaydate, ';') AS datedisplaydate
+	FROM hierarchy
+	INNER JOIN structureddategroup sdg ON sdg.id = hierarchy.id
+	WHERE hierarchy.primarytype = 'structuredDateGroup' AND hierarchy.name = 'collectionobjects_common:objectProductionDateGroupList'
+	GROUP BY hierarchy.parentid
+) sdg on sdg.parentid = obj.id
+LEFT JOIN (
+ SELECT
+	hierarchy.parentid,
+	string_agg(material.material, ';') AS material
+	FROM hierarchy
+	INNER JOIN materialgroup material on material.id = hierarchy.id
+	WHERE hierarchy.primarytype = 'materialGroup'
+	GROUP BY hierarchy.parentid
+) material on material.parentid = obj.id
+LEFT JOIN (
+ SELECT
+	hierarchy.parentid,
+	string_agg(technique.technique, ';') AS technique
+	FROM hierarchy
+	INNER JOIN techniquegroup technique on technique.id = hierarchy.id
+	WHERE hierarchy.primarytype = 'techniqueGroup'
+	GROUP BY hierarchy.parentid
+) technique on technique.parentid = obj.id
+LEFT JOIN (
+	SELECT
+		dimensions.parentid,
+		string_agg(dimensions.dimension, ';') dimension
+	FROM dimensions
+	GROUP BY dimensions.parentid
 ) dimension on dimension.parentid = obj.id
 LEFT JOIN (
 	SELECT relation.*

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/artwork_description.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/artwork_description.jrxml
@@ -15,10 +15,13 @@
 	<parameter name="tenantid" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA["1"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="csid" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="whereclause" class="java.lang.String" isForPrompting="false">
-		<defaultValueExpression><![CDATA[$P{csid} != null ?  "WHERE hier.name = '" + $P{csid} + "'"  : ""]]></defaultValueExpression>
-	</parameter>
+  <parameter name="csidlist" class="java.lang.String" isForPrompting="false" />
+  <parameter name="csids" class="java.lang.String" isForPrompting="false">
+    <defaultValueExpression><![CDATA[$P{csidlist} != null ? ("'" + $P{csidlist}.replaceAll(",", "','") + "'") : "NOVALUE"]]></defaultValueExpression>
+  </parameter>
+  <parameter name="whereclause" class="java.lang.String" isForPrompting="false">
+    <defaultValueExpression><![CDATA[$P{csids} != "NOVALUE" ? ( "WHERE hier.name IN (" + $P{csids} + ")" ) : ""]]></defaultValueExpression>
+  </parameter>
 	<queryString language="SQL">
 		<![CDATA[WITH dimensions AS (
 	SELECT

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/artwork_description.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/artwork_description.xml
@@ -7,7 +7,7 @@
       <forDocType>CollectionObject</forDocType>
     </forDocTypes>
     <supportsSingleDoc>true</supportsSingleDoc>
-    <supportsDocList>false</supportsDocList>
+    <supportsDocList>true</supportsDocList>
     <supportsGroup>false</supportsGroup>
     <supportsNoContext>true</supportsNoContext>
     <filename>artwork_description.jrxml</filename>


### PR DESCRIPTION
**What does this do?**
This makes numerous changes to the artwork description report from QA.
* Allows the report to be run from the object search result page
* Aggregates all repeating values, delimited by semi-colons
* Updates aggregation for dimensions to separate by measured part
* Gets distinct thumbnails, ordered by the most recently updated

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1280

These are changes requested from QA feedback. In addition while doing testing of my own I noticed that the dimension aggregation was often confusing if multiple measured parts/dimensions were being used. Likewise I added in the distinct query for media which was requested for some other reports, and seemed to make sense here in order for a single row to be returned for each collectionobject.

**How should this be tested? Do these changes have associated tests?**
* In the fcart profile
* Create a collectionobject with the following fields
  * object name, title, production person, production date, material description, material, production technique, measurement
* Optionally create a media handling record and relate it to the object
* Run the artwork description from both the object search page and from the object page

**Dependencies for merging? Releasing to production?**
No dependencies, but with how much aggregation is being requested I'd like to start to look into performance considerations for these queries. It's not easy to tell how this would perform with a real database, as having <10 records doesn't really match the same type of scale as production data. 

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally