### PR TITLE
DRYD-1412: Fix handling of null salt when upgrading users table.

### DIFF
--- a/services/authentication/pstore/src/main/resources/db/postgresql/authentication.sql
+++ b/services/authentication/pstore/src/main/resources/db/postgresql/authentication.sql
@@ -14,7 +14,16 @@ ALTER TABLE users ADD COLUMN IF NOT EXISTS salt VARCHAR(128);
 
 -- Upgrade older users tables to 8.0
 
-UPDATE users SET passwd = concat('{SHA-256}', '{', salt, '}', passwd)  WHERE left(passwd, 1) <> '{';
+UPDATE users
+SET passwd = concat(
+  '{SHA-256}',
+  CASE
+    WHEN salt IS NULL THEN ''
+    ELSE concat('{', salt, '}')
+  END,
+  passwd
+)
+WHERE left(passwd, 1) <> '{';
 
 -- Create tokens table required in 8.0
 


### PR DESCRIPTION
**What does this do?**

This fixes a bug in upgrading older users tables to 8.0. Due to the Spring Security upgrade, the salt in 8.0 is incorporated into the password (`passwd`) column, instead of being a separate column. When upgrading, rows with null salt were treated as if they had an empty ("") salt, resulting in an incorrect `passwd`.

**Why are we doing this? (with JIRA link)**

This caused older users (pre-5.0) to not be able to log in after upgrading to 8.0.

JIRA: https://collectionspace.atlassian.net/browse/DRYD-1412

**How should this be tested? Do these changes have associated tests?**

- Set some rows in the `users` table to resemble a pre-8.0 table:
   - The `passwd` column should contain only a hashed password (no prefixes contained in curly braces)
   - The `salt` column should have some rows that are null
- Run `ant create_db`

The `passwd` column should now look like "{SHA-256}{salt}hashedpassword" when there is a non-null salt, and like "{SHA-256}hashedpassword" when there is a null salt.

**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee tested an upgrade with users with null salt.
