### PR TITLE
DRYD-1438: Workflow Report Updates

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/deed_of_gift.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/deed_of_gift.jrxml
@@ -4,6 +4,19 @@
 	xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd"
 	name="deedofgift" pageWidth="1500" pageHeight="800" orientation="Landscape" columnWidth="1460" leftMargin="20" rightMargin="20"
 	topMargin="20" bottomMargin="20" isIgnorePagination="true" uuid="202f91ff-d0dd-4eda-90de-a15938303d79">
+	<property name="net.sf.jasperreports.jrparameter.is.ignore.pagination" value="true" />
+	<property name="net.sf.jasperreports.export.xls.one.page.per.sheet" value="false" />
+	<property name="net.sf.jasperreports.export.xls.sheet.names.all" value="DeedOfGift-Report/Footnotes" />
+	<property name="net.sf.jasperreports.export.xls.remove.empty.space.between.rows" value="true" />
+	<property name="net.sf.jasperreports.export.xls.remove.empty.space.between.columns" value="true" />
+	<property name="net.sf.jasperreports.export.xls.white.page.background" value="false" />
+	<property name="net.sf.jasperreports.export.xls.detect.cell.type" value="true" />
+	<property name="net.sf.jasperreports.page.break.no.pagination" value="apply" />
+	<property name="net.sf.jasperreports.export.xls.freeze.row" value="2" />
+	<property name="net.sf.jasperreports.print.keep.full.text" value="true" />
+	<property name="net.sf.jasperreports.export.xls.exclude.origin.keep.first.band.1" value="pageHeader" />
+	<property name="net.sf.jasperreports.export.xls.exclude.origin.band.2" value="pageFooter" />
+	<property name="net.sf.jasperreports.exports.xls.font.size.fix.enabled" value="false" />
 	<property name="com.jaspersoft.studio.data.sql.tables" value=""/>
 	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="nuxeo"/>
 	<property name="com.jaspersoft.studio.data.sql.SQLQueryDesigner.sash.w1" value="193"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/deed_of_gift.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/deed_of_gift.jrxml
@@ -42,6 +42,7 @@
 ), person_owners AS (
   SELECT ag.*,
     string_agg(primaryterm.termdisplayname, '|' ORDER BY term_hier.pos) as primarydisplayname,
+    string_agg(regexp_replace(primaryterm.termflag, '^.*\)''(.*)''$', '\1'), '|' ORDER BY term_hier.pos) as primarytermflag,
     intake.csid as intakecsid
   FROM intakes intake
   INNER JOIN intakes_common_currentowners co ON co.id = intake.id AND co.pos = 0
@@ -79,6 +80,7 @@
   INNER JOIN misc on misc.id = media.id AND misc.lifecyclestate != 'deleted'
 )
 select owner.primarydisplayname as primarydisplayname,
+  owner.primarytermflag as primarytermflag,
   owner.addressplace1 as addressplace1,
   owner.addressplace2 as addressplace2,
   owner.addresstype as addresstype,
@@ -99,6 +101,11 @@ left join related_object_media media on media.objcsid = obj.csid]]>
 	<field name="primarydisplayname" class="java.lang.String">
 		<property name="com.jaspersoft.studio.field.name" value="primarydisplayname"/>
 		<property name="com.jaspersoft.studio.field.label" value="primarydisplayname"/>
+		<property name="com.jaspersoft.studio.field.tree.path" value="persontermgroup"/>
+	</field>
+	<field name="primarytermflag" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="primarytermflag"/>
+		<property name="com.jaspersoft.studio.field.label" value="primarytermflag"/>
 		<property name="com.jaspersoft.studio.field.tree.path" value="persontermgroup"/>
 	</field>
 	<field name="addressplace1" class="java.lang.String">
@@ -185,6 +192,14 @@ left join related_object_media media on media.objcsid = obj.csid]]>
 				</reportElement>
 				<textElement markup="styled"/>
 				<text><![CDATA[Current Owner]]></text>
+			</staticText>
+			<staticText>
+				<reportElement style="Column header" x="100" y="0" width="100" height="44"
+					uuid="74dd1df6-9339-458e-bf3f-1dc3153ed738">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textElement markup="styled"/>
+				<text><![CDATA[Term Flag]]></text>
 			</staticText>
 			<staticText>
 				<reportElement style="Column header" x="200" y="0" width="100" height="44"
@@ -293,6 +308,13 @@ left join related_object_media media on media.objcsid = obj.csid]]>
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{primarydisplayname}]]></textFieldExpression>
+			</textField>
+			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
+				<reportElement style="Detail" x="100" y="0" width="100" height="30"
+					uuid="d3843a94-a23e-4fed-abf5-4a2f605996d0">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[$F{primarytermflag}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="200" y="0" width="100" height="30"

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/incoming_loan.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/incoming_loan.jrxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 6.20.1.final using JasperReports Library version 6.20.1-7584acb244139816654f64e2fd57a00d3e31921e  -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="incomingloan" pageWidth="2050" pageHeight="595" orientation="Landscape" columnWidth="802" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isIgnorePagination="true" uuid="1445cbb0-a0d2-462a-9e21-e9d0696bcd9a">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="incomingloan" pageWidth="2450" pageHeight="595" orientation="Landscape" columnWidth="802" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isIgnorePagination="true" uuid="1445cbb0-a0d2-462a-9e21-e9d0696bcd9a">
     <property name="com.jaspersoft.studio.data.sql.tables" value=""/>
     <property name="com.jaspersoft.studio.data.defaultdataadapter" value="nuxeo"/>
     <property name="com.jaspersoft.studio.data.sql.SQLQueryDesigner.sash.w1" value="193"/>
@@ -46,8 +46,11 @@ SELECT
   address.addressstateorprovince,
   loanin.loanindate,
   loanin.loanrenewalapplicationdate,
+  loanin.loanpurpose,
+  loanin.loaninconditions,
   objects.objectnumber,
   objects.objectname,
+  objects.briefdescription,
   loanvaluation.valueamount AS loanvalueamount,
   loanvaluation.valuecurrency AS loanvaluecurrency,
   objvaluation.valueamount AS objvalueamount,
@@ -73,15 +76,18 @@ LEFT JOIN (
     hier.name AS csid,
     relation.subjectcsid,
     obj.objectnumber,
-    ong.objectname
+    ong.objectname,
+    string_agg(bd.item, '; ') AS briefdescription
   FROM collectionobjects_common obj
   INNER JOIN hierarchy hier ON hier.id = obj.id
   INNER JOIN misc on misc.id = obj.id AND misc.lifecyclestate != 'deleted'
   INNER JOIN relations_common relation ON relation.objectcsid = hier.name
     AND relation.subjectdocumenttype = 'Loanin'
     AND relation.objectdocumenttype = 'CollectionObject'
+  LEFT JOIN collectionobjects_common_briefdescriptions bd ON bd.id = obj.id
   LEFT JOIN hierarchy ong_hier ON ong_hier.parentid = obj.id AND ong_hier.primarytype = 'objectNameGroup' AND ong_hier.pos = 0
   LEFT JOIN objectnamegroup ong ON ong.id = ong_hier.id
+  GROUP BY relation.subjectcsid, obj.objectnumber, ong.objectname, hier.name
 ) objects ON objects.subjectcsid = hier.name
 LEFT JOIN valuations loanvaluation ON loanvaluation.subjectcsid = hier.name
 LEFT JOIN valuations objvaluation ON objvaluation.subjectcsid = objects.csid
@@ -186,6 +192,21 @@ $P!{whereclause}]]>
         <property name="com.jaspersoft.studio.field.name" value="loanstatusdate"/>
         <property name="com.jaspersoft.studio.field.label" value="loanstatusdate"/>
         <property name="com.jaspersoft.studio.field.tree.path" value="loanstatusgroup"/>
+    </field>
+    <field name="briefdescription" class="java.lang.String">
+        <property name="com.jaspersoft.studio.field.name" value="briefdescription"/>
+        <property name="com.jaspersoft.studio.field.label" value="briefdescription"/>
+        <property name="com.jaspersoft.studio.field.tree.path" value="collectionobjects_common"/>
+    </field>
+    <field name="loanpurpose" class="java.lang.String">
+        <property name="com.jaspersoft.studio.field.name" value="loanpurpose"/>
+        <property name="com.jaspersoft.studio.field.label" value="loanpurpose"/>
+        <property name="com.jaspersoft.studio.field.tree.path" value="loansin_common"/>
+    </field>
+    <field name="loaninconditions" class="java.lang.String">
+        <property name="com.jaspersoft.studio.field.name" value="loaninconditions"/>
+        <property name="com.jaspersoft.studio.field.label" value="loaninconditions"/>
+        <property name="com.jaspersoft.studio.field.tree.path" value="loansin_common"/>
     </field>
     <background>
         <band splitType="Stretch"/>
@@ -344,6 +365,27 @@ $P!{whereclause}]]>
                 <textElement markup="styled"/>
                 <text><![CDATA[Loan status date]]></text>
             </staticText>
+            <staticText>
+                <reportElement style="Column header" x="2000" y="0" width="100" height="44" uuid="16bb764d-d439-4260-9693-7e8d2b1cf987">
+                <property name="com.jaspersoft.studio.unit.width" value="px"/>
+                </reportElement>
+                <textElement markup="styled"/>
+                <text><![CDATA[Related object description]]></text>
+            </staticText>
+            <staticText>
+                <reportElement style="Column header" x="2100" y="0" width="100" height="44" uuid="47e84d71-02e6-478d-9a4f-b17fe6b06ff2">
+                <property name="com.jaspersoft.studio.unit.width" value="px"/>
+                </reportElement>
+                <textElement markup="styled"/>
+                <text><![CDATA[Loan condition]]></text>
+            </staticText>
+            <staticText>
+                <reportElement style="Column header" x="2200" y="0" width="100" height="44" uuid="0b79ca91-bc7e-44b9-be35-c742145a81ce">
+                <property name="com.jaspersoft.studio.unit.width" value="px"/>
+                </reportElement>
+                <textElement markup="styled"/>
+                <text><![CDATA[Loan purpose]]></text>
+            </staticText>
         </band>
     </columnHeader>
     <detail>
@@ -468,6 +510,24 @@ $P!{whereclause}]]>
                     <property name="com.jaspersoft.studio.unit.y" value="px"/>
                 </reportElement>
                 <textFieldExpression><![CDATA[$F{loanstatusdate}]]></textFieldExpression>
+            </textField>
+            <textField textAdjust="StretchHeight" isBlankWhenNull="true">
+                <reportElement style="Detail" x="2000" y="0" width="100" height="30" uuid="1a55ae01-a09d-4932-92f1-e9ab02418a7b">
+                <property name="com.jaspersoft.studio.unit.y" value="px"/>
+                </reportElement>
+                <textFieldExpression><![CDATA[$F{briefdescription}]]></textFieldExpression>
+            </textField>
+            <textField textAdjust="StretchHeight" isBlankWhenNull="true">
+                <reportElement style="Detail" x="2100" y="0" width="100" height="30" uuid="85052a12-c720-4f29-a904-6e255c4cd0f3">
+                <property name="com.jaspersoft.studio.unit.y" value="px"/>
+                </reportElement>
+                <textFieldExpression><![CDATA[$F{loaninconditions}]]></textFieldExpression>
+            </textField>
+            <textField textAdjust="StretchHeight" isBlankWhenNull="true">
+                <reportElement style="Detail" x="2200" y="0" width="100" height="30" uuid="1cc83667-f7d1-4d52-a38b-b0a6f18e9713">
+                <property name="com.jaspersoft.studio.unit.y" value="px"/>
+                </reportElement>
+                <textFieldExpression><![CDATA[$F{loanpurpose}]]></textFieldExpression>
             </textField>
         </band>
     </detail>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/obj_computed_location.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/obj_computed_location.jrxml
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 6.20.1.final using JasperReports Library version 6.20.1-7584acb244139816654f64e2fd57a00d3e31921e  -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="objcomputedlocation" pageWidth="1000" pageHeight="595" orientation="Landscape" columnWidth="802" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isIgnorePagination="true" uuid="0b89017b-1c64-4285-9d1a-33596b3f5bb3">
+	<property name="net.sf.jasperreports.jrparameter.is.ignore.pagination" value="true" />
+	<property name="net.sf.jasperreports.export.xls.one.page.per.sheet" value="false" />
+	<property name="net.sf.jasperreports.export.xls.sheet.names.all" value="BasicObjWithLocation-Report/Footnotes" />
+	<property name="net.sf.jasperreports.export.xls.remove.empty.space.between.rows" value="true" />
+	<property name="net.sf.jasperreports.export.xls.remove.empty.space.between.columns" value="true" />
+	<property name="net.sf.jasperreports.export.xls.white.page.background" value="false" />
+	<property name="net.sf.jasperreports.export.xls.detect.cell.type" value="true" />
+	<property name="net.sf.jasperreports.page.break.no.pagination" value="apply" />
+	<property name="net.sf.jasperreports.export.xls.freeze.row" value="2" />
+	<property name="net.sf.jasperreports.print.keep.full.text" value="true" />
+	<property name="net.sf.jasperreports.export.xls.exclude.origin.keep.first.band.1" value="pageHeader" />
+	<property name="net.sf.jasperreports.export.xls.exclude.origin.band.2" value="pageFooter" />
+	<property name="net.sf.jasperreports.exports.xls.font.size.fix.enabled" value="false" />
 	<property name="com.jaspersoft.studio.data.sql.tables" value=""/>
 	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="nuxeo"/>
 	<property name="com.jaspersoft.studio.data.sql.SQLQueryDesigner.sash.w1" value="193"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/outgoing_loan.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/outgoing_loan.jrxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 6.20.1.final using JasperReports Library version 6.20.1-7584acb244139816654f64e2fd57a00d3e31921e  -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="outgoingloan" pageWidth="2150" pageHeight="595" orientation="Landscape" columnWidth="802" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isIgnorePagination="true" uuid="3cca5535-6d07-44da-9337-8b874cbc9f70">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="outgoingloan" pageWidth="2550" pageHeight="595" orientation="Landscape" columnWidth="802" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isIgnorePagination="true" uuid="3cca5535-6d07-44da-9337-8b874cbc9f70">
   <property name="com.jaspersoft.studio.data.sql.tables" value=""/>
   <property name="com.jaspersoft.studio.data.defaultdataadapter" value="nuxeo"/>
   <property name="com.jaspersoft.studio.data.sql.SQLQueryDesigner.sash.w1" value="193"/>
@@ -37,6 +37,8 @@ SELECT
   loan.loanoutnumber,
   loan.borrower,
   loan.borrowerscontact,
+  loan.loanpurpose,
+  loan.specialconditionsofloan,
   COALESCE(person_addr.addressplace1, org_addr.addressplace1, '') AS addressplace1,
   COALESCE(person_addr.addressplace2, org_addr.addressplace2, '') AS addressplace2,
   COALESCE(person_addr.addresstype, org_addr.addresstype, '') AS addresstype,
@@ -48,6 +50,7 @@ SELECT
   loan.loanrenewalapplicationdate,
   object.objectnumber,
   object.objectname,
+  object.briefdescription,
   loan_valuation.valueamount AS loanvalueamount,
   loan_valuation.valuecurrency AS loanvaluecurrency,
   obj_valuation.valueamount AS objvalueamount,
@@ -79,15 +82,18 @@ LEFT JOIN (
     hier.name AS csid,
     relation.subjectcsid,
     obj.objectnumber,
-    ong.objectname
+    ong.objectname,
+    string_agg(bd.item, '; ') AS briefdescription
   FROM collectionobjects_common obj
   INNER JOIN hierarchy hier ON hier.id = obj.id
   INNER JOIN misc on misc.id = obj.id AND misc.lifecyclestate != 'deleted'
   INNER JOIN relations_common relation ON relation.objectcsid = hier.name
     AND relation.subjectdocumenttype = 'Loanout'
     AND relation.objectdocumenttype = 'CollectionObject'
+  LEFT JOIN collectionobjects_common_briefdescriptions bd ON bd.id = obj.id
   LEFT JOIN hierarchy ong_hier ON ong_hier.parentid = obj.id AND ong_hier.primarytype = 'objectNameGroup' AND ong_hier.pos = 0
   LEFT JOIN objectnamegroup ong ON ong.id = ong_hier.id
+  GROUP BY relation.subjectcsid, obj.objectnumber, ong.objectname, hier.name
 ) object ON object.subjectcsid = hier.name
 -- valuations
 LEFT JOIN valuations loan_valuation ON loan_valuation.subjectcsid = hier.name
@@ -199,6 +205,21 @@ $P!{whereclause}
     <property name="com.jaspersoft.studio.field.name" value="loanstatus"/>
     <property name="com.jaspersoft.studio.field.label" value="loanstatus"/>
     <property name="com.jaspersoft.studio.field.tree.path" value="loanstatusgroup"/>
+  </field>
+  <field name="briefdescription" class="java.lang.String">
+    <property name="com.jaspersoft.studio.field.name" value="briefdescription"/>
+    <property name="com.jaspersoft.studio.field.label" value="briefdescription"/>
+    <property name="com.jaspersoft.studio.field.tree.path" value="collectionobjects_common"/>
+  </field>
+  <field name="loanpurpose" class="java.lang.String">
+    <property name="com.jaspersoft.studio.field.name" value="loanpurpose"/>
+    <property name="com.jaspersoft.studio.field.label" value="loanpurpose"/>
+    <property name="com.jaspersoft.studio.field.tree.path" value="loansout_common"/>
+  </field>
+  <field name="specialconditionsofloan" class="java.lang.String">
+    <property name="com.jaspersoft.studio.field.name" value="specialconditionsofloan"/>
+    <property name="com.jaspersoft.studio.field.label" value="specialconditionsofloan"/>
+    <property name="com.jaspersoft.studio.field.tree.path" value="loansout_common"/>
   </field>
   <background>
     <band splitType="Stretch"/>
@@ -364,6 +385,27 @@ $P!{whereclause}
         <textElement markup="styled"/>
         <text><![CDATA[Loan status]]></text>
       </staticText>
+      <staticText>
+        <reportElement style="Column header" x="2100" y="0" width="100" height="44" uuid="16bb764d-d439-4260-9693-7e8d2b1cf987">
+          <property name="com.jaspersoft.studio.unit.width" value="px"/>
+        </reportElement>
+        <textElement markup="styled"/>
+        <text><![CDATA[Related object description]]></text>
+      </staticText>
+      <staticText>
+        <reportElement style="Column header" x="2200" y="0" width="100" height="44" uuid="47e84d71-02e6-478d-9a4f-b17fe6b06ff2">
+          <property name="com.jaspersoft.studio.unit.width" value="px"/>
+        </reportElement>
+        <textElement markup="styled"/>
+        <text><![CDATA[Loan condition]]></text>
+      </staticText>
+      <staticText>
+        <reportElement style="Column header" x="2300" y="0" width="100" height="44" uuid="0b79ca91-bc7e-44b9-be35-c742145a81ce">
+          <property name="com.jaspersoft.studio.unit.width" value="px"/>
+        </reportElement>
+        <textElement markup="styled"/>
+        <text><![CDATA[Loan purpose]]></text>
+      </staticText>
     </band>
   </columnHeader>
   <detail>
@@ -494,6 +536,24 @@ $P!{whereclause}
           <property name="com.jaspersoft.studio.unit.y" value="px"/>
         </reportElement>
         <textFieldExpression><![CDATA[$F{loanstatus}]]></textFieldExpression>
+      </textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
+        <reportElement style="Detail" x="2100" y="0" width="100" height="30" uuid="1a55ae01-a09d-4932-92f1-e9ab02418a7b">
+          <property name="com.jaspersoft.studio.unit.y" value="px" />
+        </reportElement>
+        <textFieldExpression><![CDATA[$F{briefdescription}]]></textFieldExpression>
+      </textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
+        <reportElement style="Detail" x="2200" y="0" width="100" height="30" uuid="85052a12-c720-4f29-a904-6e255c4cd0f3">
+          <property name="com.jaspersoft.studio.unit.y" value="px" />
+        </reportElement>
+        <textFieldExpression><![CDATA[$F{specialconditionsofloan}]]></textFieldExpression>
+      </textField>
+      <textField textAdjust="StretchHeight" isBlankWhenNull="true">
+        <reportElement style="Detail" x="2300" y="0" width="100" height="30" uuid="1cc83667-f7d1-4d52-a38b-b0a6f18e9713">
+          <property name="com.jaspersoft.studio.unit.y" value="px" />
+        </reportElement>
+        <textFieldExpression><![CDATA[$F{loanpurpose}]]></textFieldExpression>
       </textField>
     </band>
   </detail>


### PR DESCRIPTION
**What does this do?**
* Add loan purpose, loan condition, and brief description to outgoing loan report
* Add loan purpose, loan condition, and brief description to incoming loan report
* Add person primary term flag to deed of gift
* Add headers for better formatting for xlsx output

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1438

For outgoing loan, incoming loan, and deed of gift, additional fields were requested to be added from users. We're starting to add headers for better formatting of xlsx output as well as we've found out people are using the spreadsheets in order to capture the thumbnails from generated reports. Currently the headers are only in the deed of gift (initial testing) and basic object with current location reports.

**How should this be tested? Do these changes have associated tests?**
* Deploy the reports to a collectionspace server, e.g.
```
[services (dryd-1438)] $ cd services/report/3rdparty
[3rdparty (dryd-1438)] $ ant undeploy_report_files > /dev/null
[3rdparty (dryd-1438)] $ ant deploy_report_files > /dev/null
```
* Run each of the updated reports:
  * LoansOut - Outgoing Loan
  * LoansIn - Incoming Loan
  * Intake - Deed of Gift
  * CollectionObject (from search) - Basic Object with Current Location
    * With xlsx output

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter ran outgoing loan as a csv and deed of gift as a xlsx file