### PR TITLE
DRYD-1333: Summary Documentation

### DIFF
--- a/services/JaxRsServiceProvider/pom.xml
+++ b/services/JaxRsServiceProvider/pom.xml
@@ -436,6 +436,12 @@
         <artifactId>org.collectionspace.services.nagprainventory.service</artifactId>
         <version>${project.version}</version>
       </dependency>
+        <dependency>
+            <groupId>org.collectionspace.services</groupId>
+            <artifactId>org.collectionspace.services.summarydocumentation.service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
       <!--dependency>
           <groupId>org.collectionspace.services</groupId>
           <artifactId>org.collectionspace.services.query.service</artifactId>

--- a/services/JaxRsServiceProvider/pom.xml
+++ b/services/JaxRsServiceProvider/pom.xml
@@ -431,11 +431,11 @@
             <artifactId>org.collectionspace.services.dutyofcare.service</artifactId>
             <version>${project.version}</version>
         </dependency>
-      <dependency>
-        <groupId>org.collectionspace.services</groupId>
-        <artifactId>org.collectionspace.services.nagprainventory.service</artifactId>
-        <version>${project.version}</version>
-      </dependency>
+        <dependency>
+            <groupId>org.collectionspace.services</groupId>
+            <artifactId>org.collectionspace.services.nagprainventory.service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.collectionspace.services</groupId>
             <artifactId>org.collectionspace.services.summarydocumentation.service</artifactId>

--- a/services/JaxRsServiceProvider/src/main/java/org/collectionspace/services/jaxrs/CollectionSpaceJaxRsApplication.java
+++ b/services/JaxRsServiceProvider/src/main/java/org/collectionspace/services/jaxrs/CollectionSpaceJaxRsApplication.java
@@ -39,6 +39,7 @@ import org.collectionspace.services.loanin.LoaninResource;
 import org.collectionspace.services.loanout.LoanoutResource;
 import org.collectionspace.services.nagpraclaim.NagpraClaimResource;
 import org.collectionspace.services.nagprainventory.NagpraInventoryResource;
+import org.collectionspace.services.summarydocumentation.SummaryDocumentationResource;
 import org.collectionspace.services.transport.TransportResource;
 import org.collectionspace.services.uoc.UocResource;
 import org.collectionspace.services.valuationcontrol.ValuationcontrolResource;
@@ -169,6 +170,7 @@ public class CollectionSpaceJaxRsApplication extends Application
         addResourceToMapAndSingletons(new IterationreportResource());
         addResourceToMapAndSingletons(new ChronologyAuthorityResource());
         addResourceToMapAndSingletons(new NagpraInventoryResource());
+        addResourceToMapAndSingletons(new SummaryDocumentationResource());
 
         singletons.add(new IDResource());
 

--- a/services/common/src/main/resources/db/postgresql/load_id_generators.sql
+++ b/services/common/src/main/resources/db/postgresql/load_id_generators.sql
@@ -1198,3 +1198,39 @@ INSERT INTO id_generators
         SELECT  csid
         FROM    id_generators
         );
+
+-- SUMMARY_DOCUMENTATION_REFERENCE_NUMBER
+
+INSERT INTO id_generators
+    (csid, displayname, description, priority, last_generated_id, id_generator_state)
+  SELECT
+     '54ab6096-11e0-44a3-9a41-06a87c1c1bdb',
+     'Summary Documentation Reference Number',
+     'Identifies a summary documentation.',
+     '9',
+     '',
+'<org.collectionspace.services.id.SettableIDGenerator>
+  <parts>
+    <org.collectionspace.services.id.StringIDGeneratorPart>
+      <initialValue>SD</initialValue>
+      <currentValue>SD</currentValue>
+    </org.collectionspace.services.id.StringIDGeneratorPart>
+    <org.collectionspace.services.id.YearIDGeneratorPart>
+      <currentValue></currentValue>
+    </org.collectionspace.services.id.YearIDGeneratorPart>
+    <org.collectionspace.services.id.StringIDGeneratorPart>
+      <initialValue>.</initialValue>
+      <currentValue>.</currentValue>
+    </org.collectionspace.services.id.StringIDGeneratorPart>
+    <org.collectionspace.services.id.NumericIDGeneratorPart>
+      <maxLength>6</maxLength>
+      <initialValue>1</initialValue>
+      <currentValue>-1</currentValue>
+    </org.collectionspace.services.id.NumericIDGeneratorPart>
+  </parts>
+</org.collectionspace.services.id.SettableIDGenerator>'
+  WHERE '54ab6096-11e0-44a3-9a41-06a87c1c1bdb' NOT IN
+        (
+        SELECT  csid
+        FROM    id_generators
+        );

--- a/services/nagpra-jaxb/pom.xml
+++ b/services/nagpra-jaxb/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>org.collectionspace.services.main</artifactId>
+        <groupId>org.collectionspace.services</groupId>
+        <version>${revision}</version>
+    </parent>
+
+
+    <artifactId>org.collectionspace.services.nagpra-jaxb</artifactId>
+    <version>8.1.0-SNAPSHOT</version>
+
+    <name>services.nagpra.jaxb</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.collectionspace.services</groupId>
+            <artifactId>org.collectionspace.services.jaxb</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>collectionspace-services-nagpra-jaxb</finalName>
+        <defaultGoal>install</defaultGoal>
+        <plugins>
+            <plugin>
+                <groupId>org.jvnet.jaxb2.maven2</groupId>
+                <artifactId>maven-jaxb2-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/services/nagpra-jaxb/src/main/resources/nagpra_common.xsd
+++ b/services/nagpra-jaxb/src/main/resources/nagpra_common.xsd
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+<!--
+    Common NAGPRA schemas (XSD)
+-->
+<xs:schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+  jaxb:version="2.0"
+  xmlns="http://collectionspace.org/services/nagpra"
+  targetNamespace="http://collectionspace.org/services/nagpra"
+  version="0.1"
+>
+  <xs:complexType name="consultationNotes">
+    <xs:sequence>
+      <xs:element name="consultationNote" type="xs:string" minOccurs="0" maxOccurs="unbounded"  />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="treatmentNotes">
+    <xs:sequence>
+      <xs:element name="treatmentNote" type="xs:string" minOccurs="0" maxOccurs="unbounded"  />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="alternativeTitleGroupList">
+    <xs:sequence>
+      <xs:element name="alternativeTitleGroup" type="alternativeTitleGroup" minOccurs="0" maxOccurs="unbounded"  />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="alternativeTitleGroup">
+    <xs:sequence>
+      <xs:element name="alternativeTitle" type="xs:string" />
+      <xs:element name="alternativeTitleNote" type="xs:string" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="partiesInvolvedGroupList">
+    <xs:sequence>
+      <xs:element name="partiesInvolvedGroup" type="partiesInvolvedGroup" minOccurs="0" maxOccurs="unbounded"  />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="partiesInvolvedGroup">
+    <xs:sequence>
+      <xs:element name="involvedParty" type="xs:string" />
+      <xs:element name="involvedOnBehalfOf" type="xs:string" />
+      <xs:element name="involvedRole" type="xs:string" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="culturalAffiliationGroupList">
+    <xs:sequence>
+      <xs:element name="culturalAffiliationGroup" type="culturalAffiliationGroup" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="culturalAffiliationGroup">
+    <xs:sequence>
+      <xs:element name="tribeOrNation" type="xs:string"/>
+      <xs:element name="includeInNotice" type="xs:string"/>
+      <xs:element name="determinedByList" type="determinedByList"/>
+      <xs:element name="determinationDate" type="xs:date"/>
+      <xs:element name="basisOfDetermination" type="xs:string"/>
+      <xs:element name="determinationNote" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="determinedByList">
+    <xs:sequence>
+      <xs:element name="determinedBy" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="geographicPlaceGroupList">
+    <xs:sequence>
+      <xs:element name="geographicPlaceGroup" type="geographicPlaceGroup" minOccurs="0" maxOccurs="unbounded"  />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="geographicPlaceGroup">
+    <xs:sequence>
+      <xs:element name="geographicPlace" type="xs:string" />
+      <xs:element name="geographicPlaceNote" type="xs:string" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="timePeriodGroupList">
+    <xs:sequence>
+      <xs:element name="timePeriodGroup" type="timePeriodGroup" minOccurs="0" maxOccurs="unbounded"  />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="timePeriodGroup">
+    <xs:sequence>
+      <xs:element name="timePeriod" type="xs:string" />
+      <xs:element name="timePeriodNote" type="xs:string" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="culturalGroupList">
+    <xs:sequence>
+      <xs:element name="culturalGroup" type="culturalGroup" minOccurs="0" maxOccurs="unbounded"  />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="culturalGroup">
+    <xs:sequence>
+      <xs:element name="culture" type="xs:string" />
+      <xs:element name="cultureNote" type="xs:string" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="archaeologicalSiteGroupList">
+    <xs:sequence>
+      <xs:element name="archaeologicalSiteGroup" type="archaeologicalSiteGroup" minOccurs="0" maxOccurs="unbounded"  />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="archaeologicalSiteGroup">
+    <xs:sequence>
+      <xs:element name="archaeologicalSite" type="xs:string" />
+      <xs:element name="archaeologicalSiteNote" type="xs:string" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="statusGroupList">
+    <xs:sequence>
+      <xs:element name="statusGroup" type="statusGroup" minOccurs="0" maxOccurs="unbounded"  />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="statusGroup">
+    <xs:sequence>
+      <xs:element name="statusGroupType" type="xs:string" />
+      <xs:element name="statusIndividual" type="xs:string" />
+      <xs:element name="status" type="xs:string" />
+      <xs:element name="statusDate" type="xs:date" />
+      <xs:element name="statusNote" type="xs:string" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="documentationGroupList">
+    <xs:sequence>
+      <xs:element name="documentationGroup" type="documentationGroup" minOccurs="0" maxOccurs="unbounded"  />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="documentationGroup">
+    <xs:sequence>
+      <xs:element name="documentationGroupType" type="xs:string" />
+      <xs:element name="documentationIndividual" type="xs:string" />
+      <xs:element name="documentationStatus" type="xs:string" />
+      <xs:element name="documentationDate" type="xs:date" />
+      <xs:element name="documentationNote" type="xs:string" />
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -100,6 +100,7 @@
 		<module>chronology</module>
 		<module>nagpraclaim</module>
 		<module>nagprainventory</module>
+		<module>summarydocumentation</module>
 		<module>IntegrationTests</module>
 		<module>PerformanceTests</module>
 		<module>security</module>
@@ -112,7 +113,6 @@
 		<dependency>
 			<groupId>org.testng</groupId>
 			<artifactId>testng</artifactId>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -44,6 +44,7 @@
 		<module>hyperjaxb</module>
 		<module>common</module>
 		<module>structureddate</module>
+		<module>nagpra-jaxb</module>
 		<module>systeminfo</module>
 		<module>authority</module>
 		<module>authorization-mgt</module>		<!-- relies on authorization -->

--- a/services/summarydocumentation/build.xml
+++ b/services/summarydocumentation/build.xml
@@ -1,0 +1,106 @@
+<project name="summarydocumentation" default="package" basedir=".">
+  <description>
+    summarydocumentation service
+  </description>
+  <!-- set global properties for this build -->
+  <property name="services.trunk" value="../.." />
+  <!-- environment should be declared before reading build.properties -->
+  <property environment="env" />
+  <property file="${services.trunk}/build.properties" />
+  <property name="mvn.opts" value="-V" />
+  <property name="src" location="src" />
+
+  <condition property="osfamily-unix">
+    <os family="unix" />
+  </condition>
+  <condition property="osfamily-windows">
+    <os family="windows" />
+  </condition>
+
+  <target name="package" depends="package-unix,package-windows"
+    description="Package CollectionSpace Services" />
+
+  <target name="package-unix" if="osfamily-unix">
+    <exec executable="mvn" failonerror="true">
+      <arg value="package" />
+      <arg value="-Dmaven.test.skip=true" />
+      <arg value="-f" />
+      <arg value="${basedir}/pom.xml" />
+      <arg value="-N" />
+      <arg value="${mvn.opts}" />
+    </exec>
+  </target>
+
+  <target name="package-windows" if="osfamily-windows">
+    <exec executable="cmd" failonerror="true">
+      <arg value="/c" />
+      <arg value="mvn" />
+      <arg value="package" />
+      <arg value="-Dmaven.test.skip=true" />
+      <arg value="-f" />
+      <arg value="${basedir}/pom.xml" />
+      <arg value="-N" />
+      <arg value="${mvn.opts}" />
+    </exec>
+  </target>
+
+  <target name="install" depends="install-unix,install-windows"
+    description="Install" />
+  <target name="install-unix" if="osfamily-unix">
+    <exec executable="mvn" failonerror="true">
+      <arg value="install" />
+      <arg value="-Dmaven.test.skip=true" />
+      <arg value="-f" />
+      <arg value="${basedir}/pom.xml" />
+      <arg value="-N" />
+      <arg value="${mvn.opts}" />
+    </exec>
+  </target>
+  <target name="install-windows" if="osfamily-windows">
+    <exec executable="cmd" failonerror="true">
+      <arg value="/c" />
+      <arg value="mvn" />
+      <arg value="install" />
+      <arg value="-Dmaven.test.skip=true" />
+      <arg value="-f" />
+      <arg value="${basedir}/pom.xml" />
+      <arg value="-N" />
+      <arg value="${mvn.opts}" />
+    </exec>
+  </target>
+
+  <target name="clean" depends="clean-unix,clean-windows"
+    description="Delete target directories">
+    <delete dir="${build}" />
+  </target>
+  <target name="clean-unix" if="osfamily-unix">
+    <exec executable="mvn" failonerror="true">
+      <arg value="clean" />
+      <arg value="${mvn.opts}" />
+    </exec>
+  </target>
+  <target name="clean-windows" if="osfamily-windows">
+    <exec executable="cmd" failonerror="true">
+      <arg value="/c" />
+      <arg value="mvn" />
+      <arg value="clean" />
+      <arg value="${mvn.opts}" />
+    </exec>
+  </target>
+
+  <target name="test" depends="test-unix,test-windows" description="Run tests" />
+  <target name="test-unix" if="osfamily-unix">
+    <exec executable="mvn" failonerror="true">
+      <arg value="test" />
+      <arg value="${mvn.opts}" />
+    </exec>
+  </target>
+  <target name="test-windows" if="osfamily-windows">
+    <exec executable="cmd" failonerror="true">
+      <arg value="/c" />
+      <arg value="mvn" />
+      <arg value="test" />
+      <arg value="${mvn.opts}" />
+    </exec>
+  </target>
+</project>

--- a/services/summarydocumentation/client/pom.xml
+++ b/services/summarydocumentation/client/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <groupId>org.collectionspace.services</groupId>
+    <artifactId>org.collectionspace.services.summarydocumentation</artifactId>
+    <version>${revision}</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>org.collectionspace.services.summarydocumentation.client</artifactId>
+  <name>services.summarydocumentation.client</name>
+
+  <dependencies>
+    <!-- CollectionSpace dependencies -->
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.client</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.summarydocumentation.jaxb</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- External dependencies -->
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxrs</artifactId>
+      <!-- filter out unwanted jars -->
+      <exclusions>
+        <exclusion>
+          <groupId>tjws</groupId>
+          <artifactId>webserver</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxb-provider</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-multipart-provider</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>collectionspace-services-summarydocumentation-client</finalName>
+  </build>
+</project>

--- a/services/summarydocumentation/client/src/main/java/org/collectionspace/services/client/SummaryDocumentationClient.java
+++ b/services/summarydocumentation/client/src/main/java/org/collectionspace/services/client/SummaryDocumentationClient.java
@@ -1,0 +1,53 @@
+/*
+ * This document is a part of the source code and related artifacts
+ * for CollectionSpace, an open source collections management system
+ * for museums and related institutions:
+ *
+ * http://www.collectionspace.org
+ * http://wiki.collectionspace.org
+ *
+ * Licensed under the Educational Community License (ECL), Version 2.0.
+ * You may not use this file except in compliance with this License.
+ *
+ * You may obtain a copy of the ECL 2.0 License at
+ * https://source.collectionspace.org/collection-space/LICENSE.txt
+ */
+package org.collectionspace.services.client;
+
+import org.collectionspace.services.summarydocumentation.SummaryDocumentationsCommon;
+
+/**
+ * SummarydocumentationClient.java
+ */
+public class SummaryDocumentationClient
+        extends AbstractCommonListPoxServiceClientImpl<SummaryDocumentationProxy, SummaryDocumentationsCommon> {
+
+    public static final String SERVICE_NAME = "summarydocumentations";
+    public static final String SERVICE_PATH_COMPONENT = SERVICE_NAME;
+    public static final String SERVICE_PATH = "/" + SERVICE_PATH_COMPONENT;
+    public static final String SERVICE_PATH_PROXY = SERVICE_PATH + "/";
+    public static final String SERVICE_PAYLOAD_NAME = SERVICE_NAME;
+
+    public SummaryDocumentationClient() throws Exception {
+        super();
+    }
+
+    public SummaryDocumentationClient(String clientPropertiesFilename) throws Exception {
+        super(clientPropertiesFilename);
+    }
+
+    @Override
+    public String getServicePathComponent() {
+        return SERVICE_PATH_COMPONENT;
+    }
+
+    @Override
+    public String getServiceName() {
+        return SERVICE_NAME;
+    }
+
+    @Override
+    public Class<SummaryDocumentationProxy> getProxyClass() {
+        return SummaryDocumentationProxy.class;
+    }
+}

--- a/services/summarydocumentation/client/src/main/java/org/collectionspace/services/client/SummaryDocumentationProxy.java
+++ b/services/summarydocumentation/client/src/main/java/org/collectionspace/services/client/SummaryDocumentationProxy.java
@@ -1,0 +1,27 @@
+/*
+ * This document is a part of the source code and related artifacts
+ * for CollectionSpace, an open source collections management system
+ * for museums and related institutions:
+ *
+ * http://www.collectionspace.org
+ * http://wiki.collectionspace.org
+ *
+ * Licensed under the Educational Community License (ECL), Version 2.0.
+ * You may not use this file except in compliance with this License.
+ *
+ * You may obtain a copy of the ECL 2.0 License at
+ * https://source.collectionspace.org/collection-space/LICENSE.txt
+ */
+package org.collectionspace.services.client;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+/**
+ * SummarydocumentationProxy.java
+ */
+@Path(SummaryDocumentationClient.SERVICE_PATH_PROXY)
+@Produces({"application/xml"})
+@Consumes({"application/xml"})
+public interface SummaryDocumentationProxy extends CollectionSpaceCommonListPoxProxy {}

--- a/services/summarydocumentation/client/src/test/java/org/collectionspace/services/client/test/SummaryDocumentationServiceTest.java
+++ b/services/summarydocumentation/client/src/test/java/org/collectionspace/services/client/test/SummaryDocumentationServiceTest.java
@@ -1,0 +1,500 @@
+/*
+ * This document is a part of the source code and related artifacts
+ * for CollectionSpace, an open source collections management system
+ * for museums and related institutions:
+ *
+ * http://www.collectionspace.org
+ * http://wiki.collectionspace.org
+ *
+ * Copyright © 2009 Regents of the University of California
+ *
+ * Licensed under the Educational Community License (ECL), Version 2.0.
+ * You may not use this file except in compliance with this License.
+ *
+ * You may obtain a copy of the ECL 2.0 License at
+ * https://source.collectionspace.org/collection-space/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.collectionspace.services.client.test;
+
+import javax.ws.rs.core.Response;
+import org.collectionspace.services.client.AbstractCommonListUtils;
+import org.collectionspace.services.client.CollectionSpaceClient;
+import org.collectionspace.services.client.PayloadInputPart;
+import org.collectionspace.services.client.PayloadOutputPart;
+import org.collectionspace.services.client.PoxPayloadIn;
+import org.collectionspace.services.client.PoxPayloadOut;
+import org.collectionspace.services.client.SummaryDocumentationClient;
+import org.collectionspace.services.jaxb.AbstractCommonList;
+import org.collectionspace.services.summarydocumentation.SummaryDocumentationsCommon;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+
+public class SummaryDocumentationServiceTest
+        extends AbstractPoxServiceTestImpl<AbstractCommonList, SummaryDocumentationsCommon> {
+
+    private final Logger logger = LoggerFactory.getLogger(SummaryDocumentationServiceTest.class);
+
+    final String SERVICE_NAME = "summarydocumentations";
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.BaseServiceTest#getClientInstance()
+     */
+    @Override
+    protected CollectionSpaceClient getClientInstance() throws Exception {
+        return new SummaryDocumentationClient();
+    }
+
+    @Override
+    protected CollectionSpaceClient getClientInstance(String clientPropertiesFilename) throws Exception {
+        return new SummaryDocumentationClient(clientPropertiesFilename);
+    }
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.BaseServiceTest#getAbstractCommonList(org.jboss.resteasy.client.ClientResponse)
+     */
+    @Override
+    protected AbstractCommonList getCommonList(Response response) {
+        return response.readEntity(AbstractCommonList.class);
+    }
+
+    // ---------------------------------------------------------------
+    // CRUD tests : CREATE tests
+    // ---------------------------------------------------------------
+
+    // Success outcomes
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.ServiceTest#create(java.lang.String)
+     */
+    @Override
+    public void create(String testName) throws Exception {
+        // Perform setup, such as initializing the type of service request
+        // (e.g. CREATE, DELETE), its valid and expected status codes, and
+        // its associated HTTP method name (e.g. POST, DELETE).
+        setupCreate();
+
+        // Submit the request to the service and store the response.
+        SummaryDocumentationClient client = new SummaryDocumentationClient();
+        String identifier = createIdentifier();
+        PoxPayloadOut multipart = createSummaryDocumentationInstance(identifier);
+        String newID = null;
+        Response res = client.create(multipart);
+        try {
+            int statusCode = res.getStatus();
+
+            // Check the status code of the response: does it match
+            // the expected response(s)?
+            //
+            // Specifically:
+            // Does it fall within the set of valid status codes?
+            // Does it exactly match the expected status code?
+            logger.debug(testName + ": status = " + statusCode);
+            Assert.assertTrue(
+                    testRequestType.isValidStatusCode(statusCode),
+                    invalidStatusCodeMessage(testRequestType, statusCode));
+            Assert.assertEquals(statusCode, testExpectedStatusCode);
+
+            newID = extractId(res);
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+
+        // Store the ID returned from the first resource created
+        // for additional tests below.
+        if (knownResourceId == null) {
+            knownResourceId = newID;
+            logger.debug(testName + ": knownResourceId=" + knownResourceId);
+        }
+
+        // Store the IDs from every resource created by tests,
+        // so they can be deleted after tests have been run.
+        allResourceIdsCreated.add(newID);
+    }
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.AbstractServiceTestImpl#createList(java.lang.String)
+     */
+    @Override
+    public void createList(String testName) throws Exception {
+        for (int i = 0; i < 3; i++) {
+            create(testName);
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // CRUD tests : READ tests
+    // ---------------------------------------------------------------
+
+    // Success outcomes
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.AbstractServiceTestImpl#read(java.lang.String)
+     */
+    @Override
+    public void read(String testName) throws Exception {
+        // Perform setup.
+        setupRead();
+
+        // Submit the request to the service and store the response.
+        SummaryDocumentationClient client = new SummaryDocumentationClient();
+        Response res = client.read(knownResourceId);
+        PoxPayloadIn input;
+        try {
+            assertStatusCode(res, testName);
+            input = new PoxPayloadIn(res.readEntity(String.class));
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+
+        // Get the common part of the response and verify that it is not null.
+        PayloadInputPart payloadInputPart = input.getPart(client.getCommonPartName());
+        SummaryDocumentationsCommon summaryDocumentation = null;
+        if (payloadInputPart != null) {
+            summaryDocumentation = (SummaryDocumentationsCommon) payloadInputPart.getBody();
+        }
+        Assert.assertNotNull(summaryDocumentation);
+    }
+
+    // Failure outcomes
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.AbstractServiceTestImpl#readNonExistent(java.lang.String)
+     */
+    @Override
+    public void readNonExistent(String testName) throws Exception {
+        // Perform setup.
+        setupReadNonExistent();
+
+        // Submit the request to the service and store the response.
+        SummaryDocumentationClient client = new SummaryDocumentationClient();
+        Response res = client.read(NON_EXISTENT_ID);
+        try {
+            int statusCode = res.getStatus();
+
+            // Check the status code of the response: does it match
+            // the expected response(s)?
+            logger.debug(testName + ": status = " + statusCode);
+            Assert.assertTrue(
+                    testRequestType.isValidStatusCode(statusCode),
+                    invalidStatusCodeMessage(testRequestType, statusCode));
+            Assert.assertEquals(statusCode, testExpectedStatusCode);
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // CRUD tests : READ_LIST tests
+    // ---------------------------------------------------------------
+
+    // Success outcomes
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.AbstractServiceTestImpl#readList(java.lang.String)
+     */
+    @Override
+    public void readList(String testName) throws Exception {
+        // Perform setup.
+        setupReadList();
+
+        // Submit the request to the service and store the response.
+        AbstractCommonList list;
+        SummaryDocumentationClient client = new SummaryDocumentationClient();
+        Response res = client.readList();
+        assertStatusCode(res, testName);
+        try {
+            int statusCode = res.getStatus();
+
+            // Check the status code of the response: does it match
+            // the expected response(s)?
+            logger.debug(testName + ": status = " + statusCode);
+            Assert.assertTrue(
+                    testRequestType.isValidStatusCode(statusCode),
+                    invalidStatusCodeMessage(testRequestType, statusCode));
+            Assert.assertEquals(statusCode, testExpectedStatusCode);
+
+            list = res.readEntity(getCommonListType());
+        } finally {
+            res.close();
+        }
+
+        // Optionally output additional data about list members for debugging.
+        AbstractCommonListUtils.ListItemsInAbstractCommonList(list, logger, testName);
+    }
+
+    // Failure outcomes
+    // None at present.
+
+    // ---------------------------------------------------------------
+    // CRUD tests : UPDATE tests
+    // ---------------------------------------------------------------
+
+    // Success outcomes
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.AbstractServiceTestImpl#update(java.lang.String)
+     */
+    @Override
+    public void update(String testName) throws Exception {
+        // Perform setup.
+        setupRead();
+
+        // Retrieve the contents of a resource to update.
+        SummaryDocumentationClient client = new SummaryDocumentationClient();
+        Response res = client.read(knownResourceId);
+        PoxPayloadIn input;
+        try {
+            assertStatusCode(res, testName);
+            input = new PoxPayloadIn(res.readEntity(String.class));
+            logger.debug("got object to update with ID: " + knownResourceId);
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+
+        // Extract the common part from the response.
+        PayloadInputPart payloadInputPart = input.getPart(client.getCommonPartName());
+        SummaryDocumentationsCommon summaryDocumentation = null;
+        if (payloadInputPart != null) {
+            summaryDocumentation = (SummaryDocumentationsCommon) payloadInputPart.getBody();
+        }
+        Assert.assertNotNull(summaryDocumentation);
+
+        // Update the content of this resource.
+        summaryDocumentation.setDocumentationNumber("updated-" + summaryDocumentation.getDocumentationNumber());
+
+        logger.debug("to be updated object");
+        logger.debug(objectAsXmlString(summaryDocumentation, SummaryDocumentationsCommon.class));
+
+        setupUpdate();
+
+        // Submit the updated common part in an update request to the service
+        // and store the response.
+        PoxPayloadOut output = new PoxPayloadOut(this.getServicePathComponent());
+        PayloadOutputPart commonPart = output.addPart(client.getCommonPartName(), summaryDocumentation);
+        res = client.update(knownResourceId, output);
+        try {
+            assertStatusCode(res, testName);
+            int statusCode = res.getStatus();
+            // Check the status code of the response: does it match the expected response(s)?
+            logger.debug(testName + ": status = " + statusCode);
+            Assert.assertTrue(
+                    testRequestType.isValidStatusCode(statusCode),
+                    invalidStatusCodeMessage(testRequestType, statusCode));
+            Assert.assertEquals(statusCode, testExpectedStatusCode);
+            input = new PoxPayloadIn(res.readEntity(String.class));
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+
+        // Extract the updated common part from the response.
+        payloadInputPart = input.getPart(client.getCommonPartName());
+        SummaryDocumentationsCommon updatedSummaryDocumentationCommon = null;
+        if (payloadInputPart != null) {
+            updatedSummaryDocumentationCommon = (SummaryDocumentationsCommon) payloadInputPart.getBody();
+        }
+        Assert.assertNotNull(updatedSummaryDocumentationCommon);
+
+        // Check selected fields in the updated common part.
+        Assert.assertEquals(
+                updatedSummaryDocumentationCommon.getDocumentationNumber(),
+                summaryDocumentation.getDocumentationNumber(),
+                "Data in updated object did not match submitted data.");
+    }
+
+    @Override
+    public void updateNonExistent(String testName) throws Exception {
+        // Perform setup.
+        setupUpdateNonExistent();
+
+        // Submit the request to the service and store the response.
+        // Note: The ID used in this 'create' call may be arbitrary.
+        // The only relevant ID may be the one used in update(), below.
+        SummaryDocumentationClient client = new SummaryDocumentationClient();
+        PoxPayloadOut multipart = createSummaryDocumentationInstance(NON_EXISTENT_ID);
+        Response res = client.update(NON_EXISTENT_ID, multipart);
+        try {
+            int statusCode = res.getStatus();
+
+            // Check the status code of the response: does it match
+            // the expected response(s)?
+            logger.debug(testName + ": status = " + statusCode);
+            Assert.assertTrue(
+                    testRequestType.isValidStatusCode(statusCode),
+                    invalidStatusCodeMessage(testRequestType, statusCode));
+            Assert.assertEquals(statusCode, testExpectedStatusCode);
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // CRUD tests : DELETE tests
+    // ---------------------------------------------------------------
+
+    // Success outcomes
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.AbstractServiceTestImpl#delete(java.lang.String)
+     */
+    @Override
+    public void delete(String testName) throws Exception {
+        // Perform setup.
+        setupDelete();
+
+        // Submit the request to the service and store the response.
+        SummaryDocumentationClient client = new SummaryDocumentationClient();
+        Response res = client.delete(knownResourceId);
+        try {
+            int statusCode = res.getStatus();
+
+            // Check the status code of the response: does it match
+            // the expected response(s)?
+            logger.debug(testName + ": status = " + statusCode);
+            Assert.assertTrue(
+                    testRequestType.isValidStatusCode(statusCode),
+                    invalidStatusCodeMessage(testRequestType, statusCode));
+            Assert.assertEquals(statusCode, testExpectedStatusCode);
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+    }
+
+    // Failure outcomes
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.AbstractServiceTestImpl#deleteNonExistent(java.lang.String)
+     */
+    @Override
+    public void deleteNonExistent(String testName) throws Exception {
+        // Perform setup.
+        setupDeleteNonExistent();
+
+        // Submit the request to the service and store the response.
+        SummaryDocumentationClient client = new SummaryDocumentationClient();
+        Response res = client.delete(NON_EXISTENT_ID);
+        try {
+            int statusCode = res.getStatus();
+
+            // Check the status code of the response: does it match
+            // the expected response(s)?
+            logger.debug(testName + ": status = " + statusCode);
+            Assert.assertTrue(
+                    testRequestType.isValidStatusCode(statusCode),
+                    invalidStatusCodeMessage(testRequestType, statusCode));
+            Assert.assertEquals(statusCode, testExpectedStatusCode);
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Utility tests : tests of code used in tests above
+    // ---------------------------------------------------------------
+
+    /**
+     * Tests the code for manually submitting data that is used by several
+     * of the methods above.
+     */
+    public void testSubmitRequest() {
+
+        // Expected status code: 200 OK
+        final int EXPECTED_STATUS = Response.Status.OK.getStatusCode();
+
+        // Submit the request to the service and store the response.
+        String method = ServiceRequestType.READ.httpMethodName();
+        String url = getResourceURL(knownResourceId);
+        int statusCode = submitRequest(method, url);
+
+        // Check the status code of the response: does it match
+        // the expected response(s)?
+        logger.debug("testSubmitRequest: url=" + url + " status=" + statusCode);
+        Assert.assertEquals(statusCode, EXPECTED_STATUS);
+    }
+
+    // ---------------------------------------------------------------
+    // Utility methods used by tests above
+    // ---------------------------------------------------------------
+
+    @Override
+    public String getServiceName() {
+        return SERVICE_NAME;
+    }
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.BaseServiceTest#getServicePathComponent()
+     */
+    @Override
+    public String getServicePathComponent() {
+        return SERVICE_NAME;
+    }
+
+    @Override
+    protected PoxPayloadOut createInstance(String identifier) throws Exception {
+        return createSummaryDocumentationInstance(identifier);
+    }
+
+    /**
+     * Creates the summarydocumentation instance.
+     *
+     * @param summaryDocumentationNumber the documentation number
+     * @return the multipart output
+     * @throws Exception
+     */
+    private PoxPayloadOut createSummaryDocumentationInstance(String summaryDocumentationNumber) throws Exception {
+        SummaryDocumentationsCommon summaryDocumentation = new SummaryDocumentationsCommon();
+        summaryDocumentation.setDocumentationNumber(summaryDocumentationNumber);
+
+        PoxPayloadOut multipart = new PoxPayloadOut(this.getServicePathComponent());
+        PayloadOutputPart commonPart =
+                multipart.addPart(new SummaryDocumentationClient().getCommonPartName(), summaryDocumentation);
+
+        logger.debug("to be created, summarydocumentations_common");
+        logger.debug(objectAsXmlString(summaryDocumentation, SummaryDocumentationsCommon.class));
+
+        return multipart;
+    }
+
+    @Override
+    public void CRUDTests(String testName) {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    protected PoxPayloadOut createInstance(String commonPartName, String identifier) throws Exception {
+        return createSummaryDocumentationInstance(identifier);
+    }
+
+    @Override
+    protected SummaryDocumentationsCommon updateInstance(SummaryDocumentationsCommon commonPartObject) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    protected void compareUpdatedInstances(SummaryDocumentationsCommon original, SummaryDocumentationsCommon updated) {
+        // TODO Auto-generated method stub
+    }
+}

--- a/services/summarydocumentation/jaxb/pom.xml
+++ b/services/summarydocumentation/jaxb/pom.xml
@@ -18,6 +18,11 @@
       <artifactId>org.collectionspace.services.jaxb</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.nagpra-jaxb</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/services/summarydocumentation/jaxb/pom.xml
+++ b/services/summarydocumentation/jaxb/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <artifactId>org.collectionspace.services.summarydocumentation</artifactId>
+    <groupId>org.collectionspace.services</groupId>
+    <version>${revision}</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>org.collectionspace.services.summarydocumentation.jaxb</artifactId>
+  <name>services.summarydocumentation.jaxb</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.jaxb</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>collectionspace-services-summarydocumentation-jaxb</finalName>
+    <defaultGoal>install</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>org.jvnet.jaxb2.maven2</groupId>
+        <artifactId>maven-jaxb2-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/services/summarydocumentation/jaxb/src/main/java/org/collectionspace/services/SummaryDocumentationJAXBSchema.java
+++ b/services/summarydocumentation/jaxb/src/main/java/org/collectionspace/services/SummaryDocumentationJAXBSchema.java
@@ -1,0 +1,17 @@
+/*
+ * This document is a part of the source code and related artifacts
+ * for CollectionSpace, an open source collections management system
+ * for museums and related institutions:
+ *
+ * http://www.collectionspace.org
+ * http://wiki.collectionspace.org
+ *
+ * Licensed under the Educational Community License (ECL), Version 2.0.
+ * You may not use this file except in compliance with this License.
+ *
+ * You may obtain a copy of the ECL 2.0 License at
+ * https://source.collectionspace.org/collection-space/LICENSE.txt
+ */
+package org.collectionspace.services;
+
+public interface SummaryDocumentationJAXBSchema {}

--- a/services/summarydocumentation/jaxb/src/main/java/org/collectionspace/services/SummaryDocumentationListItemJAXBSchema.java
+++ b/services/summarydocumentation/jaxb/src/main/java/org/collectionspace/services/SummaryDocumentationListItemJAXBSchema.java
@@ -1,0 +1,20 @@
+/*
+ * This document is a part of the source code and related artifacts
+ * for CollectionSpace, an open source collections management system
+ * for museums and related institutions:
+ *
+ * http://www.collectionspace.org
+ * http://wiki.collectionspace.org
+ *
+ * Licensed under the Educational Community License (ECL), Version 2.0.
+ * You may not use this file except in compliance with this License.
+ *
+ * You may obtain a copy of the ECL 2.0 License at
+ * https://source.collectionspace.org/collection-space/LICENSE.txt
+ */
+package org.collectionspace.services;
+
+public interface SummaryDocumentationListItemJAXBSchema {
+    String CSID = "csid";
+    String URI = "url";
+}

--- a/services/summarydocumentation/jaxb/src/main/resources/summarydocumentations_common.xsd
+++ b/services/summarydocumentation/jaxb/src/main/resources/summarydocumentations_common.xsd
@@ -19,7 +19,13 @@
 >
 
   <!--  SummaryDocumentation Information Group -->
-  <xs:element name="summary_documentations_common">
+  <xs:element name="summarydocumentations_common">
+    <xs:annotation>
+      <xs:appinfo>
+        <jaxb:class name="SummaryDocumentationsCommon" />
+      </xs:appinfo>
+    </xs:annotation>
+
     <xs:complexType>
       <xs:sequence>
         <xs:element name="documentationNumber" type="xs:string" />

--- a/services/summarydocumentation/jaxb/src/main/resources/summarydocumentations_common.xsd
+++ b/services/summarydocumentation/jaxb/src/main/resources/summarydocumentations_common.xsd
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+<!--
+    Summarydocumentation schema (XSD)
+
+    Entity  : SummaryDocumentation
+    Part    : Common
+    Used for: JAXB binding between XML and Java objects
+-->
+
+<xs:schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+  jaxb:version="2.0" elementFormDefault="unqualified"
+  xmlns:ns="http://collectionspace.org/services/summarydocumentation"
+  xmlns="http://collectionspace.org/services/summarydocumentation"
+  targetNamespace="http://collectionspace.org/services/summarydocumentation"
+  version="0.1"
+>
+
+  <!--  SummaryDocumentation Information Group -->
+  <xs:element name="summary_documentations_common">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="documentationNumber" type="xs:string" />
+        <xs:element name="originationDate" type="xs:date" />
+        <xs:element name="titles" type="titles" />
+        <xs:element name="types" type="types" />
+        <xs:element name="consultationNotes" type="consultationNotes" />
+        <xs:element name="treatmentNotes" type="treatmentNotes" />
+
+        <xs:element name="partiesInvolvedGroupList" type="partiesInvolvedGroupList" />
+        <xs:element name="culturalAffiliationGroupList" type="culturalAffiliationGroupList" />
+        <xs:element name="nagpraStatusGroupList" type="nagpraStatusGroupList" />
+        <xs:element name="geographicPlaceGroupList" type="geographicPlaceGroupList" />
+        <xs:element name="timePeriodGroupList" type="timePeriodGroupList" />
+        <xs:element name="culturalGroupList" type="culturalGroupList" />
+        <xs:element name="archaeologicalSiteGroupList" type="archaeologicalSiteGroupList" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:complexType name="titles">
+    <xs:sequence>
+      <xs:element name="title" type="xs:string" minOccurs="0" maxOccurs="unbounded"  />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="types">
+    <xs:sequence>
+      <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="consultationNotes">
+    <xs:sequence>
+      <xs:element name="consultationNote" type="xs:string" minOccurs="0" maxOccurs="unbounded"  />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="treatmentNotes">
+    <xs:sequence>
+      <xs:element name="treatmentNote" type="xs:string" minOccurs="0" maxOccurs="unbounded"  />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="partiesInvolvedGroupList">
+    <xs:sequence>
+      <xs:element name="partiesInvolvedGroup" type="partiesInvolvedGroup" minOccurs="0" maxOccurs="unbounded"  />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="partiesInvolvedGroup">
+    <xs:sequence>
+      <xs:element name="involvedParty" type="xs:string" />
+      <xs:element name="involvedOnBehalfOf" type="xs:string" />
+      <xs:element name="involvedRole" type="xs:string" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="culturalAffiliationGroupList">
+    <xs:sequence>
+      <xs:element name="culturalAffiliationGroup" type="culturalAffiliationGroup" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="culturalAffiliationGroup">
+    <xs:sequence>
+      <xs:element name="tribeOrNation" type="xs:string"/>
+      <xs:element name="includeInNotice" type="xs:string"/>
+      <xs:element name="determinedByList" type="determinedByList"/>
+      <xs:element name="determinationDate" type="xs:date"/>
+      <xs:element name="basisOfDetermination" type="xs:string"/>
+      <xs:element name="determinationNote" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="determinedByList">
+    <xs:sequence>
+      <xs:element name="determinedBy" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="nagpraStatusGroupList">
+    <xs:sequence>
+      <xs:element name="nagpraStatusGroup" type="nagpraStatusGroup" minOccurs="0" maxOccurs="unbounded"  />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="nagpraStatusGroup">
+    <xs:sequence>
+      <xs:element name="statusGroup" type="xs:string" />
+      <xs:element name="statusIndividual" type="xs:string" />
+      <xs:element name="status" type="xs:string" />
+      <xs:element name="statusDate" type="xs:date" />
+      <xs:element name="statusNote" type="xs:string" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="geographicPlaceGroupList">
+    <xs:sequence>
+      <xs:element name="geographicPlaceGroup" type="geographicPlaceGroup" minOccurs="0" maxOccurs="unbounded"  />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="geographicPlaceGroup">
+    <xs:sequence>
+      <xs:element name="geographicPlace" type="xs:string" />
+      <xs:element name="geographicPlaceNote" type="xs:string" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="timePeriodGroupList">
+    <xs:sequence>
+      <xs:element name="timePeriodGroup" type="timePeriodGroup" minOccurs="0" maxOccurs="unbounded"  />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="timePeriodGroup">
+    <xs:sequence>
+      <xs:element name="timePeriod" type="xs:string" />
+      <xs:element name="timePeriodNote" type="xs:string" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="culturalGroupList">
+    <xs:sequence>
+      <xs:element name="culturalGroup" type="culturalGroup" minOccurs="0" maxOccurs="unbounded"  />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="culturalGroup">
+    <xs:sequence>
+      <xs:element name="culture" type="xs:string" />
+      <xs:element name="cultureNote" type="xs:string" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="archaeologicalSiteGroupList">
+    <xs:sequence>
+      <xs:element name="archaeologicalSiteGroup" type="archaeologicalSiteGroup" minOccurs="0" maxOccurs="unbounded"  />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="archaeologicalSiteGroup">
+    <xs:sequence>
+      <xs:element name="archaeologicalSite" type="xs:string" />
+      <xs:element name="archaeologicalSiteNote" type="xs:string" />
+    </xs:sequence>
+  </xs:complexType>
+
+</xs:schema>

--- a/services/summarydocumentation/jaxb/src/main/resources/summarydocumentations_common.xsd
+++ b/services/summarydocumentation/jaxb/src/main/resources/summarydocumentations_common.xsd
@@ -11,12 +11,15 @@
 <xs:schema
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-  jaxb:version="2.0" elementFormDefault="unqualified"
-  xmlns:ns="http://collectionspace.org/services/summarydocumentation"
+  jaxb:version="2.0"
+  xmlns:nagpra="http://collectionspace.org/services/nagpra"
   xmlns="http://collectionspace.org/services/summarydocumentation"
   targetNamespace="http://collectionspace.org/services/summarydocumentation"
   version="0.1"
 >
+
+  <xs:import namespace="http://collectionspace.org/services/nagpra"
+             schemaLocation="maven:org.collectionspace.services:org.collectionspace.services.nagpra-jaxb:jar::!/nagpra_common.xsd"/>
 
   <!--  SummaryDocumentation Information Group -->
   <xs:element name="summarydocumentations_common">
@@ -32,16 +35,16 @@
         <xs:element name="originationDate" type="xs:date" />
         <xs:element name="titles" type="titles" />
         <xs:element name="types" type="types" />
-        <xs:element name="consultationNotes" type="consultationNotes" />
-        <xs:element name="treatmentNotes" type="treatmentNotes" />
+        <xs:element name="consultationNotes" type="nagpra:consultationNotes" />
+        <xs:element name="treatmentNotes" type="nagpra:treatmentNotes" />
 
-        <xs:element name="partiesInvolvedGroupList" type="partiesInvolvedGroupList" />
-        <xs:element name="culturalAffiliationGroupList" type="culturalAffiliationGroupList" />
-        <xs:element name="nagpraStatusGroupList" type="nagpraStatusGroupList" />
-        <xs:element name="geographicPlaceGroupList" type="geographicPlaceGroupList" />
-        <xs:element name="timePeriodGroupList" type="timePeriodGroupList" />
-        <xs:element name="culturalGroupList" type="culturalGroupList" />
-        <xs:element name="archaeologicalSiteGroupList" type="archaeologicalSiteGroupList" />
+        <xs:element name="partiesInvolvedGroupList" type="nagpra:partiesInvolvedGroupList" />
+        <xs:element name="culturalAffiliationGroupList" type="nagpra:culturalAffiliationGroupList" />
+        <xs:element name="statusGroupList" type="nagpra:statusGroupList" />
+        <xs:element name="geographicPlaceGroupList" type="nagpra:geographicPlaceGroupList" />
+        <xs:element name="timePeriodGroupList" type="nagpra:timePeriodGroupList" />
+        <xs:element name="culturalGroupList" type="nagpra:culturalGroupList" />
+        <xs:element name="archaeologicalSiteGroupList" type="nagpra:archaeologicalSiteGroupList" />
       </xs:sequence>
     </xs:complexType>
   </xs:element>
@@ -54,121 +57,6 @@
   <xs:complexType name="types">
     <xs:sequence>
       <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="consultationNotes">
-    <xs:sequence>
-      <xs:element name="consultationNote" type="xs:string" minOccurs="0" maxOccurs="unbounded"  />
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="treatmentNotes">
-    <xs:sequence>
-      <xs:element name="treatmentNote" type="xs:string" minOccurs="0" maxOccurs="unbounded"  />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="partiesInvolvedGroupList">
-    <xs:sequence>
-      <xs:element name="partiesInvolvedGroup" type="partiesInvolvedGroup" minOccurs="0" maxOccurs="unbounded"  />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="partiesInvolvedGroup">
-    <xs:sequence>
-      <xs:element name="involvedParty" type="xs:string" />
-      <xs:element name="involvedOnBehalfOf" type="xs:string" />
-      <xs:element name="involvedRole" type="xs:string" />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="culturalAffiliationGroupList">
-    <xs:sequence>
-      <xs:element name="culturalAffiliationGroup" type="culturalAffiliationGroup" minOccurs="0" maxOccurs="unbounded"/>
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="culturalAffiliationGroup">
-    <xs:sequence>
-      <xs:element name="tribeOrNation" type="xs:string"/>
-      <xs:element name="includeInNotice" type="xs:string"/>
-      <xs:element name="determinedByList" type="determinedByList"/>
-      <xs:element name="determinationDate" type="xs:date"/>
-      <xs:element name="basisOfDetermination" type="xs:string"/>
-      <xs:element name="determinationNote" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="determinedByList">
-    <xs:sequence>
-      <xs:element name="determinedBy" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="nagpraStatusGroupList">
-    <xs:sequence>
-      <xs:element name="nagpraStatusGroup" type="nagpraStatusGroup" minOccurs="0" maxOccurs="unbounded"  />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="nagpraStatusGroup">
-    <xs:sequence>
-      <xs:element name="statusGroup" type="xs:string" />
-      <xs:element name="statusIndividual" type="xs:string" />
-      <xs:element name="status" type="xs:string" />
-      <xs:element name="statusDate" type="xs:date" />
-      <xs:element name="statusNote" type="xs:string" />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="geographicPlaceGroupList">
-    <xs:sequence>
-      <xs:element name="geographicPlaceGroup" type="geographicPlaceGroup" minOccurs="0" maxOccurs="unbounded"  />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="geographicPlaceGroup">
-    <xs:sequence>
-      <xs:element name="geographicPlace" type="xs:string" />
-      <xs:element name="geographicPlaceNote" type="xs:string" />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="timePeriodGroupList">
-    <xs:sequence>
-      <xs:element name="timePeriodGroup" type="timePeriodGroup" minOccurs="0" maxOccurs="unbounded"  />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="timePeriodGroup">
-    <xs:sequence>
-      <xs:element name="timePeriod" type="xs:string" />
-      <xs:element name="timePeriodNote" type="xs:string" />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="culturalGroupList">
-    <xs:sequence>
-      <xs:element name="culturalGroup" type="culturalGroup" minOccurs="0" maxOccurs="unbounded"  />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="culturalGroup">
-    <xs:sequence>
-      <xs:element name="culture" type="xs:string" />
-      <xs:element name="cultureNote" type="xs:string" />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="archaeologicalSiteGroupList">
-    <xs:sequence>
-      <xs:element name="archaeologicalSiteGroup" type="archaeologicalSiteGroup" minOccurs="0" maxOccurs="unbounded"  />
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="archaeologicalSiteGroup">
-    <xs:sequence>
-      <xs:element name="archaeologicalSite" type="xs:string" />
-      <xs:element name="archaeologicalSiteNote" type="xs:string" />
     </xs:sequence>
   </xs:complexType>
 

--- a/services/summarydocumentation/pom.xml
+++ b/services/summarydocumentation/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <groupId>org.collectionspace.services</groupId>
+    <artifactId>org.collectionspace.services.main</artifactId>
+    <version>${revision}</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>org.collectionspace.services.summarydocumentation</artifactId>
+  <name>services.summarydocumentation</name>
+  <packaging>pom</packaging>
+
+  <properties>
+    <!-- spotless 2.30.0 is the last version that supports java 8 -->
+    <spotless.version>2.30.0</spotless.version>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>${spotless.version}</version>
+        <configuration>
+          <formats>
+            <!-- you can define as many formats as you want, each is independent -->
+            <format>
+              <includes>
+                <include>src/main/java/**/*.java</include>
+                <include>src/test/java/**/*.java</include>
+              </includes>
+              <trimTrailingWhitespace />
+              <endWithNewline />
+              <indent>
+                <spaces>true</spaces>
+                <spacesPerTab>4</spacesPerTab>
+              </indent>
+            </format>
+          </formats>
+          <!-- define a language-specific format -->
+          <java>
+            <palantirJavaFormat />
+          </java>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <modules>
+    <module>jaxb</module>
+    <module>service</module>
+    <module>client</module>
+  </modules>
+
+</project>

--- a/services/summarydocumentation/service/pom.xml
+++ b/services/summarydocumentation/service/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <parent>
+    <groupId>org.collectionspace.services</groupId>
+    <artifactId>org.collectionspace.services.summarydocumentation</artifactId>
+    <version>${revision}</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>org.collectionspace.services.summarydocumentation.service</artifactId>
+  <name>services.summarydocumentation.service</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.summarydocumentation.jaxb</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.summarydocumentation.client</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- External dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+    </dependency>
+
+    <!-- javax -->
+    <dependency>
+      <groupId>javax.security</groupId>
+      <artifactId>jaas</artifactId>
+      <version>1.0.01</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- jboss -->
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxrs</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>tjws</groupId>
+          <artifactId>webserver</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxb-provider</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-multipart-provider</artifactId>
+    </dependency>
+
+    <!-- nuxeo -->
+    <dependency>
+      <groupId>org.nuxeo.ecm.core</groupId>
+      <artifactId>nuxeo-core-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <artifactId>jboss-remoting</artifactId>
+          <groupId>jboss</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>collectionspace-services-summarydocumentation</finalName>
+  </build>
+</project>

--- a/services/summarydocumentation/service/src/main/java/org/collectionspace/services/summarydocumentation/SummaryDocumentationResource.java
+++ b/services/summarydocumentation/service/src/main/java/org/collectionspace/services/summarydocumentation/SummaryDocumentationResource.java
@@ -1,0 +1,49 @@
+/*
+ *  This document is a part of the source code and related artifacts
+ *  for CollectionSpace, an open source collections management system
+ *  for museums and related institutions:
+ *
+ *  http://www.collectionspace.org
+ *  http://wiki.collectionspace.org
+ *
+ *  Licensed under the Educational Community License (ECL), Version 2.0.
+ *  You may not use this file except in compliance with this License.
+ *
+ *  You may obtain a copy of the ECL 2.0 License at
+ *
+ *  https://source.collectionspace.org/collection-space/LICENSE.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.collectionspace.services.summarydocumentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import org.collectionspace.services.client.SummaryDocumentationClient;
+import org.collectionspace.services.common.NuxeoBasedResource;
+
+@Path(SummaryDocumentationClient.SERVICE_PATH)
+@Consumes("application/xml")
+@Produces("application/xml")
+public class SummaryDocumentationResource extends NuxeoBasedResource {
+
+    @Override
+    protected String getVersionString() {
+        return "$LastChangedRevision$";
+    }
+
+    @Override
+    public String getServiceName() {
+        return SummaryDocumentationClient.SERVICE_NAME;
+    }
+
+    @Override
+    public Class<SummaryDocumentationsCommon> getCommonPartClass() {
+        return SummaryDocumentationsCommon.class;
+    }
+}

--- a/services/summarydocumentation/service/src/main/java/org/collectionspace/services/summarydocumentation/nuxeo/SummaryDocumentationConstants.java
+++ b/services/summarydocumentation/service/src/main/java/org/collectionspace/services/summarydocumentation/nuxeo/SummaryDocumentationConstants.java
@@ -1,0 +1,33 @@
+/*
+ *  This document is a part of the source code and related artifacts
+ *  for CollectionSpace, an open source collections management system
+ *  for museums and related institutions:
+ *
+ *  http://www.collectionspace.org
+ *  http://wiki.collectionspace.org
+ *
+ *  Licensed under the Educational Community License (ECL), Version 2.0.
+ *  You may not use this file except in compliance with this License.
+ *
+ *  You may obtain a copy of the ECL 2.0 License at
+ *
+ *  https://source.collectionspace.org/collection-space/LICENSE.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.collectionspace.services.summarydocumentation.nuxeo;
+
+/**
+ * SummarydocumentationConstants specifies constants for the Summarydocumentation service
+ *
+ */
+public class SummaryDocumentationConstants {
+
+    public static final String NUXEO_DOCTYPE = "Summarydocumentation";
+    public static final String NUXEO_SCHEMA_NAME = "summarydocumentation";
+    public static final String NUXEO_DC_TITLE = "CollectionSpace-Summarydocumentation";
+}

--- a/services/summarydocumentation/service/src/main/java/org/collectionspace/services/summarydocumentation/nuxeo/SummaryDocumentationDocumentModelHandler.java
+++ b/services/summarydocumentation/service/src/main/java/org/collectionspace/services/summarydocumentation/nuxeo/SummaryDocumentationDocumentModelHandler.java
@@ -1,0 +1,29 @@
+/*
+ *  This document is a part of the source code and related artifacts
+ *  for CollectionSpace, an open source collections management system
+ *  for museums and related institutions:
+ *
+ *  http://www.collectionspace.org
+ *  http://wiki.collectionspace.org
+ *
+ *  Licensed under the Educational Community License (ECL), Version 2.0.
+ *  You may not use this file except in compliance with this License.
+ *
+ *  You may obtain a copy of the ECL 2.0 License at
+ *
+ *  https://source.collectionspace.org/collection-space/LICENSE.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.collectionspace.services.summarydocumentation.nuxeo;
+
+import org.collectionspace.services.nuxeo.client.java.NuxeoDocumentModelHandler;
+import org.collectionspace.services.summarydocumentation.SummaryDocumentationsCommon;
+
+/** SummarydocumentationDocumentModelHandler
+ */
+public class SummaryDocumentationDocumentModelHandler extends NuxeoDocumentModelHandler<SummaryDocumentationsCommon> {}

--- a/services/summarydocumentation/service/src/main/java/org/collectionspace/services/summarydocumentation/nuxeo/SummaryDocumentationValidatorHandler.java
+++ b/services/summarydocumentation/service/src/main/java/org/collectionspace/services/summarydocumentation/nuxeo/SummaryDocumentationValidatorHandler.java
@@ -1,0 +1,29 @@
+/*
+ * This document is a part of the source code and related artifacts
+ * for CollectionSpace, an open source collections management system
+ * for museums and related institutions:
+ *
+ * http://www.collectionspace.org
+ * http://wiki.collectionspace.org
+ *
+ * Licensed under the Educational Community License (ECL), Version 2.0.
+ * You may not use this file except in compliance with this License.
+ *
+ * You may obtain a copy of the ECL 2.0 License at
+ * https://source.collectionspace.org/collection-space/LICENSE.txt
+ */
+package org.collectionspace.services.summarydocumentation.nuxeo;
+
+import org.collectionspace.services.common.context.ServiceContext;
+import org.collectionspace.services.common.document.DocumentHandler.Action;
+import org.collectionspace.services.common.document.InvalidDocumentException;
+import org.collectionspace.services.common.document.ValidatorHandler;
+
+public class SummaryDocumentationValidatorHandler implements ValidatorHandler {
+
+    @Override
+    public void validate(Action action, ServiceContext ctx) throws InvalidDocumentException {
+        // TODO Auto-generated method stub
+        System.out.println("SummarydocumentationValidatorHandler executed.");
+    }
+}

--- a/services/summarydocumentation/service/src/main/java/org/collectionspace/services/summarydocumentation/nuxeo/SummaryDocumentationValidatorHandler.java
+++ b/services/summarydocumentation/service/src/main/java/org/collectionspace/services/summarydocumentation/nuxeo/SummaryDocumentationValidatorHandler.java
@@ -14,16 +14,52 @@
  */
 package org.collectionspace.services.summarydocumentation.nuxeo;
 
-import org.collectionspace.services.common.context.ServiceContext;
-import org.collectionspace.services.common.document.DocumentHandler.Action;
+import org.collectionspace.services.client.PoxPayloadIn;
+import org.collectionspace.services.client.PoxPayloadOut;
 import org.collectionspace.services.common.document.InvalidDocumentException;
-import org.collectionspace.services.common.document.ValidatorHandler;
+import org.collectionspace.services.common.document.ValidatorHandlerImpl;
+import org.collectionspace.services.summarydocumentation.SummaryDocumentationsCommon;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public class SummaryDocumentationValidatorHandler implements ValidatorHandler {
+public class SummaryDocumentationValidatorHandler extends ValidatorHandlerImpl<PoxPayloadIn, PoxPayloadOut> {
+
+    private static final String COMMON_PART_MISSING =
+            "Validation exception: summarydocumentations_common part is missing";
+    private static final String DOCUMENTATION_NUMBER_MISSING =
+            "Validation exception: The summary documentation field \"documentationNumber\" cannot be empty or missing";
+
+    private final Logger logger = LoggerFactory.getLogger(SummaryDocumentationValidatorHandler.class);
 
     @Override
-    public void validate(Action action, ServiceContext ctx) throws InvalidDocumentException {
-        // TODO Auto-generated method stub
-        System.out.println("SummarydocumentationValidatorHandler executed.");
+    protected Class<?> getCommonPartClass() {
+        return SummaryDocumentationsCommon.class;
     }
+
+    @Override
+    protected void handleCreate() throws InvalidDocumentException {
+        final SummaryDocumentationsCommon summary = (SummaryDocumentationsCommon) getCommonPart();
+        if (summary == null) {
+            logger.error(COMMON_PART_MISSING);
+            throw new InvalidDocumentException(COMMON_PART_MISSING);
+        }
+
+        final String documentationNumber = summary.getDocumentationNumber();
+        if (documentationNumber == null || documentationNumber.isEmpty()) {
+            logger.error(DOCUMENTATION_NUMBER_MISSING);
+            throw new InvalidDocumentException(DOCUMENTATION_NUMBER_MISSING);
+        }
+    }
+
+    @Override
+    protected void handleGet() {}
+
+    @Override
+    protected void handleGetAll() {}
+
+    @Override
+    protected void handleUpdate() {}
+
+    @Override
+    protected void handleDelete() {}
 }


### PR DESCRIPTION
**What does this do?**
* Create summary documentation service
* Add id generator for summary documentation
* Create nagpra-jaxb module to hold common xsd elements

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1333

This adds the summary documentation procedure which is a necessary part of nagpra workflows.

**How should this be tested? Do these changes have associated tests?**
* Rebuild collectionspace and run the integration tests
* Ideally we should also be checking that once deployed the summary documentation api responds correctly, e.g.
  * `curl http://localhost:8180/cspace-services/summarydocumentations`
  * also PUT with a payload to test the api, though the ui will take care of that as well

**Dependencies for merging? Releasing to production?**
Some additional changes to the xsd portion of things which I did in kind of a hacky manner (normally it seems like you would use a catalog file to overwrite the schema location for the import but I did it directly). I moved the common data structures into `nagpra_common.xsd`, which is then imported in the jaxb module for the schemas to use. Not entirely necessary but something I had done to see what we can do with the schemas.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested the api through the cspace-ui changes