### PR TITLE
Duty of Care Updates

### DIFF
--- a/services/dutyofcare/client/src/main/java/org/collectionspace/services/client/DutyofcareClient.java
+++ b/services/dutyofcare/client/src/main/java/org/collectionspace/services/client/DutyofcareClient.java
@@ -14,14 +14,14 @@
  */
 package org.collectionspace.services.client;
 
-import org.collectionspace.services.dutyofcare.DutyofcaresCommon;
+import org.collectionspace.services.dutyofcare.DutiesOfCareCommon;
 
 /**
  * DutyofcareClient.java
  */
-public class DutyofcareClient extends AbstractCommonListPoxServiceClientImpl<DutyofcareProxy, DutyofcaresCommon> {
+public class DutyofcareClient extends AbstractCommonListPoxServiceClientImpl<DutyofcareProxy, DutiesOfCareCommon> {
 
-    public static final String SERVICE_NAME = "dutyofcares";
+    public static final String SERVICE_NAME = "dutiesofcare";
     public static final String SERVICE_PATH_COMPONENT = SERVICE_NAME;
     public static final String SERVICE_PATH = "/" + SERVICE_PATH_COMPONENT;
     public static final String SERVICE_PATH_PROXY = SERVICE_PATH + "/";

--- a/services/dutyofcare/client/src/test/java/org/collectionspace/services/client/DutyofcareServiceTest.java
+++ b/services/dutyofcare/client/src/test/java/org/collectionspace/services/client/DutyofcareServiceTest.java
@@ -25,20 +25,20 @@ package org.collectionspace.services.client;
 import javax.ws.rs.core.Response;
 import org.collectionspace.services.client.test.AbstractPoxServiceTestImpl;
 import org.collectionspace.services.client.test.ServiceRequestType;
-import org.collectionspace.services.dutyofcare.DutyofcaresCommon;
+import org.collectionspace.services.dutyofcare.DutiesOfCareCommon;
 import org.collectionspace.services.jaxb.AbstractCommonList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 
-public class DutyofcareServiceTest extends AbstractPoxServiceTestImpl<AbstractCommonList, DutyofcaresCommon> {
+public class DutyofcareServiceTest extends AbstractPoxServiceTestImpl<AbstractCommonList, DutiesOfCareCommon> {
 
     private final Logger logger = LoggerFactory.getLogger(DutyofcareServiceTest.class);
 
     /** The service path component. */
-    final String SERVICE_NAME = "dutyofcares";
+    final String SERVICE_NAME = "dutiesofcare";
 
-    final String SERVICE_PATH_COMPONENT = "dutyofcares";
+    final String SERVICE_PATH_COMPONENT = "dutiesofcare";
 
     /* (non-Javadoc)
      * @see org.collectionspace.services.client.test.BaseServiceTest#getClientInstance()
@@ -156,9 +156,9 @@ public class DutyofcareServiceTest extends AbstractPoxServiceTestImpl<AbstractCo
 
         // Get the common part of the response and verify that it is not null.
         PayloadInputPart payloadInputPart = input.getPart(client.getCommonPartName());
-        DutyofcaresCommon dutyofcareCommon = null;
+        DutiesOfCareCommon dutyofcareCommon = null;
         if (payloadInputPart != null) {
-            dutyofcareCommon = (DutyofcaresCommon) payloadInputPart.getBody();
+            dutyofcareCommon = (DutiesOfCareCommon) payloadInputPart.getBody();
         }
         Assert.assertNotNull(dutyofcareCommon);
     }
@@ -265,9 +265,9 @@ public class DutyofcareServiceTest extends AbstractPoxServiceTestImpl<AbstractCo
 
         // Extract the common part from the response.
         PayloadInputPart payloadInputPart = input.getPart(client.getCommonPartName());
-        DutyofcaresCommon dutyofcareCommon = null;
+        DutiesOfCareCommon dutyofcareCommon = null;
         if (payloadInputPart != null) {
-            dutyofcareCommon = (DutyofcaresCommon) payloadInputPart.getBody();
+            dutyofcareCommon = (DutiesOfCareCommon) payloadInputPart.getBody();
         }
         Assert.assertNotNull(dutyofcareCommon);
 
@@ -275,7 +275,7 @@ public class DutyofcareServiceTest extends AbstractPoxServiceTestImpl<AbstractCo
         dutyofcareCommon.setDutyOfCareNumber("updated-" + dutyofcareCommon.getDutyOfCareNumber());
 
         logger.debug("to be updated object");
-        logger.debug(objectAsXmlString(dutyofcareCommon, DutyofcaresCommon.class));
+        logger.debug(objectAsXmlString(dutyofcareCommon, DutiesOfCareCommon.class));
 
         setupUpdate();
 
@@ -302,9 +302,9 @@ public class DutyofcareServiceTest extends AbstractPoxServiceTestImpl<AbstractCo
 
         // Extract the updated common part from the response.
         payloadInputPart = input.getPart(client.getCommonPartName());
-        DutyofcaresCommon updatedDutyofcareCommon = null;
+        DutiesOfCareCommon updatedDutyofcareCommon = null;
         if (payloadInputPart != null) {
-            updatedDutyofcareCommon = (DutyofcaresCommon) payloadInputPart.getBody();
+            updatedDutyofcareCommon = (DutiesOfCareCommon) payloadInputPart.getBody();
         }
         Assert.assertNotNull(updatedDutyofcareCommon);
 
@@ -461,14 +461,14 @@ public class DutyofcareServiceTest extends AbstractPoxServiceTestImpl<AbstractCo
      * @throws Exception
      */
     private PoxPayloadOut createDutyofcareInstance(String dutyofcareNumber) throws Exception {
-        DutyofcaresCommon dutyofcareCommon = new DutyofcaresCommon();
+        DutiesOfCareCommon dutyofcareCommon = new DutiesOfCareCommon();
         dutyofcareCommon.setDutyOfCareNumber(dutyofcareNumber);
 
         PoxPayloadOut multipart = new PoxPayloadOut(this.getServicePathComponent());
         PayloadOutputPart commonPart = multipart.addPart(new DutyofcareClient().getCommonPartName(), dutyofcareCommon);
 
         logger.debug("to be created, dutyofcare common");
-        logger.debug(objectAsXmlString(dutyofcareCommon, DutyofcaresCommon.class));
+        logger.debug(objectAsXmlString(dutyofcareCommon, DutiesOfCareCommon.class));
 
         return multipart;
     }
@@ -485,13 +485,13 @@ public class DutyofcareServiceTest extends AbstractPoxServiceTestImpl<AbstractCo
     }
 
     @Override
-    protected DutyofcaresCommon updateInstance(DutyofcaresCommon commonPartObject) {
+    protected DutiesOfCareCommon updateInstance(DutiesOfCareCommon commonPartObject) {
         // TODO Auto-generated method stub
         return null;
     }
 
     @Override
-    protected void compareUpdatedInstances(DutyofcaresCommon original, DutyofcaresCommon updated) {
+    protected void compareUpdatedInstances(DutiesOfCareCommon original, DutiesOfCareCommon updated) {
         // TODO Auto-generated method stub
     }
 }

--- a/services/dutyofcare/jaxb/src/main/resources/dutiesofcare_common.xsd
+++ b/services/dutyofcare/jaxb/src/main/resources/dutiesofcare_common.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-    Dutyofcare schema (XSD)
+    Duty-of-Care schema (XSD)
     Entity  : Dutyofcare
     Part    : Common
     Used for: JAXB binding between XML and Java objects
@@ -16,13 +16,14 @@
   version="0.1"
 >
 
-  <!--
-      Avoid XmlRootElement nightmare:
-      See http://weblogs.java.net/blog/kohsuke/archive/2006/03/why_does_jaxb_p.html
-  -->
-
   <!--  Dutyofcare Information Group -->
-  <xs:element name="dutyofcares_common">
+  <xs:element name="dutiesofcare_common">
+    <xs:annotation>
+      <xs:appinfo>
+        <jaxb:class name="DutiesOfCareCommon" />
+      </xs:appinfo>
+    </xs:annotation>
+
     <xs:complexType>
       <xs:sequence>
         <xs:element name="dutyOfCareNumber" type="xs:string"/>

--- a/services/dutyofcare/jaxb/src/main/resources/dutiesofcare_common.xsd
+++ b/services/dutyofcare/jaxb/src/main/resources/dutiesofcare_common.xsd
@@ -28,7 +28,7 @@
       <xs:sequence>
         <xs:element name="dutyOfCareNumber" type="xs:string"/>
         <xs:element name="dutyOfCareDate" type="xs:date"/>
-        <xs:element name="title" type="xs:string"/>
+        <xs:element name="dutyOfCareTitle" type="xs:string"/>
 
         <xs:element name="notes" type="notes"/>
         <xs:element name="partiesInvolvedGroupList" type="partiesInvolvedGroupList"/>

--- a/services/dutyofcare/service/src/main/java/org/collectionspace/services/dutyofcare/DutyofcareResource.java
+++ b/services/dutyofcare/service/src/main/java/org/collectionspace/services/dutyofcare/DutyofcareResource.java
@@ -48,7 +48,7 @@ public class DutyofcareResource extends NuxeoBasedResource {
     }
 
     @Override
-    public Class<DutyofcaresCommon> getCommonPartClass() {
-        return DutyofcaresCommon.class;
+    public Class<DutiesOfCareCommon> getCommonPartClass() {
+        return DutiesOfCareCommon.class;
     }
 }

--- a/services/dutyofcare/service/src/main/java/org/collectionspace/services/dutyofcare/nuxeo/DutyofcareDocumentModelHandler.java
+++ b/services/dutyofcare/service/src/main/java/org/collectionspace/services/dutyofcare/nuxeo/DutyofcareDocumentModelHandler.java
@@ -21,10 +21,10 @@
  */
 package org.collectionspace.services.dutyofcare.nuxeo;
 
-import org.collectionspace.services.dutyofcare.DutyofcaresCommon;
+import org.collectionspace.services.dutyofcare.DutiesOfCareCommon;
 import org.collectionspace.services.nuxeo.client.java.NuxeoDocumentModelHandler;
 
 /**
  * DutyofcareDocumentModelHandler
  */
-public class DutyofcareDocumentModelHandler extends NuxeoDocumentModelHandler<DutyofcaresCommon> {}
+public class DutyofcareDocumentModelHandler extends NuxeoDocumentModelHandler<DutiesOfCareCommon> {}

--- a/services/dutyofcare/service/src/main/java/org/collectionspace/services/dutyofcare/nuxeo/DutyofcareValidatorHandler.java
+++ b/services/dutyofcare/service/src/main/java/org/collectionspace/services/dutyofcare/nuxeo/DutyofcareValidatorHandler.java
@@ -14,16 +14,51 @@
  */
 package org.collectionspace.services.dutyofcare.nuxeo;
 
-import org.collectionspace.services.common.context.ServiceContext;
-import org.collectionspace.services.common.document.DocumentHandler.Action;
+import org.collectionspace.services.client.PoxPayloadIn;
+import org.collectionspace.services.client.PoxPayloadOut;
 import org.collectionspace.services.common.document.InvalidDocumentException;
-import org.collectionspace.services.common.document.ValidatorHandler;
+import org.collectionspace.services.common.document.ValidatorHandlerImpl;
+import org.collectionspace.services.dutyofcare.DutiesOfCareCommon;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public class DutyofcareValidatorHandler implements ValidatorHandler {
+public class DutyofcareValidatorHandler extends ValidatorHandlerImpl<PoxPayloadIn, PoxPayloadOut> {
+
+    private final Logger logger = LoggerFactory.getLogger(DutyofcareValidatorHandler.class);
+
+    private static final String COMMON_PART_MISSING = "Validation exception: dutiesofcare_common part is missing";
+    private static final String DOCUMENTATION_NUMBER_MISSING =
+            "Validation exception: The duty of care field \"dutyOfCareNumber\" cannot be empty or missing";
 
     @Override
-    public void validate(Action action, ServiceContext ctx) throws InvalidDocumentException {
-        // TODO Auto-generated method stub
-        System.out.println("DutyofcareValidatorHandler executed.");
+    protected Class<?> getCommonPartClass() {
+        return DutiesOfCareCommon.class;
     }
+
+    @Override
+    protected void handleCreate() throws InvalidDocumentException {
+        final DutiesOfCareCommon common = (DutiesOfCareCommon) getCommonPart();
+        if (common == null) {
+            logger.error(COMMON_PART_MISSING);
+            throw new InvalidDocumentException(COMMON_PART_MISSING);
+        }
+
+        final String dutyOfCareNumber = common.getDutyOfCareNumber();
+        if (dutyOfCareNumber == null || dutyOfCareNumber.isEmpty()) {
+            logger.error(DOCUMENTATION_NUMBER_MISSING);
+            throw new InvalidDocumentException(DOCUMENTATION_NUMBER_MISSING);
+        }
+    }
+
+    @Override
+    protected void handleGet() throws InvalidDocumentException {}
+
+    @Override
+    protected void handleGetAll() throws InvalidDocumentException {}
+
+    @Override
+    protected void handleUpdate() throws InvalidDocumentException {}
+
+    @Override
+    protected void handleDelete() throws InvalidDocumentException {}
 }


### PR DESCRIPTION
**What does this do?**
* Fix pluralization for duty of care
* Change title to dutyOfCareTitle
* Implement validation handler

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1332

These changes come from the testing done against Duty of Care. The pluralization update which was requested is being applied here for consistency throughout the procedure. I also noticed that the `title` field exists in the dublin core schema, which was sometimes being pulled back in the search results, so I've updated the field definition to be `dutyOfCareTitle` to avoid that collision.

**How should this be tested? Do these changes have associated tests?**
* Rebuild and start collectionspace
* Test that the Duty of Care service is accessible on the new uri
```
curl --user 'admin@core.collectionspace.org:Administrator' http://localhost:8180/cspace-services/dutiesofcare
```

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local instance