### PR TITLE
Borrowing Receipt Report Updates

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/borrowing_receipt.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/borrowing_receipt.jrxml
@@ -20,7 +20,50 @@
 		<defaultValueExpression><![CDATA[$P{csid} != null ?  "WHERE hier.name = '" + $P{csid} + "'"  : ""]]></defaultValueExpression>
 	</parameter>
 	<queryString language="SQL">
-		<![CDATA[SELECT
+		<![CDATA[WITH ong AS (
+	SELECT
+		hier.parentid,
+		string_agg(ong.objectname, ';') AS objectname
+	FROM hierarchy hier
+	LEFT JOIN objectnamegroup ong ON ong.id = hier.id
+	WHERE hier.primarytype = 'objectNameGroup'
+	GROUP BY hier.parentid
+), titles AS (
+	SELECT
+		hier.parentid,
+		string_agg(tg.title, ';') AS title
+	FROM hierarchy hier
+	LEFT JOIN titlegroup tg ON tg.id = hier.id
+	WHERE hier.primarytype = 'titleGroup'
+	GROUP BY hier.parentid
+), productionpeople AS (
+	SELECT
+		hier.parentid,
+		string_agg(regexp_replace(person.objectproductionperson, '^.*\)''(.*)''$', '\1'), ';') AS objectproductionperson
+	FROM hierarchy hier
+	LEFT JOIN objectproductionpersongroup person ON person.id = hier.id
+	WHERE hier.primarytype = 'objectProductionPersonGroup'
+	GROUP BY hier.parentid
+), productiondates AS (
+	SELECT
+		hier.parentid,
+		string_agg(sdg.datedisplaydate, ';') AS objectproductiondate
+	FROM hierarchy hier
+	LEFT JOIN structureddategroup sdg ON sdg.id = hier.id
+	WHERE hier.primarytype = 'structuredDateGroup' AND hier.name = 'collectionobjects_common:objectProductionDateGroupList'
+	GROUP BY hier.parentid
+), relatedmedia AS (
+	SELECT DISTINCT ON (relation.subjectcsid)
+		relation.subjectcsid,
+		relation.objectcsid AS mediacsid
+	FROM media_common media
+	INNER JOIN hierarchy hier ON hier.id = media.id
+	INNER JOIN misc ON misc.id = media.id AND misc.lifecyclestate != 'deleted'
+	INNER JOIN relations_common relation ON relation.objectcsid = hier.name AND relation.subjectdocumenttype = 'CollectionObject'
+	INNER JOIN collectionspace_core core ON core.id = media.id
+	ORDER BY relation.subjectcsid, core.updatedat DESC
+)
+SELECT
 	loan.loanoutnumber,
 	loan.borrower,
 	object.objectnumber,
@@ -42,25 +85,21 @@ LEFT JOIN (
 		obj.objectnumber,
 		obj.computedcurrentlocation,
 		ong.objectname,
-		tg.title,
+		titles.title,
 		person.objectproductionperson,
-		sdg.datedisplaydate AS objectproductiondate,
-		media.objectcsid AS mediacsid
+		productiondate.objectproductiondate,
+		media.mediacsid
 	FROM collectionobjects_common obj
 	INNER JOIN hierarchy hier ON hier.id = obj.id
 	INNER JOIN misc on misc.id = obj.id AND misc.lifecyclestate != 'deleted'
 	INNER JOIN relations_common relation ON relation.objectcsid = hier.name
 		AND relation.subjectdocumenttype = 'Loanout'
 		AND relation.objectdocumenttype = 'CollectionObject'
-	LEFT JOIN hierarchy ong_hier ON ong_hier.parentid = obj.id AND ong_hier.primarytype = 'objectNameGroup' AND ong_hier.pos = 0
-	LEFT JOIN objectnamegroup ong ON ong.id = ong_hier.id
-	LEFT JOIN hierarchy title_hier ON title_hier.parentid = obj.id AND title_hier.primarytype = 'titleGroup' AND title_hier.pos = 0
-	LEFT JOIN titlegroup tg ON tg.id = title_hier.id
-	LEFT JOIN hierarchy person_hier ON person_hier.parentid = obj.id AND person_hier.primarytype = 'objectProductionPersonGroup' AND person_hier.pos = 0
-	LEFT JOIN objectproductionpersongroup person ON person.id = person_hier.id
-	LEFT JOIN hierarchy sdg_hier ON sdg_hier.parentid = obj.id AND sdg_hier.primarytype = 'structuredDateGroup' AND sdg_hier.name = 'collectionobjects_common:objectProductionDateGroupList' AND sdg_hier.pos = 0
-	LEFT JOIN structureddategroup sdg ON sdg.id = sdg_hier.id
-	LEFT JOIN relations_common media ON media.subjectcsid = hier.name AND media.objectdocumenttype = 'Media' AND media.subjectdocumenttype = 'CollectionObject'
+	LEFT JOIN ong ON ong.parentid = obj.id
+	LEFT JOIN titles ON titles.parentid = obj.id
+	LEFT JOIN productionpeople person ON person.parentid = obj.id
+	LEFT JOIN productiondates productiondate ON productiondate.parentid = obj.id
+	LEFT JOIN relatedmedia media ON media.subjectcsid = hier.name
 ) object ON object.subjectcsid = hier.name
 $P!{whereclause}]]>
 	</queryString>


### PR DESCRIPTION
**What does this do?**
This makes updates to the borrowing receipt from qa feedback.
* Get the most recent thumbnail for objects
* Aggregate data for all repeatable fields

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1279

By having only the most recent thumbnail display, we avoid returning multiple rows for each object for each thumbnail. This is especially good for csvs where nothing is shown, and data ends up looking redundant.

The aggregation of data was requested for fields which are repeatable. This report will only aggregate per object, so multiple rows can still be returned. This seemed like the best way to handle displaying the data since it can only be run on a single loan out record.

**How should this be tested? Do these changes have associated tests?**
* Create a loan out with a borrower
* Create one or more collectionobjects with:
  * object name(s)
  * object title(s)
  * production person(s)
  * production date(s)
  * related LMI
  * related media

**Dependencies for merging? Releasing to production?**
A third issue was brought up related to computed current location not displaying in the report. When looking into the event handler, I found that the location date was required to be set in order for the computed location to be set. So if you have two or more LMI records with no location date, the computed location will be cleared. I don't know if this is documented anywhere, but it is likely worth it in case it comes up in the future.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally