### PR TITLE
DRYD-1417: Set password success login URL to UI authorization page.

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -27,7 +27,7 @@ cspace.im.root=
 # UI settings
 cspace.ui.package.name=cspace-ui
 cspace.ui.library.name=cspaceUI
-cspace.ui.version=9.0.0
+cspace.ui.version=9.0.1
 cspace.ui.build.branch=master
 cspace.ui.build.node.ver=14
 service.ui.library.name=${cspace.ui.library.name}-service

--- a/services/account/service/src/main/java/org/collectionspace/services/account/AccountResource.java
+++ b/services/account/service/src/main/java/org/collectionspace/services/account/AccountResource.java
@@ -285,8 +285,13 @@ public class AccountResource extends SecurityResourceBase<AccountsCommon, Accoun
             uiConfig.put("csrf", csrfConfig);
         }
 
+        String tenantId = token.getTenantId();
+        TenantBindingConfigReaderImpl tenantBindingConfigReader = ServiceMain.getInstance().getTenantBindingConfigReader();
+        TenantBindingType tenantBinding = tenantBindingConfigReader.getTenantBinding(tenantId);
+
         uiConfig.put("token", tokenId);
-        uiConfig.put("tenantId", token.getTenantId());
+        uiConfig.put("tenantId", tenantId);
+        uiConfig.put("tenantLoginUrl", ConfigUtils.getUILoginSuccessUrl(tenantBinding));
 
         String uiConfigJS;
 


### PR DESCRIPTION
**What does this do?**

This sets the login link on the password reset page to be tenant-specific UI authorization page.

**Why are we doing this? (with JIRA link)**

Previously, the login link on the password reset page went to the services login page (/cspace-services/login) instead of the UI page that initiates authorization. This caused the error described in DRYD-1417.

JIRA: https://collectionspace.atlassian.net/browse/DRYD-1417
See also https://github.com/collectionspace/cspace-ui.js/pull/213.

**How should this be tested? Do these changes have associated tests?**

See the reproduction steps in the above JIRA.

**Dependencies for merging? Releasing to production?**

This works in tandem with https://github.com/collectionspace/cspace-ui.js/pull/213 to fix DRYD-1417, but doesn't break anything further if that PR has not been merged. cspace-ui 9.0.1 contains that PR.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee tested locally.