### PR TITLE
Update basic object with current location report output type

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/obj_computed_location.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/obj_computed_location.xml
@@ -11,6 +11,6 @@
     <supportsGroup>false</supportsGroup>
     <supportsNoContext>true</supportsNoContext>
     <filename>obj_computed_location.jrxml</filename>
-    <outputMIME>text/csv</outputMIME>
+    <outputMIME>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</outputMIME>
   </ns2:reports_common>
 </document>


### PR DESCRIPTION
**What does this do?**
* Updates mime type for Basic Object with Computed Location

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1451

This is updates so that xlsx output is set by default, as it has a way to both provide tabular data and thumbnails. As the workflow is still being tested, we're only adding this to a single report so that we can understand how it might work with, e.g. mail merge.

**How should this be tested? Do these changes have associated tests?**
* Rebuild collectionspace
* Create a collectionobject
* Search for collectionobjects
* Select the Basic object with current location report and see xlsx as the default output 

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally