### PR TITLE
Adjust bindings so that replacement happens in the correct order

### DIFF
--- a/services/common/src/main/cspace/config/services/tenants/fcart/fcart-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/fcart/fcart-tenant-bindings.delta.xml
@@ -8,6 +8,15 @@
 	<!-- value in cspace/config/services/tenants/fcart-tenant-bindings-proto.xml -->
 
 	<tenant:tenantBinding id="1000">
+		<tenant:serviceBindings merge:matcher="id" id="Reports">
+			<service:properties xmlns:service="http://collectionspace.org/services/config/service" xmlns:types="http://collectionspace.org/services/config/types">
+				<types:item merge:matcher="skip" merge:action="insert">
+					<types:key>report</types:key>
+					<types:value>artwork_description</types:value>
+				</types:item>
+			</service:properties>
+		</tenant:serviceBindings>
+
 		<tenant:elasticSearchIndexConfig merge:action="replace">
 			<tenant:mapping merge:action="replace">
 				{
@@ -339,14 +348,5 @@
 				}
 			</tenant:mapping>
 		</tenant:elasticSearchIndexConfig>
-
-		<tenant:serviceBindings merge:matcher="id" id="Reports">
-			<service:properties xmlns:service="http://collectionspace.org/services/config/service" xmlns:types="http://collectionspace.org/services/config/types">
-				<types:item merge:matcher="skip" merge:action="insert">
-					<types:key>report</types:key>
-					<types:value>artwork_description</types:value>
-				</types:item>
-			</service:properties>
-		</tenant:serviceBindings>
 	</tenant:tenantBinding>
 </tenant:TenantBindingConfig>


### PR DESCRIPTION
**What does this do?**
Moves the report service binding before the elastic index configuration

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/jira/software/c/projects/CB/issues/CB-31

When testing the public browser against fcart we saw that `objectProductionPlace` wasn't being de-urned correctly. This was strange because it had been working prior to 8.0,  and other profiles were indexing refnames correctly.

Upon investigation I found that the fcart index was using the default es config from the tenant-bindings-proto-unified.xml. Looking at the merged fcart tenant bindings I noticed that there were two entries for the `tenant:elasticSearchIndexConfig`. Adjusting the declared bindings in the fcart-tenant-bindings.delta.xml so that they matched the order of the tenant-bindings-proto and rebuilding resolved the issue. 

**How should this be tested? Do these changes have associated tests?**
* If a collectionspace instance is not yet built, build or deploy without these changes
* Check the tenant-bindings to see the duplicate `tenant:elasticSearchIndexConfig` entry
```
[tomcat] $ rg --count tenant:elasticSearchIndexConfig | grep -v 2
cspace/config/services/tenants/fcart/tenant-bindings.merged.xml:4
[tomcat] $ grep -R --count tenant:elasticSearchIndexConfig cspace/config/services/tenants/ | grep -v -E '2|0' 
cspace/config/services/tenants/fcart/tenant-bindings.merged.xml:4
```
* Stop collectionspace and redeploy with these changes
* Start collectionspace in order to generate the merged tenant bindings
* Check the tenant-bindings to see the duplicate `tenant:elasticSearchIndexConfig` entry no longer exists
```
[tomcat] $ rg --count tenant:elasticSearchIndexConfig | grep -v 2
```
* You can also check that the elastic config has the correct settings for objectProductionPlace
```
[tomcat] $ rg '"collectionobjects_common:objectProductionPlaceGroupList": \{' -A 14 cspace/config/services/tenants/fcart/tenant-bindings.merged.xml 
7010:                                           "collectionobjects_common:objectProductionPlaceGroupList": {
7011-                                                   "type": "object",
7012-                                                   "properties": {
7013-                                                           "objectProductionPlace": {
7014-                                                                   "type": "keyword",
7015-                                                                   "copy_to": "all_field",
7016-                                                                   "fields": {
7017-                                                                           "displayName": {
7018-                                                                                   "type": "keyword",
7019-                                                                                   "normalizer": "refname_displayname_normalizer"
7020-                                                                           }
7021-                                                                   }
7022-                                                           }
7023-                                                   }
7024-                                           },
```

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested that the index has the correct config when deploying locally