### PR TITLE
DRYD-1451: Xlsx Report Configuration

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/accessions.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/accessions.xml
@@ -11,6 +11,6 @@
     <supportsGroup>false</supportsGroup>
     <supportsNoContext>true</supportsNoContext>
     <filename>accessions.jrxml</filename>
-    <outputMIME>text/csv</outputMIME>
+    <outputMIME>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</outputMIME>
   </ns2:reports_common>
 </document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/artwork_description.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/artwork_description.xml
@@ -11,6 +11,6 @@
     <supportsGroup>false</supportsGroup>
     <supportsNoContext>true</supportsNoContext>
     <filename>artwork_description.jrxml</filename>
-    <outputMIME>text/csv</outputMIME>
+    <outputMIME>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</outputMIME>
   </ns2:reports_common>
 </document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/borrowing_receipt.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/borrowing_receipt.xml
@@ -11,6 +11,6 @@
     <supportsGroup>false</supportsGroup>
     <supportsNoContext>true</supportsNoContext>
     <filename>borrowing_receipt.jrxml</filename>
-    <outputMIME>text/csv</outputMIME>
+    <outputMIME>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</outputMIME>
   </ns2:reports_common>
 </document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/box_list.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/box_list.xml
@@ -11,6 +11,6 @@
     <supportsGroup>false</supportsGroup>
     <supportsNoContext>true</supportsNoContext>
     <filename>box_list.jrxml</filename>
-    <outputMIME>text/csv</outputMIME>
+    <outputMIME>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</outputMIME>
   </ns2:reports_common>
 </document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/condition.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/condition.xml
@@ -11,6 +11,6 @@
     <supportsGroup>false</supportsGroup>
     <supportsNoContext>true</supportsNoContext>
     <filename>condition.jrxml</filename>
-    <outputMIME>text/csv</outputMIME>
+    <outputMIME>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</outputMIME>
   </ns2:reports_common>
 </document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/deaccessions.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/deaccessions.xml
@@ -11,6 +11,6 @@
     <supportsGroup>false</supportsGroup>
     <supportsNoContext>true</supportsNoContext>
     <filename>deaccessions.jrxml</filename>
-    <outputMIME>text/csv</outputMIME>
+    <outputMIME>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</outputMIME>
   </ns2:reports_common>
 </document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/deed_of_gift.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/deed_of_gift.jrxml
@@ -4,19 +4,8 @@
 	xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd"
 	name="deedofgift" pageWidth="1500" pageHeight="800" orientation="Landscape" columnWidth="1460" leftMargin="20" rightMargin="20"
 	topMargin="20" bottomMargin="20" isIgnorePagination="true" uuid="202f91ff-d0dd-4eda-90de-a15938303d79">
-	<property name="net.sf.jasperreports.jrparameter.is.ignore.pagination" value="true" />
-	<property name="net.sf.jasperreports.export.xls.one.page.per.sheet" value="false" />
-	<property name="net.sf.jasperreports.export.xls.sheet.names.all" value="DeedOfGift-Report/Footnotes" />
-	<property name="net.sf.jasperreports.export.xls.remove.empty.space.between.rows" value="true" />
-	<property name="net.sf.jasperreports.export.xls.remove.empty.space.between.columns" value="true" />
-	<property name="net.sf.jasperreports.export.xls.white.page.background" value="false" />
-	<property name="net.sf.jasperreports.export.xls.detect.cell.type" value="true" />
-	<property name="net.sf.jasperreports.page.break.no.pagination" value="apply" />
-	<property name="net.sf.jasperreports.export.xls.freeze.row" value="2" />
-	<property name="net.sf.jasperreports.print.keep.full.text" value="true" />
 	<property name="net.sf.jasperreports.export.xls.exclude.origin.keep.first.band.1" value="pageHeader" />
 	<property name="net.sf.jasperreports.export.xls.exclude.origin.band.2" value="pageFooter" />
-	<property name="net.sf.jasperreports.exports.xls.font.size.fix.enabled" value="false" />
 	<property name="com.jaspersoft.studio.data.sql.tables" value=""/>
 	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="nuxeo"/>
 	<property name="com.jaspersoft.studio.data.sql.SQLQueryDesigner.sash.w1" value="193"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/deed_of_gift.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/deed_of_gift.xml
@@ -11,6 +11,6 @@
     <supportsGroup>false</supportsGroup>
     <supportsNoContext>true</supportsNoContext>
     <filename>deed_of_gift.jrxml</filename>
-    <outputMIME>text/csv</outputMIME>
+    <outputMIME>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</outputMIME>
   </ns2:reports_common>
 </document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/full_obj_place.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/full_obj_place.xml
@@ -11,6 +11,6 @@
     <supportsGroup>false</supportsGroup>
     <supportsNoContext>true</supportsNoContext>
     <filename>full_obj_place.jrxml</filename>
-    <outputMIME>text/csv</outputMIME>
+    <outputMIME>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</outputMIME>
   </ns2:reports_common>
 </document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/incoming_loan.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/incoming_loan.xml
@@ -11,6 +11,6 @@
     <supportsGroup>false</supportsGroup>
     <supportsNoContext>true</supportsNoContext>
     <filename>incoming_loan.jrxml</filename>
-    <outputMIME>text/csv</outputMIME>
+    <outputMIME>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</outputMIME>
   </ns2:reports_common>
 </document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/incoming_loan_letter.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/incoming_loan_letter.xml
@@ -11,6 +11,6 @@
     <supportsGroup>false</supportsGroup>
     <supportsNoContext>true</supportsNoContext>
     <filename>incoming_loan_letter.jrxml</filename>
-    <outputMIME>text/csv</outputMIME>
+    <outputMIME>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</outputMIME>
   </ns2:reports_common>
 </document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/obj_computed_location.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/obj_computed_location.jrxml
@@ -1,19 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 6.20.1.final using JasperReports Library version 6.20.1-7584acb244139816654f64e2fd57a00d3e31921e  -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="objcomputedlocation" pageWidth="1000" pageHeight="595" orientation="Landscape" columnWidth="802" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isIgnorePagination="true" uuid="0b89017b-1c64-4285-9d1a-33596b3f5bb3">
-	<property name="net.sf.jasperreports.jrparameter.is.ignore.pagination" value="true" />
-	<property name="net.sf.jasperreports.export.xls.one.page.per.sheet" value="false" />
-	<property name="net.sf.jasperreports.export.xls.sheet.names.all" value="BasicObjWithLocation-Report/Footnotes" />
-	<property name="net.sf.jasperreports.export.xls.remove.empty.space.between.rows" value="true" />
-	<property name="net.sf.jasperreports.export.xls.remove.empty.space.between.columns" value="true" />
-	<property name="net.sf.jasperreports.export.xls.white.page.background" value="false" />
-	<property name="net.sf.jasperreports.export.xls.detect.cell.type" value="true" />
-	<property name="net.sf.jasperreports.page.break.no.pagination" value="apply" />
-	<property name="net.sf.jasperreports.export.xls.freeze.row" value="2" />
-	<property name="net.sf.jasperreports.print.keep.full.text" value="true" />
 	<property name="net.sf.jasperreports.export.xls.exclude.origin.keep.first.band.1" value="pageHeader" />
 	<property name="net.sf.jasperreports.export.xls.exclude.origin.band.2" value="pageFooter" />
-	<property name="net.sf.jasperreports.exports.xls.font.size.fix.enabled" value="false" />
 	<property name="com.jaspersoft.studio.data.sql.tables" value=""/>
 	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="nuxeo"/>
 	<property name="com.jaspersoft.studio.data.sql.SQLQueryDesigner.sash.w1" value="193"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/obj_computed_location.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/obj_computed_location.xml
@@ -11,6 +11,6 @@
     <supportsGroup>false</supportsGroup>
     <supportsNoContext>true</supportsNoContext>
     <filename>obj_computed_location.jrxml</filename>
-    <outputMIME>text/csv</outputMIME>
+    <outputMIME>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</outputMIME>
   </ns2:reports_common>
 </document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/obj_current_place_details.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/obj_current_place_details.xml
@@ -11,6 +11,6 @@
     <supportsGroup>false</supportsGroup>
     <supportsNoContext>true</supportsNoContext>
     <filename>obj_current_place_details.jrxml</filename>
-    <outputMIME>text/csv</outputMIME>
+    <outputMIME>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</outputMIME>
   </ns2:reports_common>
 </document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/object_valuation.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/object_valuation.jrxml
@@ -2,18 +2,8 @@
 <!-- Created with Jaspersoft Studio version 6.10.0.final using JasperReports Library version 6.10.0-unknown  -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="obj_val" pageWidth="1000" pageHeight="800" orientation="Landscape" columnWidth="100" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isIgnorePagination="true" uuid="49b29b35-57c3-422f-8699-01975b0a33f9">
 	<property name="com.jaspersoft.studio.data.sql.tables" value=""/>
-	<property name="net.sf.jasperreports.jrparameter.is.ignore.pagination" value="true"/>
-	<property name="net.sf.jasperreports.export.xls.one.page.per.sheet" value="false"/>
-	<property name="net.sf.jasperreports.export.xls.remove.empty.space.between.rows" value="true"/>
-	<property name="net.sf.jasperreports.export.xls.remove.empty.space.between.columns" value="true"/>
-	<property name="net.sf.jasperreports.export.xls.white.page.background" value="false"/>
-	<property name="net.sf.jasperreports.export.xls.detect.cell.type" value="true"/>
-	<property name="net.sf.jasperreports.page.break.no.pagination" value="apply"/>
-	<property name="net.sf.jasperreports.export.xls.freeze.row" value="2"/>
-	<property name="net.sf.jasperreports.print.keep.full.text" value="true"/>
 	<property name="net.sf.jasperreports.export.xls.exclude.origin.keep.first.band.1" value="pageHeader"/>
 	<property name="net.sf.jasperreports.export.xls.exclude.origin.band.2" value="pageFooter"/>
-	<property name="net.sf.jasperreports.exports.xls.font.size.fix.enabled" value="false"/>
 	<style name="Column header" fontName="SansSerif" fontSize="12" isBold="true"/>
 	<style name="Detail" fontName="SansSerif" fontSize="12"/>
 	<parameter name="csidlist" class="java.lang.String" isForPrompting="false"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/outgoing_loan.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/outgoing_loan.xml
@@ -11,6 +11,6 @@
     <supportsGroup>false</supportsGroup>
     <supportsNoContext>true</supportsNoContext>
     <filename>outgoing_loan.jrxml</filename>
-    <outputMIME>text/csv</outputMIME>
+    <outputMIME>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</outputMIME>
   </ns2:reports_common>
 </document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/outgoing_loan_letter.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/outgoing_loan_letter.xml
@@ -11,6 +11,6 @@
     <supportsGroup>false</supportsGroup>
     <supportsNoContext>true</supportsNoContext>
     <filename>outgoing_loan_letter.jrxml</filename>
-    <outputMIME>text/csv</outputMIME>
+    <outputMIME>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</outputMIME>
   </ns2:reports_common>
 </document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/referral.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/referral.xml
@@ -11,6 +11,6 @@
     <supportsGroup>false</supportsGroup>
     <supportsNoContext>true</supportsNoContext>
     <filename>referral.jrxml</filename>
-    <outputMIME>text/csv</outputMIME>
+    <outputMIME>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</outputMIME>
   </ns2:reports_common>
 </document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tombstone_with_budget.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tombstone_with_budget.xml
@@ -11,6 +11,6 @@
     <supportsGroup>false</supportsGroup>
     <supportsNoContext>true</supportsNoContext>
     <filename>tombstone_with_budget.jrxml</filename>
-    <outputMIME>text/csv</outputMIME>
+    <outputMIME>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</outputMIME>
   </ns2:reports_common>
 </document>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tombstone_with_creator.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tombstone_with_creator.xml
@@ -11,6 +11,6 @@
     <supportsGroup>false</supportsGroup>
     <supportsNoContext>true</supportsNoContext>
     <filename>tombstone_with_creator.jrxml</filename>
-    <outputMIME>text/csv</outputMIME>
+    <outputMIME>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</outputMIME>
   </ns2:reports_common>
 </document>

--- a/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
+++ b/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
@@ -398,10 +398,8 @@ public class ReportDocumentModelHandler extends NuxeoDocumentModelHandler<Report
 
 			conn = getConnection();
 
-			if (logger.isTraceEnabled()) {
-				logger.trace("ReportResource for csid=" + reportCSID
-							 + " output as " + outputMimeType + " using report file: " + reportCompiledFile.getAbsolutePath());
-			}
+			logger.trace("ReportResource for csid={} output as {} using report file: {}", reportCSID, outputMimeType,
+						 reportCompiledFile.getAbsolutePath());
 
 			FileInputStream fileStream = new FileInputStream(reportCompiledFile);
 			// Report will be to a temporary file.

--- a/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
+++ b/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
@@ -441,9 +441,46 @@ public class ReportDocumentModelHandler extends NuxeoDocumentModelHandler<Report
 					   || outputMimeType.equals(ReportClient.OPEN_DOCX_MIME_TYPE)) {
 				exporter = new JRDocxExporter();
 				outputFilename = outputFilename + ".docx";
-			} else if (outputMimeType.equals(ReportClient.MSEXCEL_MIME_TYPE)    // Understand msexcel as xlsx
+			} else if (outputMimeType.equals(ReportClient.MSEXCEL_MIME_TYPE) // Understand msexcel as xlsx
 					   || outputMimeType.equals(ReportClient.OPEN_XLSX_MIME_TYPE)) {
-				exporter = new JRXlsxExporter();
+				// Kind of unnecessary but avoids complaining about unchecked typing issues
+				JRXlsxExporter xlsxExporter = new JRXlsxExporter();
+				/**
+				 * 	??
+				 * 	<property name="net.sf.jasperreports.export.xls.exclude.origin.keep.first.band.1"
+				 * 	value="pageHeader"/>
+				 * 	<property name="net.sf.jasperreports.export.xls.exclude.origin.band.2" value="pageFooter"/>
+				 */
+				params.put(JRParameter.IS_IGNORE_PAGINATION, true);
+				params.put(JRBreak.PROPERTY_PAGE_BREAK_NO_PAGINATION, JRBreak.PAGE_BREAK_NO_PAGINATION_APPLY);
+				params.put(JRTextElement.PROPERTY_PRINT_KEEP_FULL_TEXT, true);
+
+				SimpleXlsxReportConfiguration reportConfig = new SimpleXlsxReportConfiguration();
+				reportConfig.setCollapseRowSpan(true);
+				reportConfig.setRemoveEmptySpaceBetweenRows(true);
+				reportConfig.setRemoveEmptySpaceBetweenColumns(true);
+				reportConfig.setDetectCellType(true);
+				reportConfig.setOnePagePerSheet(false);
+				reportConfig.setFontSizeFixEnabled(true);
+				reportConfig.setFreezeRow(2);
+				reportConfig.setSheetNames(new String[] {outputFilename});
+				xlsxExporter.setConfiguration(reportConfig);
+				xlsxExporter.setExporterOutput(new SimpleOutputStreamExporterOutput(tempOutputStream));
+				exporter = xlsxExporter;
+
+				// Note: Configuration properties added as parameters do not work
+				// Also note: This should be done through exporter.setConfiguration, however this can't be mixed with
+				//            setParameter
+				// exporter.setParameter(JRXlsAbstractExporterParameter.IS_COLLAPSE_ROW_SPAN, true);
+				// exporter.setParameter(JRXlsAbstractExporterParameter.IS_REMOVE_EMPTY_SPACE_BETWEEN_ROWS, true);
+				// exporter.setParameter(JRXlsAbstractExporterParameter.IS_REMOVE_EMPTY_SPACE_BETWEEN_COLUMNS, true);
+				// exporter.setParameter(JRXlsAbstractExporterParameter.IS_DETECT_CELL_TYPE, true);
+				// exporter.setParameter(JRXlsAbstractExporterParameter.IS_ONE_PAGE_PER_SHEET, false);
+				// exporter.setParameter(JRXlsAbstractExporterParameter.IS_WHITE_PAGE_BACKGROUND, false);
+				// exporter.setParameter(JRXlsAbstractExporterParameter.IS_FONT_SIZE_FIX_ENABLED, false);
+				// WHERE DO THESE GO????
+				// params.put(XlsReportConfiguration.PROPERTY_FREEZE_ROW, 2);
+				// params.put(XlsReportConfiguration.PROPERTY_SHEET_NAMES_PREFIX + "all", outputFilename);
 				outputFilename = outputFilename + ".xlsx";
 			} else if (outputMimeType.equals(ReportClient.MSPPT_MIME_TYPE)    // Understand msppt as xlsx
 					   || outputMimeType.equals(ReportClient.OPEN_PPTX_MIME_TYPE)) {

--- a/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
+++ b/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
@@ -367,8 +367,6 @@ public class ReportDocumentModelHandler extends NuxeoDocumentModelHandler<Report
 		String outputMimeType,
 		StringBuffer outReportFileName) throws Exception {
 
-		InputStream result = null;
-
 		try (Connection conn = getConnection()) {
 			String reportName = Tools.getFilenameBase(reportFileName);
 			File reportCompiledFile = ReportResource.getReportCompiledFile(reportName);
@@ -474,8 +472,7 @@ public class ReportDocumentModelHandler extends NuxeoDocumentModelHandler<Report
 			exporter.exportReport();
 			tempOutputStream.close();
 
-			result = new FileInputStream(tempOutputFile);
-			return result;
+			return new FileInputStream(tempOutputFile);
 		} catch (SQLException sqle) {
 			// SQLExceptions can be chained. We have at least one exception, so
 			// set up a loop to make sure we let the user know about all of them

--- a/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
+++ b/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
@@ -367,10 +367,9 @@ public class ReportDocumentModelHandler extends NuxeoDocumentModelHandler<Report
 		String outputMimeType,
 		StringBuffer outReportFileName) throws Exception {
 
-		Connection conn = null;
 		InputStream result = null;
 
-		try {
+		try (Connection conn = getConnection()) {
 			String reportName = Tools.getFilenameBase(reportFileName);
 			File reportCompiledFile = ReportResource.getReportCompiledFile(reportName);
 
@@ -395,8 +394,6 @@ public class ReportDocumentModelHandler extends NuxeoDocumentModelHandler<Report
 
 				JasperCompileManager.compileReportToFile(design, reportCompiledFile.getAbsolutePath());
 			}
-
-			conn = getConnection();
 
 			logger.trace("ReportResource for csid={} output as {} using report file: {}", reportCSID, outputMimeType,
 						 reportCompiledFile.getAbsolutePath());
@@ -508,19 +505,6 @@ public class ReportDocumentModelHandler extends NuxeoDocumentModelHandler<Report
 				Response.Status.INTERNAL_SERVER_ERROR).entity(
 				"Invoke failed (SQL problem) on Report csid=" + reportCSID).type("text/plain").build();
 			throw new CSWebApplicationException(fnfe, response);
-		} finally {
-			if (conn != null) {
-				try {
-					conn.close();
-				} catch (SQLException sqle) {
-					// SQLExceptions can be chained. We have at least one exception, so
-					// set up a loop to make sure we let the user know about all of them
-					// if there happens to be more than one.
-					logger.debug("SQL Exception closing connection: {}", sqle.getLocalizedMessage());
-				} catch (Exception e) {
-					logger.debug("Exception closing connection", e);
-				}
-			}
 		}
 	}
 

--- a/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
+++ b/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
@@ -474,18 +474,7 @@ public class ReportDocumentModelHandler extends NuxeoDocumentModelHandler<Report
 
 			return new FileInputStream(tempOutputFile);
 		} catch (SQLException sqle) {
-			// SQLExceptions can be chained. We have at least one exception, so
-			// set up a loop to make sure we let the user know about all of them
-			// if there happens to be more than one.
-			if (logger.isDebugEnabled()) {
-				SQLException tempException = sqle;
-				while (null != tempException) {
-					logger.debug("SQL Exception: {}", sqle.getLocalizedMessage());
-
-					// loop to the next exception
-					tempException = tempException.getNextException();
-				}
-			}
+			logger.error("SQL Exception in report {}", reportCSID, sqle);
 			Response response = Response.status(
 				Response.Status.INTERNAL_SERVER_ERROR).entity(
 				"Invoke failed (SQL problem) on Report csid=" + reportCSID).type("text/plain").build();

--- a/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
+++ b/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
@@ -475,21 +475,21 @@ public class ReportDocumentModelHandler extends NuxeoDocumentModelHandler<Report
 			return new FileInputStream(tempOutputFile);
 		} catch (SQLException sqle) {
 			logger.error("SQL Exception in report {}", reportCSID, sqle);
-			Response response = Response.status(
-				Response.Status.INTERNAL_SERVER_ERROR).entity(
-				"Invoke failed (SQL problem) on Report csid=" + reportCSID).type("text/plain").build();
+			Response response = Response.serverError()
+				.entity("Invoke failed (SQL problem) on Report csid=" + reportCSID)
+				.type("text/plain").build();
 			throw new CSWebApplicationException(sqle, response);
 		} catch (JRException jre) {
 			logger.error("JasperReports Exception: {} Cause: {}", jre.getLocalizedMessage(), jre.getCause());
-			Response response = Response.status(
-				Response.Status.INTERNAL_SERVER_ERROR).entity(
-				"Invoke failed (Jasper problem) on Report csid=" + reportCSID).type("text/plain").build();
+			Response response = Response.serverError()
+				.entity("Invoke failed (Jasper problem) on Report csid=" + reportCSID)
+				.type("text/plain").build();
 			throw new CSWebApplicationException(jre, response);
 		} catch (FileNotFoundException fnfe) {
 			logger.error("FileNotFoundException: {}", fnfe.getLocalizedMessage());
-			Response response = Response.status(
-				Response.Status.INTERNAL_SERVER_ERROR).entity(
-				"Invoke failed (FileNotFound) on Report csid=" + reportCSID).type("text/plain").build();
+			Response response = Response.serverError()
+				.entity("Invoke failed (FileNotFound) on Report csid=" + reportCSID)
+				.type("text/plain").build();
 			throw new CSWebApplicationException(fnfe, response);
 		}
 	}

--- a/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
+++ b/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
@@ -205,7 +205,7 @@ public class ReportDocumentModelHandler extends NuxeoDocumentModelHandler<Report
 		boolean releaseRepoSession = false;
 
 		// Ensure the current user has permission to run this report
-		if (isAuthoritzed(reportsCommon) == false) {
+		if (!isAuthorized(reportsCommon)) {
 			String msg = String.format("Report Resource: The user '%s' is not authorized to run the report '%s' CSID='%s'",
 					AuthN.get().getUserId(), reportsCommon.getName(), csid);
 			throw new PermissionException(msg);
@@ -596,7 +596,7 @@ public class ReportDocumentModelHandler extends NuxeoDocumentModelHandler<Report
 	 * @param reportsCommon
 	 * @return
 	 */
-	protected boolean isAuthoritzedWithPermissions(ReportsCommon reportsCommon) {
+	protected boolean isAuthorizedWithPermissions(ReportsCommon reportsCommon) {
 		boolean result = true;
 
 		ResourceActionGroupList resourceActionGroupList = reportsCommon.getResourceActionGroupList();
@@ -662,13 +662,13 @@ public class ReportDocumentModelHandler extends NuxeoDocumentModelHandler<Report
 	 * @param reportsCommon
 	 * @return
 	 */
-	protected boolean isAuthoritzed(ReportsCommon reportsCommon) {
+	protected boolean isAuthorized(ReportsCommon reportsCommon) {
 		boolean result = true;
 
 		if (hasRequiredRoles(reportsCommon)) {
 			result = isAuthorizedWithRoles(reportsCommon);
 		} else if (hasRequiredPermissions(reportsCommon)) {
-			result = isAuthoritzedWithPermissions(reportsCommon);
+			result = isAuthorizedWithPermissions(reportsCommon);
 		}
 
 		return result;

--- a/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
+++ b/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
@@ -355,49 +355,49 @@ public class ReportDocumentModelHandler extends NuxeoDocumentModelHandler<Report
 
 	}
 
-    private InputStream buildReportResult(
-			String reportCSID,
-			HashMap<String, Object> params,
-			String reportFileName,
-			String outputMimeType,
-			StringBuffer outReportFileName
-		) throws Exception {
+	private InputStream buildReportResult(
+		String reportCSID,
+		HashMap<String, Object> params,
+		String reportFileName,
+		String outputMimeType,
+		StringBuffer outReportFileName
+										 ) throws Exception {
 
-			Connection conn = null;
-			InputStream result = null;
+		Connection conn = null;
+		InputStream result = null;
 
-    	try {
-				String reportName = Tools.getFilenameBase(reportFileName);
-				File reportCompiledFile = ReportResource.getReportCompiledFile(reportName);
+		try {
+			String reportName = Tools.getFilenameBase(reportFileName);
+			File reportCompiledFile = ReportResource.getReportCompiledFile(reportName);
 
-				if (!reportCompiledFile.exists()) {
-					// Need to compile the file.
+			if (!reportCompiledFile.exists()) {
+				// Need to compile the file.
 
-					File reportSourceFile = ReportResource.getReportSourceFile(reportName);
+				File reportSourceFile = ReportResource.getReportSourceFile(reportName);
 
-					if(!reportSourceFile.exists()) {
-						logger.error("Report for csid={} is missing source file: {}",
-								reportCSID, reportSourceFile.getAbsolutePath());
+				if (!reportSourceFile.exists()) {
+					logger.error("Report for csid={} is missing source file: {}",
+								 reportCSID, reportSourceFile.getAbsolutePath());
 
-						throw new RuntimeException("Report is missing source file");
-					}
+					throw new RuntimeException("Report is missing source file");
+				}
 
-					logger.info("Report for csid={} is not compiled. Compiling first, and saving to: {}",
+				logger.info("Report for csid={} is not compiled. Compiling first, and saving to: {}",
 							reportCSID, reportCompiledFile.getAbsolutePath());
 
-					JasperDesign design = JRXmlLoader.load(reportSourceFile.getAbsolutePath());
+				JasperDesign design = JRXmlLoader.load(reportSourceFile.getAbsolutePath());
 
-					design.setScriptletClass("org.collectionspace.services.report.jasperreports.CSpaceReportScriptlet");
+				design.setScriptletClass("org.collectionspace.services.report.jasperreports.CSpaceReportScriptlet");
 
-					JasperCompileManager.compileReportToFile(design, reportCompiledFile.getAbsolutePath());
-				}
+				JasperCompileManager.compileReportToFile(design, reportCompiledFile.getAbsolutePath());
+			}
 
-				conn = getConnection();
+			conn = getConnection();
 
-				if (logger.isTraceEnabled()) {
-					logger.trace("ReportResource for csid=" + reportCSID
-							+ " output as " + outputMimeType + " using report file: " + reportCompiledFile.getAbsolutePath());
-				}
+			if (logger.isTraceEnabled()) {
+				logger.trace("ReportResource for csid=" + reportCSID
+							 + " output as " + outputMimeType + " using report file: " + reportCompiledFile.getAbsolutePath());
+			}
 
 			FileInputStream fileStream = new FileInputStream(reportCompiledFile);
 
@@ -420,48 +420,48 @@ public class ReportDocumentModelHandler extends NuxeoDocumentModelHandler<Report
 			if (outputMimeType.equals(MediaType.APPLICATION_XML)) {
 				params.put(JRParameter.IS_IGNORE_PAGINATION, Boolean.TRUE);
 				exporter = new JRXmlExporter();
-				outputFilename = outputFilename+".xml";
-			} else if(outputMimeType.equals(MediaType.TEXT_HTML)) {
+				outputFilename = outputFilename + ".xml";
+			} else if (outputMimeType.equals(MediaType.TEXT_HTML)) {
 				exporter = new HtmlExporter();
-				outputFilename = outputFilename+".html";
-			} else if(outputMimeType.equals(ReportClient.PDF_MIME_TYPE)) {
+				outputFilename = outputFilename + ".html";
+			} else if (outputMimeType.equals(ReportClient.PDF_MIME_TYPE)) {
 				exporter = new JRPdfExporter();
-				outputFilename = outputFilename+".pdf";
-			} else if(outputMimeType.equals(ReportClient.CSV_MIME_TYPE)) {
+				outputFilename = outputFilename + ".pdf";
+			} else if (outputMimeType.equals(ReportClient.CSV_MIME_TYPE)) {
 				params.put(JRParameter.IS_IGNORE_PAGINATION, Boolean.TRUE);
 				exporter = new JRCsvExporter();
 				exporter.setParameter(JRCsvExporterParameter.FIELD_DELIMITER, ",");
-				outputFilename = outputFilename+".csv";
-			} else if(outputMimeType.equals(ReportClient.TSV_MIME_TYPE)) {
+				outputFilename = outputFilename + ".csv";
+			} else if (outputMimeType.equals(ReportClient.TSV_MIME_TYPE)) {
 				params.put(JRParameter.IS_IGNORE_PAGINATION, Boolean.TRUE);
 				exporter = new JRCsvExporter();
 				exporter.setParameter(JRCsvExporterParameter.FIELD_DELIMITER, "\t");
-				outputFilename = outputFilename+".csv";
-			} else if(outputMimeType.equals(ReportClient.MSWORD_MIME_TYPE)	// Understand msword as docx
-					|| outputMimeType.equals(ReportClient.OPEN_DOCX_MIME_TYPE)) {
+				outputFilename = outputFilename + ".csv";
+			} else if (outputMimeType.equals(ReportClient.MSWORD_MIME_TYPE)    // Understand msword as docx
+					   || outputMimeType.equals(ReportClient.OPEN_DOCX_MIME_TYPE)) {
 				exporter = new JRDocxExporter();
-				outputFilename = outputFilename+".docx";
-			} else if(outputMimeType.equals(ReportClient.MSEXCEL_MIME_TYPE)	// Understand msexcel as xlsx
-					|| outputMimeType.equals(ReportClient.OPEN_XLSX_MIME_TYPE)) {
+				outputFilename = outputFilename + ".docx";
+			} else if (outputMimeType.equals(ReportClient.MSEXCEL_MIME_TYPE)    // Understand msexcel as xlsx
+					   || outputMimeType.equals(ReportClient.OPEN_XLSX_MIME_TYPE)) {
 				exporter = new JRXlsxExporter();
-				outputFilename = outputFilename+".xlsx";
-			} else if(outputMimeType.equals(ReportClient.MSPPT_MIME_TYPE)	// Understand msppt as xlsx
-					|| outputMimeType.equals(ReportClient.OPEN_PPTX_MIME_TYPE)) {
+				outputFilename = outputFilename + ".xlsx";
+			} else if (outputMimeType.equals(ReportClient.MSPPT_MIME_TYPE)    // Understand msppt as xlsx
+					   || outputMimeType.equals(ReportClient.OPEN_PPTX_MIME_TYPE)) {
 				exporter = new JRPptxExporter();
-				outputFilename = outputFilename+".pptx";
+				outputFilename = outputFilename + ".pptx";
 			} else {
 				logger.error("Reporting: unsupported output MIME type - defaulting to PDF");
 				exporter = new JRPdfExporter();
-				outputFilename = outputFilename+"-default-to.pdf";
+				outputFilename = outputFilename + "-default-to.pdf";
 			}
 			outReportFileName.append(outputFilename); // Set the out going param to the report's final file name
-                        // FIXME: Logging temporarily set to INFO level for CSPACE-5766;
-                        // can change to TRACE or DEBUG level as warranted thereafter
-                        if (logger.isInfoEnabled()) {
-                            logger.info(FileTools.getJavaTmpDirInfo());
-                        }
-                        // fill the report
-			JasperPrint jasperPrint = JasperFillManager.fillReport(fileStream, params,conn);
+			// FIXME: Logging temporarily set to INFO level for CSPACE-5766;
+			// can change to TRACE or DEBUG level as warranted thereafter
+			if (logger.isInfoEnabled()) {
+				logger.info(FileTools.getJavaTmpDirInfo());
+			}
+			// fill the report
+			JasperPrint jasperPrint = JasperFillManager.fillReport(fileStream, params, conn);
 
 			// Report will be to a temporary file.
 			File tempOutputFile = Files.createTempFile("report-", null).toFile();
@@ -472,79 +472,79 @@ public class ReportDocumentModelHandler extends NuxeoDocumentModelHandler<Report
 			tempOutputStream.close();
 
 			result = new FileInputStream(tempOutputFile);
-	       	return result;
-        } catch (SQLException sqle) {
-            // SQLExceptions can be chained. We have at least one exception, so
-            // set up a loop to make sure we let the user know about all of them
-            // if there happens to be more than one.
-            if (logger.isDebugEnabled()) {
-	            SQLException tempException = sqle;
-	            while (null != tempException) {
-	                	logger.debug("SQL Exception: " + sqle.getLocalizedMessage());
+			return result;
+		} catch (SQLException sqle) {
+			// SQLExceptions can be chained. We have at least one exception, so
+			// set up a loop to make sure we let the user know about all of them
+			// if there happens to be more than one.
+			if (logger.isDebugEnabled()) {
+				SQLException tempException = sqle;
+				while (null != tempException) {
+					logger.debug("SQL Exception: " + sqle.getLocalizedMessage());
 
-	                // loop to the next exception
-	                tempException = tempException.getNextException();
-	            }
-            }
-            Response response = Response.status(
-                    Response.Status.INTERNAL_SERVER_ERROR).entity(
-                    		"Invoke failed (SQL problem) on Report csid=" + reportCSID).type("text/plain").build();
-            throw new CSWebApplicationException(sqle, response);
-        } catch (JRException jre) {
-            if (logger.isDebugEnabled()) {
-            	logger.debug("JR Exception: " + jre.getLocalizedMessage() + " Cause: "+jre.getCause());
-            }
-            Response response = Response.status(
-                    Response.Status.INTERNAL_SERVER_ERROR).entity(
-                    		"Invoke failed (Jasper problem) on Report csid=" + reportCSID).type("text/plain").build();
-            throw new CSWebApplicationException(jre, response);
-        } catch (FileNotFoundException fnfe) {
-            if (logger.isDebugEnabled()) {
-            	logger.debug("FileNotFoundException: " + fnfe.getLocalizedMessage());
-            }
-            Response response = Response.status(
-                    Response.Status.INTERNAL_SERVER_ERROR).entity(
-                    		"Invoke failed (SQL problem) on Report csid=" + reportCSID).type("text/plain").build();
-            throw new CSWebApplicationException(fnfe, response);
+					// loop to the next exception
+					tempException = tempException.getNextException();
+				}
+			}
+			Response response = Response.status(
+				Response.Status.INTERNAL_SERVER_ERROR).entity(
+				"Invoke failed (SQL problem) on Report csid=" + reportCSID).type("text/plain").build();
+			throw new CSWebApplicationException(sqle, response);
+		} catch (JRException jre) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("JR Exception: " + jre.getLocalizedMessage() + " Cause: " + jre.getCause());
+			}
+			Response response = Response.status(
+				Response.Status.INTERNAL_SERVER_ERROR).entity(
+				"Invoke failed (Jasper problem) on Report csid=" + reportCSID).type("text/plain").build();
+			throw new CSWebApplicationException(jre, response);
+		} catch (FileNotFoundException fnfe) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("FileNotFoundException: " + fnfe.getLocalizedMessage());
+			}
+			Response response = Response.status(
+				Response.Status.INTERNAL_SERVER_ERROR).entity(
+				"Invoke failed (SQL problem) on Report csid=" + reportCSID).type("text/plain").build();
+			throw new CSWebApplicationException(fnfe, response);
 		} finally {
-        	if (conn!=null) {
-        		try {
-        			conn.close();
-                } catch (SQLException sqle) {
-                    // SQLExceptions can be chained. We have at least one exception, so
-                    // set up a loop to make sure we let the user know about all of them
-                    // if there happens to be more than one.
-                    if (logger.isDebugEnabled()) {
-   	                	logger.debug("SQL Exception closing connection: "
-   	                			+ sqle.getLocalizedMessage());
-                    }
-                } catch (Exception e) {
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("Exception closing connection", e);
-                    }
-                }
-        	}
-        }
-    }
+			if (conn != null) {
+				try {
+					conn.close();
+				} catch (SQLException sqle) {
+					// SQLExceptions can be chained. We have at least one exception, so
+					// set up a loop to make sure we let the user know about all of them
+					// if there happens to be more than one.
+					if (logger.isDebugEnabled()) {
+						logger.debug("SQL Exception closing connection: "
+									 + sqle.getLocalizedMessage());
+					}
+				} catch (Exception e) {
+					if (logger.isDebugEnabled()) {
+						logger.debug("Exception closing connection", e);
+					}
+				}
+			}
+		}
+	}
 
-    private Connection getConnection() throws NamingException, SQLException {
-    	Connection result = null;
+	private Connection getConnection() throws NamingException, SQLException {
+		Connection result = null;
 
-    	ServiceContext<PoxPayloadIn, PoxPayloadOut> ctx = this.getServiceContext();
-    	try {
-    		String repositoryName = ctx.getRepositoryName();
-	    	if (repositoryName != null && repositoryName.trim().isEmpty() == false) {
-                        String cspaceInstanceId = ServiceMain.getInstance().getCspaceInstanceId();
-                        String databaseName = JDBCTools.getDatabaseName(repositoryName, cspaceInstanceId);
-	    		result = JDBCTools.getConnection(JDBCTools.NUXEO_READER_DATASOURCE_NAME, databaseName);
-	    	}
+		ServiceContext<PoxPayloadIn, PoxPayloadOut> ctx = this.getServiceContext();
+		try {
+			String repositoryName = ctx.getRepositoryName();
+			if (repositoryName != null && repositoryName.trim().isEmpty() == false) {
+				String cspaceInstanceId = ServiceMain.getInstance().getCspaceInstanceId();
+				String databaseName = JDBCTools.getDatabaseName(repositoryName, cspaceInstanceId);
+				result = JDBCTools.getConnection(JDBCTools.NUXEO_READER_DATASOURCE_NAME, databaseName);
+			}
 		} catch (Exception e) {
 			Log.error(e);
 			throw new NamingException();
 		}
 
-    	return result;
-    }
+		return result;
+	}
 
 	/**
 	 * Check to see if the current user is authorized to run/invoke this report.  If the report

--- a/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
+++ b/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
@@ -105,7 +105,6 @@ import org.collectionspace.services.report.ReportsCommon.ForRoles;
 import org.collectionspace.services.report.ReportsOuputMimeList;
 import org.collectionspace.services.report.ResourceActionGroup;
 import org.collectionspace.services.report.ResourceActionGroupList;
-import org.jfree.util.Log;
 import org.nuxeo.ecm.core.api.DocumentModel;
 import org.nuxeo.ecm.core.api.model.PropertyException;
 import org.slf4j.Logger;
@@ -368,8 +367,7 @@ public class ReportDocumentModelHandler extends NuxeoDocumentModelHandler<Report
 		HashMap<String, Object> params,
 		String reportFileName,
 		String outputMimeType,
-		StringBuffer outReportFileName
-										 ) throws Exception {
+		StringBuffer outReportFileName) throws Exception {
 
 		Connection conn = null;
 		InputStream result = null;
@@ -528,7 +526,7 @@ public class ReportDocumentModelHandler extends NuxeoDocumentModelHandler<Report
 			if (logger.isDebugEnabled()) {
 				SQLException tempException = sqle;
 				while (null != tempException) {
-					logger.debug("SQL Exception: " + sqle.getLocalizedMessage());
+					logger.debug("SQL Exception: {}", sqle.getLocalizedMessage());
 
 					// loop to the next exception
 					tempException = tempException.getNextException();
@@ -539,17 +537,13 @@ public class ReportDocumentModelHandler extends NuxeoDocumentModelHandler<Report
 				"Invoke failed (SQL problem) on Report csid=" + reportCSID).type("text/plain").build();
 			throw new CSWebApplicationException(sqle, response);
 		} catch (JRException jre) {
-			if (logger.isDebugEnabled()) {
-				logger.debug("JR Exception: " + jre.getLocalizedMessage() + " Cause: " + jre.getCause());
-			}
+			logger.error("JasperReports Exception: {} Cause: {}", jre.getLocalizedMessage(), jre.getCause());
 			Response response = Response.status(
 				Response.Status.INTERNAL_SERVER_ERROR).entity(
 				"Invoke failed (Jasper problem) on Report csid=" + reportCSID).type("text/plain").build();
 			throw new CSWebApplicationException(jre, response);
 		} catch (FileNotFoundException fnfe) {
-			if (logger.isDebugEnabled()) {
-				logger.debug("FileNotFoundException: " + fnfe.getLocalizedMessage());
-			}
+			logger.error("FileNotFoundException: {}", fnfe.getLocalizedMessage());
 			Response response = Response.status(
 				Response.Status.INTERNAL_SERVER_ERROR).entity(
 				"Invoke failed (SQL problem) on Report csid=" + reportCSID).type("text/plain").build();
@@ -562,14 +556,9 @@ public class ReportDocumentModelHandler extends NuxeoDocumentModelHandler<Report
 					// SQLExceptions can be chained. We have at least one exception, so
 					// set up a loop to make sure we let the user know about all of them
 					// if there happens to be more than one.
-					if (logger.isDebugEnabled()) {
-						logger.debug("SQL Exception closing connection: "
-									 + sqle.getLocalizedMessage());
-					}
+					logger.debug("SQL Exception closing connection: {}", sqle.getLocalizedMessage());
 				} catch (Exception e) {
-					if (logger.isDebugEnabled()) {
-						logger.debug("Exception closing connection", e);
-					}
+					logger.debug("Exception closing connection", e);
 				}
 			}
 		}
@@ -587,7 +576,7 @@ public class ReportDocumentModelHandler extends NuxeoDocumentModelHandler<Report
 				result = JDBCTools.getConnection(JDBCTools.NUXEO_READER_DATASOURCE_NAME, databaseName);
 			}
 		} catch (Exception e) {
-			Log.error(e);
+			logger.error("Error getting database connection", e);
 			throw new NamingException();
 		}
 

--- a/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
+++ b/services/report/service/src/main/java/org/collectionspace/services/report/nuxeo/ReportDocumentModelHandler.java
@@ -503,7 +503,7 @@ public class ReportDocumentModelHandler extends NuxeoDocumentModelHandler<Report
 			logger.error("FileNotFoundException: {}", fnfe.getLocalizedMessage());
 			Response response = Response.status(
 				Response.Status.INTERNAL_SERVER_ERROR).entity(
-				"Invoke failed (SQL problem) on Report csid=" + reportCSID).type("text/plain").build();
+				"Invoke failed (FileNotFound) on Report csid=" + reportCSID).type("text/plain").build();
 			throw new CSWebApplicationException(fnfe, response);
 		}
 	}


### PR DESCRIPTION
**What does this do?**
* Add xlsx configuration to jasper exporter
* Remove xlsx configuration properties from reports
* Refactor jasper exporter configuration to use newer exporters
* Update various logging messages to be more clear
* Wrap connection in try with resources
* Fix typos and some whitespace formatting

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1451

This is a follow up on testing exporting reports as xlsx files in order to display thumbnails. Instead of adding the headers to each individual report, we're adding them to the config directly and using that with the xlsx exporter. The headers have been removed from reports which previously had them as they're no longer necessary. I left the two `exclude` headers in, which from my testing didn't seem to change the report output.

I also did a bit of refactoring, mostly in the creation of the `Exporter` object. When changing from the parameter based config, the ExporterOutput had to match what each exporter expected. The easiest way to do this was to not use the generic `Exporter`, but each specific exporter which has the correct output type.

Other minor refactoring changes were just updating to try-with-resources and fixing some typos. I was considering doing more but didn't want to create too large of a PR.

**How should this be tested? Do these changes have associated tests?**
* Rebuild and start collectionspace
* Create a few Collection Objects
* Create a few Media Handling records associated to the CollectionObjects
* Search for CollectionObjects in order to run the `Basic Object with Current Location` report
* Run the report with xlsx output (should be default now)
* Check the spreadsheet is formatted correctly and displays thumbnails

**Dependencies for merging? Releasing to production?**
I think there could still be better error handling done here if we wanted to have more granular logging of what exactly failed. e.g. all the jasper errors get logged the same but could be differentiated (though the stack trace will at least do that).

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally using the `Basic Object with Current Location` report