### PR TITLE
Add DutyOfCare

### DIFF
--- a/services/JaxRsServiceProvider/pom.xml
+++ b/services/JaxRsServiceProvider/pom.xml
@@ -415,9 +415,14 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-          <groupId>org.collectionspace.services</groupId>
-          <artifactId>org.collectionspace.services.chronology.service</artifactId>
-          <version>${project.version}</version>
+            <groupId>org.collectionspace.services</groupId>
+            <artifactId>org.collectionspace.services.chronology.service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.collectionspace.services</groupId>
+            <artifactId>org.collectionspace.services.dutyofcare.service</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <!--dependency>
             <groupId>org.collectionspace.services</groupId>

--- a/services/JaxRsServiceProvider/src/main/java/org/collectionspace/services/jaxrs/CollectionSpaceJaxRsApplication.java
+++ b/services/JaxRsServiceProvider/src/main/java/org/collectionspace/services/jaxrs/CollectionSpaceJaxRsApplication.java
@@ -27,6 +27,7 @@ import org.collectionspace.services.account.TenantResource;
 import org.collectionspace.services.blob.BlobResource;
 import org.collectionspace.services.chronology.ChronologyAuthorityResource;
 import org.collectionspace.services.collectionobject.CollectionObjectResource;
+import org.collectionspace.services.dutyofcare.DutyofcareResource;
 import org.collectionspace.services.id.IDResource;
 import org.collectionspace.services.insurance.InsuranceResource;
 import org.collectionspace.services.iterationreport.IterationreportResource;
@@ -80,7 +81,6 @@ import java.util.Set;
 
 
 
-//import org.collectionspace.services.common.FileUtils;
 import org.collectionspace.services.authorization.RoleResource;
 import org.collectionspace.services.common.NuxeoBasedResource;
 import org.collectionspace.services.common.ResourceMap;
@@ -142,6 +142,7 @@ public class CollectionSpaceJaxRsApplication extends Application
         addResourceToMapAndSingletons(new InsuranceResource());
         addResourceToMapAndSingletons(new IntakeResource());
         addResourceToMapAndSingletons(new DimensionResource());
+        addResourceToMapAndSingletons(new DutyofcareResource());
         addResourceToMapAndSingletons(new RelationResource());
         addResourceToMapAndSingletons(new LoaninResource());
         addResourceToMapAndSingletons(new LoanoutResource());

--- a/services/common/src/main/resources/db/postgresql/load_id_generators.sql
+++ b/services/common/src/main/resources/db/postgresql/load_id_generators.sql
@@ -1090,3 +1090,39 @@ INSERT INTO id_generators
         SELECT  csid
         FROM    id_generators
         );
+
+-- DUTYOFCARE_REFERENCE_NUMBER
+
+INSERT INTO id_generators
+    (csid, displayname, description, priority, last_generated_id, id_generator_state)
+  SELECT
+     '6205cfe5-d144-4e89-b641-0e8e4b356f34',
+     'Duty of Care Reference Number',
+     'Identifies a dutyofcare.',
+     '9',
+     '',
+'<org.collectionspace.services.id.SettableIDGenerator>
+  <parts>
+    <org.collectionspace.services.id.StringIDGeneratorPart>
+      <initialValue>DC</initialValue>
+      <currentValue>DC</currentValue>
+    </org.collectionspace.services.id.StringIDGeneratorPart>
+    <org.collectionspace.services.id.YearIDGeneratorPart>
+      <currentValue></currentValue>
+    </org.collectionspace.services.id.YearIDGeneratorPart>
+    <org.collectionspace.services.id.StringIDGeneratorPart>
+      <initialValue>.</initialValue>
+      <currentValue>.</currentValue>
+    </org.collectionspace.services.id.StringIDGeneratorPart>
+    <org.collectionspace.services.id.NumericIDGeneratorPart>
+      <maxLength>6</maxLength>
+      <initialValue>1</initialValue>
+      <currentValue>-1</currentValue>
+    </org.collectionspace.services.id.NumericIDGeneratorPart>
+  </parts>
+</org.collectionspace.services.id.SettableIDGenerator>'
+  WHERE '6205cfe5-d144-4e89-b641-0e8e4b356f34' NOT IN
+        (
+        SELECT  csid
+        FROM    id_generators
+        );

--- a/services/dutyofcare/build.xml
+++ b/services/dutyofcare/build.xml
@@ -1,0 +1,108 @@
+<project name="dutyofcare" default="package" basedir=".">
+  <description>
+    dutyofcare service
+  </description>
+  <!-- set global properties for this build -->
+  <property name="services.trunk" value="../.."/>
+  <!-- environment should be declared before reading build.properties -->
+  <property environment="env"/>
+  <property file="${services.trunk}/build.properties"/>
+  <property name="mvn.opts" value="-V"/>
+  <property name="src" location="src"/>
+
+  <condition property="osfamily-unix">
+    <os family="unix"/>
+  </condition>
+  <condition property="osfamily-windows">
+    <os family="windows"/>
+  </condition>
+
+  <target name="package" depends="package-unix,package-windows"
+          description="Package CollectionSpace Services"/>
+
+  <target name="package-unix" if="osfamily-unix">
+    <exec executable="mvn" failonerror="true">
+      <arg value="package"/>
+      <arg value="-Dmaven.test.skip=true"/>
+      <arg value="-f"/>
+      <arg value="${basedir}/pom.xml"/>
+      <arg value="-N"/>
+      <arg value="${mvn.opts}"/>
+    </exec>
+  </target>
+
+  <target name="package-windows" if="osfamily-windows">
+    <exec executable="cmd" failonerror="true">
+      <arg value="/c"/>
+      <arg value="mvn"/>
+      <arg value="package"/>
+      <arg value="-Dmaven.test.skip=true"/>
+      <arg value="-f"/>
+      <arg value="${basedir}/pom.xml"/>
+      <arg value="-N"/>
+      <arg value="${mvn.opts}"/>
+    </exec>
+  </target>
+
+
+  <target name="install" depends="install-unix,install-windows"
+          description="Install"/>
+  <target name="install-unix" if="osfamily-unix">
+    <exec executable="mvn" failonerror="true">
+      <arg value="install"/>
+      <arg value="-Dmaven.test.skip=true"/>
+      <arg value="-f"/>
+      <arg value="${basedir}/pom.xml"/>
+      <arg value="-N"/>
+      <arg value="${mvn.opts}"/>
+    </exec>
+  </target>
+  <target name="install-windows" if="osfamily-windows">
+    <exec executable="cmd" failonerror="true">
+      <arg value="/c"/>
+      <arg value="mvn"/>
+      <arg value="install"/>
+      <arg value="-Dmaven.test.skip=true"/>
+      <arg value="-f"/>
+      <arg value="${basedir}/pom.xml"/>
+      <arg value="-N"/>
+      <arg value="${mvn.opts}"/>
+    </exec>
+  </target>
+
+  <target name="clean" depends="clean-unix,clean-windows"
+          description="Delete target directories">
+    <delete dir="${build}"/>
+  </target>
+  <target name="clean-unix" if="osfamily-unix">
+    <exec executable="mvn" failonerror="true">
+      <arg value="clean"/>
+      <arg value="${mvn.opts}"/>
+    </exec>
+  </target>
+  <target name="clean-windows" if="osfamily-windows">
+    <exec executable="cmd" failonerror="true">
+      <arg value="/c"/>
+      <arg value="mvn"/>
+      <arg value="clean"/>
+      <arg value="${mvn.opts}"/>
+    </exec>
+  </target>
+
+  <target name="test" depends="test-unix,test-windows" description="Run tests"/>
+  <target name="test-unix" if="osfamily-unix">
+    <exec executable="mvn" failonerror="true">
+      <arg value="test"/>
+      <arg value="${mvn.opts}"/>
+    </exec>
+  </target>
+  <target name="test-windows" if="osfamily-windows">
+    <exec executable="cmd" failonerror="true">
+      <arg value="/c"/>
+      <arg value="mvn"/>
+      <arg value="test"/>
+      <arg value="${mvn.opts}"/>
+    </exec>
+  </target>
+
+</project>

--- a/services/dutyofcare/client/pom.xml
+++ b/services/dutyofcare/client/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <groupId>org.collectionspace.services</groupId>
+    <artifactId>org.collectionspace.services.dutyofcare</artifactId>
+    <version>${revision}</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>org.collectionspace.services.dutyofcare.client</artifactId>
+  <name>services.dutyofcare.client</name>
+
+  <dependencies>
+    <!-- CollectionSpace dependencies -->
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.authority.jaxb</artifactId>
+      <optional>true</optional>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.jaxb</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.common</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.client</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.dutyofcare.jaxb</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.person.client</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <!-- External dependencies -->
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxrs</artifactId>
+      <!-- filter out unwanted jars -->
+      <exclusions>
+        <exclusion>
+          <groupId>tjws</groupId>
+          <artifactId>webserver</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxb-provider</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-multipart-provider</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-httpclient</groupId>
+      <artifactId>commons-httpclient</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>collectionspace-services-dutyofcare-client</finalName>
+  </build>
+</project>

--- a/services/dutyofcare/client/src/main/java/org/collectionspace/services/client/DutyofcareClient.java
+++ b/services/dutyofcare/client/src/main/java/org/collectionspace/services/client/DutyofcareClient.java
@@ -1,0 +1,52 @@
+/**
+ * This document is a part of the source code and related artifacts
+ * for CollectionSpace, an open source collections management system
+ * for museums and related institutions:
+ *
+ * http://www.collectionspace.org
+ * http://wiki.collectionspace.org
+ *
+ * Licensed under the Educational Community License (ECL), Version 2.0.
+ * You may not use this file except in compliance with this License.
+ *
+ * You may obtain a copy of the ECL 2.0 License at
+ * https://source.collectionspace.org/collection-space/LICENSE.txt
+ */
+package org.collectionspace.services.client;
+
+import org.collectionspace.services.dutyofcare.DutyofcaresCommon;
+
+/**
+ * DutyofcareClient.java
+ */
+public class DutyofcareClient extends AbstractCommonListPoxServiceClientImpl<DutyofcareProxy, DutyofcaresCommon> {
+
+    public static final String SERVICE_NAME = "dutyofcares";
+    public static final String SERVICE_PATH_COMPONENT = SERVICE_NAME;
+    public static final String SERVICE_PATH = "/" + SERVICE_PATH_COMPONENT;
+    public static final String SERVICE_PATH_PROXY = SERVICE_PATH + "/";
+    public static final String SERVICE_PAYLOAD_NAME = SERVICE_NAME;
+
+    public DutyofcareClient() throws Exception {
+        super();
+    }
+
+    public DutyofcareClient(String clientPropertiesFilename) throws Exception {
+        super(clientPropertiesFilename);
+    }
+
+    @Override
+    public String getServicePathComponent() {
+        return SERVICE_PATH_COMPONENT;
+    }
+
+    @Override
+    public String getServiceName() {
+        return SERVICE_NAME;
+    }
+
+    @Override
+    public Class<DutyofcareProxy> getProxyClass() {
+        return DutyofcareProxy.class;
+    }
+}

--- a/services/dutyofcare/client/src/main/java/org/collectionspace/services/client/DutyofcareProxy.java
+++ b/services/dutyofcare/client/src/main/java/org/collectionspace/services/client/DutyofcareProxy.java
@@ -1,0 +1,27 @@
+/**
+ * This document is a part of the source code and related artifacts
+ * for CollectionSpace, an open source collections management system
+ * for museums and related institutions:
+ *
+ * http://www.collectionspace.org
+ * http://wiki.collectionspace.org
+ *
+ * Licensed under the Educational Community License (ECL), Version 2.0.
+ * You may not use this file except in compliance with this License.
+ *
+ * You may obtain a copy of the ECL 2.0 License at
+ * https://source.collectionspace.org/collection-space/LICENSE.txt
+ */
+package org.collectionspace.services.client;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+/**
+ * DutyofcareProxy.java
+ */
+@Path(DutyofcareClient.SERVICE_PATH_PROXY)
+@Produces({"application/xml"})
+@Consumes({"application/xml"})
+public interface DutyofcareProxy extends CollectionSpaceCommonListPoxProxy {}

--- a/services/dutyofcare/client/src/test/java/org/collectionspace/services/client/DutyofcareServiceTest.java
+++ b/services/dutyofcare/client/src/test/java/org/collectionspace/services/client/DutyofcareServiceTest.java
@@ -1,0 +1,497 @@
+/*
+ * This document is a part of the source code and related artifacts
+ * for CollectionSpace, an open source collections management system
+ * for museums and related institutions:
+ *
+ * http://www.collectionspace.org
+ * http://wiki.collectionspace.org
+ *
+ * Copyright © 2009 Regents of the University of California
+ *
+ * Licensed under the Educational Community License (ECL), Version 2.0.
+ * You may not use this file except in compliance with this License.
+ *
+ * You may obtain a copy of the ECL 2.0 License at
+ * https://source.collectionspace.org/collection-space/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.collectionspace.services.client;
+
+import javax.ws.rs.core.Response;
+import org.collectionspace.services.client.test.AbstractPoxServiceTestImpl;
+import org.collectionspace.services.client.test.ServiceRequestType;
+import org.collectionspace.services.dutyofcare.DutyofcaresCommon;
+import org.collectionspace.services.jaxb.AbstractCommonList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+
+public class DutyofcareServiceTest extends AbstractPoxServiceTestImpl<AbstractCommonList, DutyofcaresCommon> {
+
+    private final Logger logger = LoggerFactory.getLogger(DutyofcareServiceTest.class);
+
+    /** The service path component. */
+    final String SERVICE_NAME = "dutyofcares";
+
+    final String SERVICE_PATH_COMPONENT = "dutyofcares";
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.BaseServiceTest#getClientInstance()
+     */
+    @Override
+    protected CollectionSpaceClient getClientInstance() throws Exception {
+        return new DutyofcareClient();
+    }
+
+    @Override
+    protected CollectionSpaceClient getClientInstance(String clientPropertiesFilename) throws Exception {
+        return new DutyofcareClient(clientPropertiesFilename);
+    }
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.BaseServiceTest#getAbstractCommonList(org.jboss.resteasy.client.ClientResponse)
+     */
+    @Override
+    protected AbstractCommonList getCommonList(Response response) {
+        return response.readEntity(AbstractCommonList.class);
+    }
+
+    // ---------------------------------------------------------------
+    // CRUD tests : CREATE tests
+    // ---------------------------------------------------------------
+
+    // Success outcomes
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.ServiceTest#create(java.lang.String)
+     */
+    @Override
+    public void create(String testName) throws Exception {
+        // Perform setup, such as initializing the type of service request
+        // (e.g. CREATE, DELETE), its valid and expected status codes, and
+        // its associated HTTP method name (e.g. POST, DELETE).
+        setupCreate();
+
+        // Submit the request to the service and store the response.
+        DutyofcareClient client = new DutyofcareClient();
+        String identifier = createIdentifier();
+        PoxPayloadOut multipart = createDutyofcareInstance(identifier);
+        String newID = null;
+        Response res = client.create(multipart);
+        try {
+            int statusCode = res.getStatus();
+
+            // Check the status code of the response: does it match
+            // the expected response(s)?
+            //
+            // Specifically:
+            // Does it fall within the set of valid status codes?
+            // Does it exactly match the expected status code?
+            logger.debug(testName + ": status = " + statusCode);
+            Assert.assertTrue(
+                    testRequestType.isValidStatusCode(statusCode),
+                    invalidStatusCodeMessage(testRequestType, statusCode));
+            Assert.assertEquals(statusCode, testExpectedStatusCode);
+
+            newID = extractId(res);
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+
+        // Store the ID returned from the first resource created
+        // for additional tests below.
+        if (knownResourceId == null) {
+            knownResourceId = newID;
+            logger.debug(testName + ": knownResourceId=" + knownResourceId);
+        }
+
+        // Store the IDs from every resource created by tests,
+        // so they can be deleted after tests have been run.
+        allResourceIdsCreated.add(newID);
+    }
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.AbstractServiceTestImpl#createList(java.lang.String)
+     */
+    @Override
+    public void createList(String testName) throws Exception {
+        for (int i = 0; i < 3; i++) {
+            create(testName);
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // CRUD tests : READ tests
+    // ---------------------------------------------------------------
+
+    // Success outcomes
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.AbstractServiceTestImpl#read(java.lang.String)
+     */
+    @Override
+    public void read(String testName) throws Exception {
+        // Perform setup.
+        setupRead();
+
+        // Submit the request to the service and store the response.
+        DutyofcareClient client = new DutyofcareClient();
+        Response res = client.read(knownResourceId);
+        PoxPayloadIn input;
+        try {
+            assertStatusCode(res, testName);
+            input = new PoxPayloadIn(res.readEntity(String.class));
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+
+        // Get the common part of the response and verify that it is not null.
+        PayloadInputPart payloadInputPart = input.getPart(client.getCommonPartName());
+        DutyofcaresCommon dutyofcareCommon = null;
+        if (payloadInputPart != null) {
+            dutyofcareCommon = (DutyofcaresCommon) payloadInputPart.getBody();
+        }
+        Assert.assertNotNull(dutyofcareCommon);
+    }
+
+    // Failure outcomes
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.AbstractServiceTestImpl#readNonExistent(java.lang.String)
+     */
+    @Override
+    public void readNonExistent(String testName) throws Exception {
+        // Perform setup.
+        setupReadNonExistent();
+
+        // Submit the request to the service and store the response.
+        DutyofcareClient client = new DutyofcareClient();
+        Response res = client.read(NON_EXISTENT_ID);
+        try {
+            int statusCode = res.getStatus();
+
+            // Check the status code of the response: does it match
+            // the expected response(s)?
+            logger.debug(testName + ": status = " + statusCode);
+            Assert.assertTrue(
+                    testRequestType.isValidStatusCode(statusCode),
+                    invalidStatusCodeMessage(testRequestType, statusCode));
+            Assert.assertEquals(statusCode, testExpectedStatusCode);
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // CRUD tests : READ_LIST tests
+    // ---------------------------------------------------------------
+
+    // Success outcomes
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.AbstractServiceTestImpl#readList(java.lang.String)
+     */
+    @Override
+    public void readList(String testName) throws Exception {
+        // Perform setup.
+        setupReadList();
+
+        // Submit the request to the service and store the response.
+        AbstractCommonList list;
+        DutyofcareClient client = new DutyofcareClient();
+        Response res = client.readList();
+        assertStatusCode(res, testName);
+        try {
+            int statusCode = res.getStatus();
+
+            // Check the status code of the response: does it match
+            // the expected response(s)?
+            logger.debug(testName + ": status = " + statusCode);
+            Assert.assertTrue(
+                    testRequestType.isValidStatusCode(statusCode),
+                    invalidStatusCodeMessage(testRequestType, statusCode));
+            Assert.assertEquals(statusCode, testExpectedStatusCode);
+
+            list = res.readEntity(getCommonListType());
+        } finally {
+            res.close();
+        }
+
+        // Optionally output additional data about list members for debugging.
+        AbstractCommonListUtils.ListItemsInAbstractCommonList(list, logger, testName);
+    }
+
+    // Failure outcomes
+    // None at present.
+
+    // ---------------------------------------------------------------
+    // CRUD tests : UPDATE tests
+    // ---------------------------------------------------------------
+
+    // Success outcomes
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.AbstractServiceTestImpl#update(java.lang.String)
+     */
+    @Override
+    public void update(String testName) throws Exception {
+        // Perform setup.
+        setupRead();
+
+        // Retrieve the contents of a resource to update.
+        DutyofcareClient client = new DutyofcareClient();
+        Response res = client.read(knownResourceId);
+        PoxPayloadIn input;
+        try {
+            assertStatusCode(res, testName);
+            input = new PoxPayloadIn(res.readEntity(String.class));
+            logger.debug("got object to update with ID: " + knownResourceId);
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+
+        // Extract the common part from the response.
+        PayloadInputPart payloadInputPart = input.getPart(client.getCommonPartName());
+        DutyofcaresCommon dutyofcareCommon = null;
+        if (payloadInputPart != null) {
+            dutyofcareCommon = (DutyofcaresCommon) payloadInputPart.getBody();
+        }
+        Assert.assertNotNull(dutyofcareCommon);
+
+        // Update the content of this resource.
+        dutyofcareCommon.setDutyOfCareNumber("updated-" + dutyofcareCommon.getDutyOfCareNumber());
+
+        logger.debug("to be updated object");
+        logger.debug(objectAsXmlString(dutyofcareCommon, DutyofcaresCommon.class));
+
+        setupUpdate();
+
+        // Submit the updated common part in an update request to the service
+        // and store the response.
+        PoxPayloadOut output = new PoxPayloadOut(this.getServicePathComponent());
+        PayloadOutputPart commonPart = output.addPart(client.getCommonPartName(), dutyofcareCommon);
+        res = client.update(knownResourceId, output);
+        try {
+            assertStatusCode(res, testName);
+            int statusCode = res.getStatus();
+            // Check the status code of the response: does it match the expected response(s)?
+            logger.debug(testName + ": status = " + statusCode);
+            Assert.assertTrue(
+                    testRequestType.isValidStatusCode(statusCode),
+                    invalidStatusCodeMessage(testRequestType, statusCode));
+            Assert.assertEquals(statusCode, testExpectedStatusCode);
+            input = new PoxPayloadIn(res.readEntity(String.class));
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+
+        // Extract the updated common part from the response.
+        payloadInputPart = input.getPart(client.getCommonPartName());
+        DutyofcaresCommon updatedDutyofcareCommon = null;
+        if (payloadInputPart != null) {
+            updatedDutyofcareCommon = (DutyofcaresCommon) payloadInputPart.getBody();
+        }
+        Assert.assertNotNull(updatedDutyofcareCommon);
+
+        // Check selected fields in the updated common part.
+        Assert.assertEquals(
+                updatedDutyofcareCommon.getDutyOfCareNumber(),
+                dutyofcareCommon.getDutyOfCareNumber(),
+                "Data in updated object did not match submitted data.");
+    }
+
+    @Override
+    public void updateNonExistent(String testName) throws Exception {
+        // Perform setup.
+        setupUpdateNonExistent();
+
+        // Submit the request to the service and store the response.
+        // Note: The ID used in this 'create' call may be arbitrary.
+        // The only relevant ID may be the one used in update(), below.
+        DutyofcareClient client = new DutyofcareClient();
+        PoxPayloadOut multipart = createDutyofcareInstance(NON_EXISTENT_ID);
+        Response res = client.update(NON_EXISTENT_ID, multipart);
+        try {
+            int statusCode = res.getStatus();
+
+            // Check the status code of the response: does it match
+            // the expected response(s)?
+            logger.debug(testName + ": status = " + statusCode);
+            Assert.assertTrue(
+                    testRequestType.isValidStatusCode(statusCode),
+                    invalidStatusCodeMessage(testRequestType, statusCode));
+            Assert.assertEquals(statusCode, testExpectedStatusCode);
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // CRUD tests : DELETE tests
+    // ---------------------------------------------------------------
+
+    // Success outcomes
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.AbstractServiceTestImpl#delete(java.lang.String)
+     */
+    @Override
+    public void delete(String testName) throws Exception {
+        // Perform setup.
+        setupDelete();
+
+        // Submit the request to the service and store the response.
+        DutyofcareClient client = new DutyofcareClient();
+        Response res = client.delete(knownResourceId);
+        try {
+            int statusCode = res.getStatus();
+
+            // Check the status code of the response: does it match
+            // the expected response(s)?
+            logger.debug(testName + ": status = " + statusCode);
+            Assert.assertTrue(
+                    testRequestType.isValidStatusCode(statusCode),
+                    invalidStatusCodeMessage(testRequestType, statusCode));
+            Assert.assertEquals(statusCode, testExpectedStatusCode);
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+    }
+
+    // Failure outcomes
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.AbstractServiceTestImpl#deleteNonExistent(java.lang.String)
+     */
+    @Override
+    public void deleteNonExistent(String testName) throws Exception {
+        // Perform setup.
+        setupDeleteNonExistent();
+
+        // Submit the request to the service and store the response.
+        DutyofcareClient client = new DutyofcareClient();
+        Response res = client.delete(NON_EXISTENT_ID);
+        try {
+            int statusCode = res.getStatus();
+
+            // Check the status code of the response: does it match
+            // the expected response(s)?
+            logger.debug(testName + ": status = " + statusCode);
+            Assert.assertTrue(
+                    testRequestType.isValidStatusCode(statusCode),
+                    invalidStatusCodeMessage(testRequestType, statusCode));
+            Assert.assertEquals(statusCode, testExpectedStatusCode);
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Utility tests : tests of code used in tests above
+    // ---------------------------------------------------------------
+
+    /**
+     * Tests the code for manually submitting data that is used by several
+     * of the methods above.
+     */
+    public void testSubmitRequest() {
+
+        // Expected status code: 200 OK
+        final int EXPECTED_STATUS = Response.Status.OK.getStatusCode();
+
+        // Submit the request to the service and store the response.
+        String method = ServiceRequestType.READ.httpMethodName();
+        String url = getResourceURL(knownResourceId);
+        int statusCode = submitRequest(method, url);
+
+        // Check the status code of the response: does it match
+        // the expected response(s)?
+        logger.debug("testSubmitRequest: url=" + url + " status=" + statusCode);
+        Assert.assertEquals(statusCode, EXPECTED_STATUS);
+    }
+
+    // ---------------------------------------------------------------
+    // Utility methods used by tests above
+    // ---------------------------------------------------------------
+
+    @Override
+    public String getServiceName() {
+        return SERVICE_NAME;
+    }
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.BaseServiceTest#getServicePathComponent()
+     */
+    @Override
+    public String getServicePathComponent() {
+        return SERVICE_PATH_COMPONENT;
+    }
+
+    @Override
+    protected PoxPayloadOut createInstance(String identifier) throws Exception {
+        return createDutyofcareInstance(identifier);
+    }
+
+    /**
+     * Creates the dutyofcare instance.
+     *
+     * @param dutyofcareNumber the exhibition number
+     * @return the multipart output
+     * @throws Exception
+     */
+    private PoxPayloadOut createDutyofcareInstance(String dutyofcareNumber) throws Exception {
+        DutyofcaresCommon dutyofcareCommon = new DutyofcaresCommon();
+        dutyofcareCommon.setDutyOfCareNumber(dutyofcareNumber);
+
+        PoxPayloadOut multipart = new PoxPayloadOut(this.getServicePathComponent());
+        PayloadOutputPart commonPart = multipart.addPart(new DutyofcareClient().getCommonPartName(), dutyofcareCommon);
+
+        logger.debug("to be created, dutyofcare common");
+        logger.debug(objectAsXmlString(dutyofcareCommon, DutyofcaresCommon.class));
+
+        return multipart;
+    }
+
+    @Override
+    public void CRUDTests(String testName) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    protected PoxPayloadOut createInstance(String commonPartName, String identifier) throws Exception {
+        return createDutyofcareInstance(identifier);
+    }
+
+    @Override
+    protected DutyofcaresCommon updateInstance(DutyofcaresCommon commonPartObject) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    protected void compareUpdatedInstances(DutyofcaresCommon original, DutyofcaresCommon updated) {
+        // TODO Auto-generated method stub
+    }
+}

--- a/services/dutyofcare/jaxb/pom.xml
+++ b/services/dutyofcare/jaxb/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <artifactId>org.collectionspace.services.dutyofcare</artifactId>
+    <groupId>org.collectionspace.services</groupId>
+    <version>${revision}</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>org.collectionspace.services.dutyofcare.jaxb</artifactId>
+  <name>services.dutyofcare.jaxb</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.jaxb</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>collectionspace-services-dutyofcare-jaxb</finalName>
+    <defaultGoal>install</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>org.jvnet.jaxb2.maven2</groupId>
+        <artifactId>maven-jaxb2-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/services/dutyofcare/jaxb/src/main/java/org/collectionspace/services/DutyofcareJAXBSchema.java
+++ b/services/dutyofcare/jaxb/src/main/java/org/collectionspace/services/DutyofcareJAXBSchema.java
@@ -1,0 +1,17 @@
+/**
+ * This document is a part of the source code and related artifacts
+ * for CollectionSpace, an open source collections management system
+ * for museums and related institutions:
+ *
+ * http://www.collectionspace.org
+ * http://wiki.collectionspace.org
+ *
+ * Licensed under the Educational Community License (ECL), Version 2.0.
+ * You may not use this file except in compliance with this License.
+ *
+ * You may obtain a copy of the ECL 2.0 License at
+ * https://source.collectionspace.org/collection-space/LICENSE.txt
+ */
+package org.collectionspace.services;
+
+public interface DutyofcareJAXBSchema {}

--- a/services/dutyofcare/jaxb/src/main/java/org/collectionspace/services/DutyofcareListItemJAXBSchema.java
+++ b/services/dutyofcare/jaxb/src/main/java/org/collectionspace/services/DutyofcareListItemJAXBSchema.java
@@ -1,0 +1,20 @@
+/**
+ * This document is a part of the source code and related artifacts
+ * for CollectionSpace, an open source collections management system
+ * for museums and related institutions:
+ *
+ * http://www.collectionspace.org
+ * http://wiki.collectionspace.org
+ *
+ * Licensed under the Educational Community License (ECL), Version 2.0.
+ * You may not use this file except in compliance with this License.
+ *
+ * You may obtain a copy of the ECL 2.0 License at
+ * https://source.collectionspace.org/collection-space/LICENSE.txt
+ */
+package org.collectionspace.services;
+
+public interface DutyofcareListItemJAXBSchema {
+    String CSID = "csid";
+    String URI = "url";
+}

--- a/services/dutyofcare/jaxb/src/main/resources/dutyofcares_common.xsd
+++ b/services/dutyofcare/jaxb/src/main/resources/dutyofcares_common.xsd
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+<!--
+    Dutyofcare schema (XSD)
+    Entity  : Dutyofcare
+    Part    : Common
+    Used for: JAXB binding between XML and Java objects
+-->
+
+<xs:schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+  jaxb:version="1.0" elementFormDefault="unqualified"
+  xmlns="http://collectionspace.org/services/dutyofcare"
+  targetNamespace="http://collectionspace.org/services/dutyofcare"
+  version="0.1"
+>
+
+  <!--
+      Avoid XmlRootElement nightmare:
+      See http://weblogs.java.net/blog/kohsuke/archive/2006/03/why_does_jaxb_p.html
+  -->
+
+  <!--  Dutyofcare Information Group -->
+  <xs:element name="dutyofcares_common">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="dutyOfCareNumber" type="xs:string"/>
+        <xs:element name="dutyOfCareDate" type="xs:date"/>
+        <xs:element name="dutyOfCareTitle" type="xs:string"/>
+
+        <xs:element name="dutyOfCareNotes" type="dutyOfCareNotes"/>
+        <xs:element name="partiesInvolvedGroupList" type="partiesInvolvedGroupList"/>
+        <xs:element name="dutyOfCareDetailGroupList" type="dutyOfCareDetailGroupList"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:complexType name="dutyOfCareNotes">
+    <xs:sequence>
+      <xs:element name="dutyOfCareNote" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="partiesInvolvedGroupList">
+    <xs:sequence>
+      <xs:element name="partiesInvolvedGroup" type="partiesInvolvedGroup" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="partiesInvolvedGroup">
+    <xs:sequence>
+      <xs:element name="involvedParty" type="xs:string"/>
+      <xs:element name="involvedOnBehalfOf" type="xs:string"/>
+      <xs:element name="involvedRole" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="dutyOfCareDetailGroupList">
+    <xs:sequence>
+      <xs:element name="dutyOfCareDetailGroup" type="dutyOfCareDetailGroup" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="dutyOfCareDetailGroup">
+    <xs:sequence>
+      <xs:element name="detailType" type="xs:string"/>
+      <xs:element name="detailLevel" type="xs:string"/>
+      <xs:element name="detailDeterminedBy" type="xs:string"/>
+      <xs:element name="detailDeterminationDate" type="xs:date"/>
+      <xs:element name="detailNote" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/services/dutyofcare/jaxb/src/main/resources/dutyofcares_common.xsd
+++ b/services/dutyofcare/jaxb/src/main/resources/dutyofcares_common.xsd
@@ -27,18 +27,18 @@
       <xs:sequence>
         <xs:element name="dutyOfCareNumber" type="xs:string"/>
         <xs:element name="dutyOfCareDate" type="xs:date"/>
-        <xs:element name="dutyOfCareTitle" type="xs:string"/>
+        <xs:element name="title" type="xs:string"/>
 
-        <xs:element name="dutyOfCareNotes" type="dutyOfCareNotes"/>
+        <xs:element name="notes" type="notes"/>
         <xs:element name="partiesInvolvedGroupList" type="partiesInvolvedGroupList"/>
-        <xs:element name="dutyOfCareDetailGroupList" type="dutyOfCareDetailGroupList"/>
+        <xs:element name="detailGroupList" type="detailGroupList"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>
 
-  <xs:complexType name="dutyOfCareNotes">
+  <xs:complexType name="notes">
     <xs:sequence>
-      <xs:element name="dutyOfCareNote" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="note" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
     </xs:sequence>
   </xs:complexType>
 
@@ -56,13 +56,13 @@
     </xs:sequence>
   </xs:complexType>
 
-  <xs:complexType name="dutyOfCareDetailGroupList">
+  <xs:complexType name="detailGroupList">
     <xs:sequence>
-      <xs:element name="dutyOfCareDetailGroup" type="dutyOfCareDetailGroup" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="detailGroup" type="detailGroup" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
   </xs:complexType>
 
-  <xs:complexType name="dutyOfCareDetailGroup">
+  <xs:complexType name="detailGroup">
     <xs:sequence>
       <xs:element name="detailType" type="xs:string"/>
       <xs:element name="detailLevel" type="xs:string"/>

--- a/services/dutyofcare/pom.xml
+++ b/services/dutyofcare/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <groupId>org.collectionspace.services</groupId>
+    <artifactId>org.collectionspace.services.main</artifactId>
+    <version>${revision}</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>org.collectionspace.services.dutyofcare</artifactId>
+  <name>services.dutyofcare</name>
+  <packaging>pom</packaging>
+
+  <properties>
+    <!-- spotless 2.30.0 is the last version that supports java 8 -->
+    <spotless.version>2.30.0</spotless.version>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>${spotless.version}</version>
+        <configuration>
+          <formats>
+            <!-- you can define as many formats as you want, each is independent -->
+            <format>
+              <includes>
+                <include>src/main/java/**/*.java</include>
+                <include>src/test/java/**/*.java</include>
+              </includes>
+              <trimTrailingWhitespace/>
+              <endWithNewline/>
+              <indent>
+                <spaces>true</spaces>
+                <spacesPerTab>4</spacesPerTab>
+              </indent>
+            </format>
+          </formats>
+          <!-- define a language-specific format -->
+          <java>
+            <palantirJavaFormat />
+          </java>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <modules>
+    <module>jaxb</module>
+    <module>service</module>
+    <module>client</module>
+  </modules>
+
+</project>

--- a/services/dutyofcare/service/pom.xml
+++ b/services/dutyofcare/service/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <parent>
+    <groupId>org.collectionspace.services</groupId>
+    <artifactId>org.collectionspace.services.dutyofcare</artifactId>
+    <version>${revision}</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>org.collectionspace.services.dutyofcare.service</artifactId>
+  <name>services.dutyofcare.service</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.dutyofcare.jaxb</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.dutyofcare.client</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.collectionobject.jaxb</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <!-- External dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+    </dependency>
+
+    <!-- javax -->
+    <dependency>
+      <groupId>javax.security</groupId>
+      <artifactId>jaas</artifactId>
+      <version>1.0.01</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- jboss -->
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxrs</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>tjws</groupId>
+          <artifactId>webserver</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxb-provider</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-multipart-provider</artifactId>
+    </dependency>
+
+    <!-- nuxeo -->
+    <dependency>
+      <groupId>org.nuxeo.ecm.core</groupId>
+      <artifactId>nuxeo-core-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <artifactId>jboss-remoting</artifactId>
+          <groupId>jboss</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <finalName>collectionspace-services-dutyofcare</finalName>
+  </build>
+</project>

--- a/services/dutyofcare/service/src/main/java/org/collectionspace/services/dutyofcare/DutyofcareResource.java
+++ b/services/dutyofcare/service/src/main/java/org/collectionspace/services/dutyofcare/DutyofcareResource.java
@@ -1,0 +1,54 @@
+/**
+ * This document is a part of the source code and related artifacts
+ * for CollectionSpace, an open source collections management system
+ * for museums and related institutions:
+ *
+ * http://www.collectionspace.org
+ * http://wiki.collectionspace.org
+ *
+ * Licensed under the Educational Community License (ECL), Version 2.0.
+ * You may not use this file except in compliance with this License.
+ *
+ * You may obtain a copy of the ECL 2.0 License at
+ *
+ * https://source.collectionspace.org/collection-space/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.collectionspace.services.dutyofcare;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import org.collectionspace.services.client.DutyofcareClient;
+import org.collectionspace.services.common.NuxeoBasedResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Path(DutyofcareClient.SERVICE_PATH)
+@Consumes("application/xml")
+@Produces("application/xml")
+public class DutyofcareResource extends NuxeoBasedResource {
+
+    final Logger logger = LoggerFactory.getLogger(DutyofcareResource.class);
+
+    @Override
+    protected String getVersionString() {
+        final String lastChangeRevision = "$LastChangedRevision$";
+        return lastChangeRevision;
+    }
+
+    @Override
+    public String getServiceName() {
+        return DutyofcareClient.SERVICE_NAME;
+    }
+
+    @Override
+    public Class<DutyofcaresCommon> getCommonPartClass() {
+        return DutyofcaresCommon.class;
+    }
+}

--- a/services/dutyofcare/service/src/main/java/org/collectionspace/services/dutyofcare/nuxeo/DutyofcareConstants.java
+++ b/services/dutyofcare/service/src/main/java/org/collectionspace/services/dutyofcare/nuxeo/DutyofcareConstants.java
@@ -1,0 +1,33 @@
+/**
+ *  This document is a part of the source code and related artifacts
+ *  for CollectionSpace, an open source collections management system
+ *  for museums and related institutions:
+ *
+ *  http://www.collectionspace.org
+ *  http://wiki.collectionspace.org
+ *
+ *  Licensed under the Educational Community License (ECL), Version 2.0.
+ *  You may not use this file except in compliance with this License.
+ *
+ *  You may obtain a copy of the ECL 2.0 License at
+ *
+ *  https://source.collectionspace.org/collection-space/LICENSE.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.collectionspace.services.dutyofcare.nuxeo;
+
+/**
+ * DutyofcareConstants specifies constants for the Dutyofcare service
+ *
+ */
+public class DutyofcareConstants {
+
+    public static final String NUXEO_DOCTYPE = "Dutyofcare";
+    public static final String NUXEO_SCHEMA_NAME = "dutyofcare";
+    public static final String NUXEO_DC_TITLE = "CollectionSpace-Dutyofcare";
+}

--- a/services/dutyofcare/service/src/main/java/org/collectionspace/services/dutyofcare/nuxeo/DutyofcareDocumentModelHandler.java
+++ b/services/dutyofcare/service/src/main/java/org/collectionspace/services/dutyofcare/nuxeo/DutyofcareDocumentModelHandler.java
@@ -1,0 +1,30 @@
+/**
+ *  This document is a part of the source code and related artifacts
+ *  for CollectionSpace, an open source collections management system
+ *  for museums and related institutions:
+ *
+ *  http://www.collectionspace.org
+ *  http://wiki.collectionspace.org
+ *
+ *  Licensed under the Educational Community License (ECL), Version 2.0.
+ *  You may not use this file except in compliance with this License.
+ *
+ *  You may obtain a copy of the ECL 2.0 License at
+ *
+ *  https://source.collectionspace.org/collection-space/LICENSE.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.collectionspace.services.dutyofcare.nuxeo;
+
+import org.collectionspace.services.dutyofcare.DutyofcaresCommon;
+import org.collectionspace.services.nuxeo.client.java.NuxeoDocumentModelHandler;
+
+/**
+ * DutyofcareDocumentModelHandler
+ */
+public class DutyofcareDocumentModelHandler extends NuxeoDocumentModelHandler<DutyofcaresCommon> {}

--- a/services/dutyofcare/service/src/main/java/org/collectionspace/services/dutyofcare/nuxeo/DutyofcareValidatorHandler.java
+++ b/services/dutyofcare/service/src/main/java/org/collectionspace/services/dutyofcare/nuxeo/DutyofcareValidatorHandler.java
@@ -1,0 +1,29 @@
+/**
+ * This document is a part of the source code and related artifacts
+ * for CollectionSpace, an open source collections management system
+ * for museums and related institutions:
+ *
+ * http://www.collectionspace.org
+ * http://wiki.collectionspace.org
+ *
+ * Licensed under the Educational Community License (ECL), Version 2.0.
+ * You may not use this file except in compliance with this License.
+ *
+ * You may obtain a copy of the ECL 2.0 License at
+ * https://source.collectionspace.org/collection-space/LICENSE.txt
+ */
+package org.collectionspace.services.dutyofcare.nuxeo;
+
+import org.collectionspace.services.common.context.ServiceContext;
+import org.collectionspace.services.common.document.DocumentHandler.Action;
+import org.collectionspace.services.common.document.InvalidDocumentException;
+import org.collectionspace.services.common.document.ValidatorHandler;
+
+public class DutyofcareValidatorHandler implements ValidatorHandler {
+
+    @Override
+    public void validate(Action action, ServiceContext ctx) throws InvalidDocumentException {
+        // TODO Auto-generated method stub
+        System.out.println("DutyofcareValidatorHandler executed.");
+    }
+}

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -73,6 +73,7 @@
 		<module>transport</module>
 		<module>conditioncheck</module>
 		<module>conservation</module>
+		<module>dutyofcare</module>
 		<module>valuationcontrol</module>
 		<module>objectexit</module>
 		<module>propagation</module>


### PR DESCRIPTION
**What does this do?**
* Creates the DutyOfCare procedure

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1332

This is one of the procedures for the NAGPRA support we're working on for the next release.

**How should this be tested? Do these changes have associated tests?**
* Rebuild collectionspace
* Run the test suite against collectionspace

**Dependencies for merging? Releasing to production?**
Not a dependency but I've been playing around with using spotless to handle formatting. I added it to the parent dutyofcare pom, and it can be run with `mvn spotless:check` or `mvn spotless:apply`. I'm only doing it for the procedures for now as applying to everything is slightly overwhelming.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested the procedure through the ui updates