### PR TITLE
LHMC ElasticSearch Config

### DIFF
--- a/services/common/src/main/cspace/config/services/tenants/lhmc/lhmc-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/lhmc/lhmc-tenant-bindings.delta.xml
@@ -8,6 +8,336 @@
     <!-- value in cspace/config/services/tenants/lhmc-tenant-bindings-proto.xml -->
 
     <tenant:tenantBinding id="501">
+      <tenant:elasticSearchIndexConfig merge:action="replace">
+        <tenant:mapping merge:action="replace">
+{
+  // For now, don't index a field unless there's a mapping explicitly defined. This keeps the
+  // index as small as possible. We may want to turn this on in the future, to support arbitrary
+  // searches through Elasticsearch, e.g. NXQL queries for ad hoc reporting in the CSpace UI.
+  "dynamic": false,
+  "_all" : {
+    "enabled": false
+  },
+  "_source": {
+    "includes": [
+    "collectionobjects_common:briefDescriptions",
+    "collectionobjects_common:collection",
+    "collectionobjects_common:colors",
+    "collectionobjects_common:computedCurrentLocation",
+    "collectionobjects_common:contentConcepts",
+    "collectionobjects_common:contentDescription",
+    "collectionobjects_common:contentEvents",
+    "collectionobjects_common:contentOrganizations",
+    "collectionobjects_common:contentPersons",
+    "collectionobjects_common:materialGroupList",
+    "collectionobjects_common:measuredPartGroupList",
+    "collectionobjects_common:numberOfObjects",
+    "collectionobjects_common:objectCountGroupList",
+    "collectionobjects_common:objectHistoryNote",
+    "collectionobjects_common:objectNameList",
+    "collectionobjects_common:objectNumber",
+    "collectionobjects_common:objectProductionDateGroupList",
+    "collectionobjects_common:objectProductionOrganizationGroupList",
+    "collectionobjects_common:objectProductionPersonGroupList",
+    "collectionobjects_common:objectProductionPeopleGroupList",
+    "collectionobjects_common:objectProductionPlaceGroupList",
+    "collectionobjects_common:objectStatusList",
+    "collectionobjects_common:otherNumberList",
+    "collectionobjects_common:ownersContributionNote",
+    "collectionobjects_common:publishToList",
+    "collectionobjects_common:responsibleDepartments",
+    "collectionobjects_common:rightsGroupList.rightStatement",
+    "collectionobjects_common:rightsGroupList.standardizedRightStatement",
+    "collectionobjects_common:rightsInGroupList.rightReproductionStatement",
+    "collectionobjects_common:techniqueGroupList",
+    "collectionobjects_common:titleGroupList",
+    "collectionobjects_common:viewersContributionNote",
+    "collectionspace_core:*",
+    "collectionspace_denorm:*",
+    "ecm:currentLifeCycleState",
+    "ecm:name",
+    "ecm:primaryType",
+    "media_common:blobCsid"
+    ]
+  },
+  "properties" : {
+    "all_field": {
+      "type": "text",
+      "analyzer": "fulltext"
+    },
+
+    "ecm:currentLifeCycleState": {
+      "type": "keyword"
+    },
+    "ecm:name": {
+      "type": "keyword"
+    },
+    "ecm:primaryType": {
+      "type": "text",
+      "analyzer" : "doctype_analyzer"
+    },
+
+    "collectionspace_core:createdAt": {
+      "type": "date",
+      "format": "date_time"
+    },
+    "collectionobjects_common:publishToList": {
+      "type": "keyword",
+      "fields": {
+        "shortid": {
+          "type": "keyword",
+          "normalizer": "refname_shortid_normalizer"
+        }
+      }
+    },
+
+    "collectionspace_denorm:title": {
+      "type": "keyword",
+      "normalizer": "sorting_normalizer"
+    },
+    "collectionspace_denorm:hasMedia": {
+      "type": "boolean"
+    },
+    "collectionspace_denorm:mediaAltText": {
+      "type": "text",
+      "copy_to": "all_field"
+    },
+    "collectionspace_denorm:prodYears": {
+      "type": "integer"
+    },
+    "collectionspace_denorm:exhibition": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "keyword",
+          "copy_to": "all_field"
+        },
+        "generalNote": {
+          "type": "text",
+          "copy_to": "all_field"
+        },
+        "curatorialNote": {
+          "type": "text",
+          "copy_to": "all_field"
+        }
+      }
+    },
+    "collectionspace_denorm:materialGroupList": {
+      "type": "object",
+      "properties": {
+        "material": {
+          "type": "keyword",
+          "copy_to": "all_field"
+        }
+      }
+    },
+    "collectionspace_denorm:objectNameList": {
+      "type": "object",
+      "properties": {
+        "objectName": {
+          "type": "keyword",
+          "copy_to": "all_field"
+        }
+      }
+    },
+    "collectionspace_denorm:contentSubjectList": {
+      "type": "object",
+      "properties": {
+        "subject": {
+          "type": "keyword",
+          "copy_to": "all_field"
+        }
+      }
+    },
+
+    "collectionobjects_common:objectNumber": {
+      "type": "keyword",
+      "copy_to": "all_field"
+    },
+    "collectionobjects_common:briefDescriptions": {
+      "type": "text",
+      "copy_to": "all_field"
+    },
+    "collectionobjects_common:titleGroupList": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "text",
+          "copy_to": "all_field"
+        }
+      }
+    },
+    "collectionobjects_common:objectNameList": {
+      "type": "object",
+      "properties": {
+        "objectName": {
+          "type": "keyword",
+          "copy_to": "all_field"
+        }
+      }
+    },
+    "collectionobjects_common:objectProductionPersonGroupList": {
+      "type": "object",
+      "properties": {
+        "objectProductionPerson": {
+          "type": "keyword",
+          "copy_to": "all_field",
+          "fields": {
+            "displayName": {
+              "type": "keyword",
+              "normalizer": "refname_displayname_normalizer"
+            }
+          }
+        }
+      }
+    },
+    "collectionobjects_common:objectProductionOrganizationGroupList": {
+      "type": "object",
+      "properties": {
+        "objectProductionOrganization": {
+          "type": "keyword",
+          "copy_to": "all_field",
+          "fields": {
+            "displayName": {
+              "type": "keyword",
+              "normalizer": "refname_displayname_normalizer"
+            }
+          }
+        }
+      }
+    },
+    "collectionobjects_common:objectProductionPeopleGroupList": {
+      "type": "object",
+      "properties": {
+        "objectProductionPeople": {
+          "type": "keyword",
+          "copy_to": "all_field"
+        }
+      }
+    },
+    "collectionobjects_common:objectProductionDateGroupList": {
+      "type": "object",
+      "properties": {
+        "dateDisplayDate": {
+          "type": "text",
+          "copy_to": "all_field"
+        }
+      }
+    },
+    "collectionobjects_common:objectProductionPlaceGroupList": {
+      "type": "object",
+      "properties": {
+        "objectProductionPlace": {
+          "type": "keyword",
+          "copy_to": "all_field",
+          "fields": {
+            "displayName": {
+              "type": "keyword",
+              "normalizer": "refname_displayname_normalizer"
+            }
+          }
+        }
+      }
+    },
+    "collectionobjects_common:materialGroupList": {
+      "type": "object",
+      "properties": {
+        "material": {
+          "type": "keyword",
+          "copy_to": "all_field"
+        }
+      }
+    },
+    "collectionobjects_common:colors": {
+      "type": "keyword",
+      "copy_to": "all_field"
+    },
+    "collectionobjects_common:responsibleDepartments": {
+      "type": "keyword",
+      "copy_to": "all_field"
+    },
+    "collectionobjects_common:contentConcepts": {
+      "type": "keyword",
+      "copy_to": "all_field",
+      "fields": {
+        "displayName": {
+          "type": "keyword",
+          "normalizer": "refname_displayname_normalizer"
+        }
+      }
+    },
+    "collectionobjects_common:contentDescription": {
+      "type": "text",
+      "copy_to": "all_field"
+    },
+    "collectionobjects_common:contentEvents": {
+      "type": "keyword",
+      "copy_to": "all_field",
+      "fields": {
+        "displayName": {
+          "type": "keyword",
+          "normalizer": "refname_displayname_normalizer"
+        }
+      }
+    },
+    "collectionobjects_common:contentOrganizations": {
+      "type": "keyword",
+      "copy_to": "all_field",
+      "fields": {
+        "displayName": {
+          "type": "keyword",
+          "normalizer": "refname_displayname_normalizer"
+        }
+      }
+    },
+    "collectionobjects_common:contentPersons": {
+      "type": "keyword",
+      "copy_to": "all_field",
+      "fields": {
+        "displayName": {
+          "type": "keyword",
+          "normalizer": "refname_displayname_normalizer"
+        }
+      }
+    },
+    "collectionobjects_common:techniqueGroupList": {
+      "type": "object",
+      "properties": {
+        "technique": {
+          "type": "keyword",
+          "copy_to": "all_field"
+        }
+      }
+    },
+    "collectionobjects_common:objectHistoryNote": {
+      "type": "text",
+      "copy_to": "all_field"
+    },
+    "collectionobjects_common:ownersContributionNote": {
+      "type": "text",
+      "copy_to": "all_field"
+    },
+    "collectionobjects_common:viewersContributionNote": {
+      "type": "text",
+      "copy_to": "all_field"
+    },
+
+    "media_common:blobCsid": {
+      "type": "keyword"
+    },
+    "media_common:publishToList": {
+      "type": "keyword",
+      "fields": {
+        "shortid": {
+          "type": "keyword",
+          "normalizer": "refname_shortid_normalizer"
+        }
+      }
+    }
+  }
+}
+        </tenant:mapping>
+      </tenant:elasticSearchIndexConfig>
     </tenant:tenantBinding>
 
 </tenant:TenantBindingConfig>


### PR DESCRIPTION
**What does this do?**
* Add the elasticsearch config to the tenant bindings for lhmc
* Add displayName index for production place

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/jira/software/c/projects/CB/issues/CB-29

For LHMC the objectProductionPlace field uses the place authority and needs to be deurned when being indexed for the public browser. This handles the services side of this change and adds the config/updates the objectProductionPlace field.

**How should this be tested? Do these changes have associated tests?**
* Build collectionspace with the lhmc tenant enabled
* Deploy the gateway with settings for lhmc
```
zuul:
  routes:
    lhmc-cspace-services:
      path: /lhmc/cspace-services/**
      # The URL of the CollectionSpace REST API.
      url: http://localhost:8180/cspace-services
      # Credentials to use for connecting to the CollectionSpace REST API.
      username: reader@lhmc.collectionspace.org
      password: reader

    lhmc-es:
      path: /lhmc/es/**
      # The URL of the Elasticsearch cluster (including index).
      url: http://localhost:9200/lhmc_default

```
* Create a collectionobject using the objectProductionPlace field
* Run the public browser and see that the Filter facet has the deurned values for objectProductionPlace

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally