### PR TITLE
Add migration script for collectionobject fieldCollectionPlaces

### DIFF
--- a/src/main/resources/db/postgresql/upgrade/8.0.0/post-init/01_collectionobject.sql
+++ b/src/main/resources/db/postgresql/upgrade/8.0.0/post-init/01_collectionobject.sql
@@ -1,0 +1,33 @@
+-- Upgrade collectionobject. Move fieldCollectionPlace into repeating field (DRYD-1395).
+DO $$
+DECLARE
+    trow record;
+    maxpos int;
+BEGIN
+    -- For new install, if collectionobjects_common.fieldcollectionplace does not exist, there is nothing to migrate.
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='collectionobjects_common' AND column_name='fieldcollectionplace') THEN
+        FOR trow IN
+            -- Get record in collectionobjects_common that does not have an existing/matching record in
+            -- collectionobjects_common_fieldcollectionplaces:
+            SELECT co.id, co.fieldcollectionplace
+            FROM public.collectionobjects_common co
+            LEFT OUTER JOIN public.collectionobjects_common_fieldcollectionplaces co_fcp ON
+                (co.id = co_fcp.id AND co.fieldcollectionplace = co_fcp.item)
+            WHERE co.fieldcollectionplace IS NOT NULL AND co.fieldcollectionplace != '' AND co_fcp.item IS NULL
+
+            LOOP
+                -- Get max pos value for the collectionobject record's current owner field:
+                SELECT coalesce(max(pos), -1) INTO maxpos
+                FROM public.collectionobjects_common_fieldcollectionplaces
+                WHERE id = trow.id;
+
+                -- Migrate collectionobjects_common fieldcollectionplace data to
+                -- collectionobjects_common_fieldcollectionplaces table:
+                INSERT INTO public.collectionobjects_common_fieldcollectionplaces(id, pos, item)
+                VALUES (trow.id, maxpos + 1, trow.fieldcollectionplace);
+            END LOOP;
+    ELSE
+        RAISE NOTICE 'No v7.2 collectionobject field collection place data to migrate: collectionobjects_common.fieldcollectionplace does not exist';
+    END IF;
+END
+$$;

--- a/src/main/resources/db/postgresql/upgrade/8.0.0/post-init/01_collectionobject.sql
+++ b/src/main/resources/db/postgresql/upgrade/8.0.0/post-init/01_collectionobject.sql
@@ -16,7 +16,7 @@ BEGIN
             WHERE co.fieldcollectionplace IS NOT NULL AND co.fieldcollectionplace != '' AND co_fcp.item IS NULL
 
             LOOP
-                -- Get max pos value for the collectionobject record's current owner field:
+                -- Get max pos value for the collectionobject record's field collection place field:
                 SELECT coalesce(max(pos), -1) INTO maxpos
                 FROM public.collectionobjects_common_fieldcollectionplaces
                 WHERE id = trow.id;


### PR DESCRIPTION
**What does this do?**
Create a script for migrating collectionobjects_common.fieldCollectionPlace into collectionobjects_common_fieldcollectionplaces. This allows for the field to be repeatable.

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1395

The fieldCollectionPlace field was requested to be updated to be a repeating field. Any data from 7.2 needs to be migrated and inserted it into the new table collectionobjects_common_fieldcollectionplaces. 

**How should this be tested? Do these changes have associated tests?**
* Using collectionspace 7.2, create a collectionobject with a fieldCollectionPlace
  * As a side note - I had to update cspace.meta because I built with 8.0.0-SNAPSHOT 
* Stop collectionspace
* Using this PR, rebuild collectionspace and start the server
* Check the database to see that the data has been migrated
```
nuxeo_default=# select * from collectionobjects_common_fieldcollectionplaces;
```
* Or check through the cspace-ui PR which updates the ui to show the field in a repeatable display

**Dependencies for merging? Releasing to production?**
Will need to make sure the other migration script needed for 8.0 does not conflict with this one. It will also be on collectionobject so likely will happen.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local instance