### PR TITLE
DRYD-1487: Fix text search configuration does not exist error

### DIFF
--- a/3rdparty/nuxeo/nuxeo-server/9.10-HF30/config/proto-repo-config.xml
+++ b/3rdparty/nuxeo/nuxeo-server/9.10-HF30/config/proto-repo-config.xml
@@ -37,7 +37,7 @@
 			<pathOptimizations enabled="true"/>
 			<idType>varchar</idType>
 			<indexing>
-			<fulltext disabled="false" analyzer="cspace_english">
+			<fulltext disabled="false" analyzer="public.cspace_english">
 			  <index name="default">
 				<!-- all props implied -->
 			  </index>

--- a/3rdparty/nuxeo/nuxeo-server/9.10-HF30/config/vcsconfig.sql.txt
+++ b/3rdparty/nuxeo/nuxeo-server/9.10-HF30/config/vcsconfig.sql.txt
@@ -18,10 +18,10 @@
 #
 
 #TEST:
-SELECT 1 FROM pg_ts_config WHERE cfgname = '${fulltextAnalyzer}';
+SELECT 1 FROM pg_ts_config WHERE cfgname = 'cspace_english';
 
 #IF: emptyResult
-CREATE TEXT SEARCH CONFIGURATION ${fulltextAnalyzer} ( COPY = english );
+CREATE TEXT SEARCH CONFIGURATION public.cspace_english ( COPY = english );
 
 
 


### PR DESCRIPTION
**What does this do?**

This updates the nuxeo full text search configuration to schema-qualify the analyzer (`public.cspace_english` instead of `cspace_english`).

**Why are we doing this? (with JIRA link)**

This fixes an error where the `cspace_english` text search configuration could not be found during a postgres auto analyze activity. When autovacuuming, recent versions of postgres use a schema search path containing only `pg_catalog`, so anything in the `public` schema needs to be explicitly schema-qualified.

JIRA: https://collectionspace.atlassian.net/browse/DRYD-1487

**How should this be tested? Do these changes have associated tests?**

Run cspace. Keep an eye on the postgres log. Entries that look like the following should not appear:

```
2024-07-24 17:33:46 UTC::@:[15731]:CONTEXT: SQL function "nx_to_tsvector" during inlining
automatic analyze of table "momm_momm.public.fulltext"
2024-07-24 17:33:46 UTC::@:[15732]:ERROR: text search configuration "cspace_english" does not exist at character 23
2024-07-24 17:33:46 UTC::@:[15732]:QUERY:
SELECT TO_TSVECTOR('cspace_english', SUBSTR($1, 1, 250000))
```

**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee tested locally.