### PR TITLE
Update Tombstone with Creator Report

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tombstone_with_creator.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tombstone_with_creator.jrxml
@@ -51,8 +51,9 @@ LEFT JOIN collectionobjects_common_inventorystatuslist inventory ON inventory.id
 LEFT JOIN (
   SELECT
     hier.parentid,
-    string_agg(sd.datedisplaydate, '|') as artworkdate
+    string_agg(concat_ws(';', sd.datedisplaydate, regexp_replace(papdg.publicartproductiondatetype,'^.*\)''(.*)''$', '\1')), '|') as artworkdate
   FROM hierarchy hier
+  LEFT JOIN publicartproductiondategroup papdg on papdg.id = hier.id
   LEFT JOIN hierarchy sdg_hier on sdg_hier.parentid = hier.id AND sdg_hier.primarytype = 'structuredDateGroup'
   LEFT JOIN structureddategroup sd on sd.id = sdg_hier.id
   WHERE hier.primarytype = 'publicartProductionDateGroup'


### PR DESCRIPTION
**What does this do?**
This adds the production date type to the artwork date field

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1196

  This change was requested for the public art profile to modify the response for the artwork date field. It brings in the production date type which is the adjacent field in the group.

**How should this be tested? Do these changes have associated tests?**
* Using the publicart profile
* Create a collectionobject with
  * Artwork date and type (Production Information)
* Search for objects and run the Tombstone with Creator Report

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local install