### PR TITLE
DRYD-1516: Install public browser front-end along with UI.

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -29,8 +29,15 @@ cspace.ui.package.name=cspace-ui
 cspace.ui.library.name=cspaceUI
 cspace.ui.version=9.0.1
 cspace.ui.build.branch=master
-cspace.ui.build.node.ver=14
+cspace.ui.build.node.ver=20
 service.ui.library.name=${cspace.ui.library.name}-service
+
+# Public browser settings
+cspace.public.browser.package.name=@collectionspace/cspace-public-browser
+cspace.public.browser.library.name=cspacePublicBrowser
+cspace.public.browser.version=3.1.0
+cspace.public.browser.build.branch=master
+cspace.public.browser.build.node.ver=20
 
 #nuxeo
 nuxeo.release=9.10-HF30

--- a/cspace-ui/anthro/WEB-INF/web.xml
+++ b/cspace-ui/anthro/WEB-INF/web.xml
@@ -8,6 +8,20 @@
                 <filter-name>FallbackResourceFilter</filter-name>
                 <url-pattern>/*</url-pattern>
         </filter-mapping>
+
+        <filter>
+                <filter-name>PublicBrowserFallbackResourceFilter</filter-name>
+                <filter-class>org.collectionspace.services.common.filter.FallbackResourceFilter</filter-class>
+                <init-param>
+                        <param-name>file</param-name>
+                        <param-value>/public/index.jsp</param-value>
+                </init-param>
+        </filter>
+        <filter-mapping>
+                <filter-name>PublicBrowserFallbackResourceFilter</filter-name>
+                <url-pattern>/public/*</url-pattern>
+        </filter-mapping>
+
         <filter>
                 <filter-name>ExpiresFilter</filter-name>
                 <filter-class>org.apache.catalina.filters.ExpiresFilter</filter-class>

--- a/cspace-ui/anthro/build.properties
+++ b/cspace-ui/anthro/build.properties
@@ -5,3 +5,6 @@ tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-anthro
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileAnthro
 tenant.ui.profile.plugin.version=8.0.0
 tenant.ui.profile.plugin.build.branch=master
+
+# If not set, defaults to /gateway/${tenant.shortname} on the current host.
+# tenant.public.browser.gateway.url=https://core.dev.collectionspace.org/gateway/${tenant.shortname}

--- a/cspace-ui/anthro/public/index.jsp
+++ b/cspace-ui/anthro/public/index.jsp
@@ -1,0 +1,22 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%! String configuredGatewayUrl = "@GATEWAY_URL@"; %>
+<html>
+	<head>
+		<meta charset="UTF-8" />
+	</head>
+	<body>
+		<div id="cspace-browser"></div>
+    <script src="/cspace-ui/@PUBLIC_BROWSER_FILENAME@"></script>
+    <script>
+      cspacePublicBrowser({
+        basename: '@BASENAME@/public',
+        baseConfig: '@TENANT_SHORTNAME@',
+        gatewayUrl: '<%=
+          configuredGatewayUrl.length() > 0
+            ? configuredGatewayUrl
+            : request.getRequestURL().substring(0, request.getRequestURL().length() - request.getRequestURI().length()) + "/gateway/@TENANT_SHORTNAME@"
+        %>',
+      });
+    </script>
+	</body>
+</html>

--- a/cspace-ui/bonsai/WEB-INF/web.xml
+++ b/cspace-ui/bonsai/WEB-INF/web.xml
@@ -8,6 +8,20 @@
                 <filter-name>FallbackResourceFilter</filter-name>
                 <url-pattern>/*</url-pattern>
         </filter-mapping>
+
+        <filter>
+                <filter-name>PublicBrowserFallbackResourceFilter</filter-name>
+                <filter-class>org.collectionspace.services.common.filter.FallbackResourceFilter</filter-class>
+                <init-param>
+                        <param-name>file</param-name>
+                        <param-value>/public/index.jsp</param-value>
+                </init-param>
+        </filter>
+        <filter-mapping>
+                <filter-name>PublicBrowserFallbackResourceFilter</filter-name>
+                <url-pattern>/public/*</url-pattern>
+        </filter-mapping>
+
         <filter>
                 <filter-name>ExpiresFilter</filter-name>
                 <filter-class>org.apache.catalina.filters.ExpiresFilter</filter-class>

--- a/cspace-ui/bonsai/build.properties
+++ b/cspace-ui/bonsai/build.properties
@@ -5,3 +5,6 @@ tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-bonsai
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileBonsai
 tenant.ui.profile.plugin.version=6.0.0
 tenant.ui.profile.plugin.build.branch=master
+
+# If not set, defaults to /gateway/${tenant.shortname} on the current host.
+# tenant.public.browser.gateway.url=https://core.dev.collectionspace.org/gateway/${tenant.shortname}

--- a/cspace-ui/bonsai/public/index.jsp
+++ b/cspace-ui/bonsai/public/index.jsp
@@ -1,0 +1,22 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%! String configuredGatewayUrl = "@GATEWAY_URL@"; %>
+<html>
+	<head>
+		<meta charset="UTF-8" />
+	</head>
+	<body>
+		<div id="cspace-browser"></div>
+    <script src="/cspace-ui/@PUBLIC_BROWSER_FILENAME@"></script>
+    <script>
+      cspacePublicBrowser({
+        basename: '@BASENAME@/public',
+        baseConfig: '@TENANT_SHORTNAME@',
+        gatewayUrl: '<%=
+          configuredGatewayUrl.length() > 0
+            ? configuredGatewayUrl
+            : request.getRequestURL().substring(0, request.getRequestURL().length() - request.getRequestURI().length()) + "/gateway/@TENANT_SHORTNAME@"
+        %>',
+      });
+    </script>
+	</body>
+</html>

--- a/cspace-ui/botgarden/WEB-INF/web.xml
+++ b/cspace-ui/botgarden/WEB-INF/web.xml
@@ -8,6 +8,20 @@
                 <filter-name>FallbackResourceFilter</filter-name>
                 <url-pattern>/*</url-pattern>
         </filter-mapping>
+
+        <filter>
+                <filter-name>PublicBrowserFallbackResourceFilter</filter-name>
+                <filter-class>org.collectionspace.services.common.filter.FallbackResourceFilter</filter-class>
+                <init-param>
+                        <param-name>file</param-name>
+                        <param-value>/public/index.jsp</param-value>
+                </init-param>
+        </filter>
+        <filter-mapping>
+                <filter-name>PublicBrowserFallbackResourceFilter</filter-name>
+                <url-pattern>/public/*</url-pattern>
+        </filter-mapping>
+
         <filter>
                 <filter-name>ExpiresFilter</filter-name>
                 <filter-class>org.apache.catalina.filters.ExpiresFilter</filter-class>

--- a/cspace-ui/botgarden/build.properties
+++ b/cspace-ui/botgarden/build.properties
@@ -5,3 +5,6 @@ tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-botgarden
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileBotGarden
 tenant.ui.profile.plugin.version=3.1.1
 tenant.ui.profile.plugin.build.branch=master
+
+# If not set, defaults to /gateway/${tenant.shortname} on the current host.
+# tenant.public.browser.gateway.url=https://core.dev.collectionspace.org/gateway/${tenant.shortname}

--- a/cspace-ui/botgarden/public/index.jsp
+++ b/cspace-ui/botgarden/public/index.jsp
@@ -1,0 +1,22 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%! String configuredGatewayUrl = "@GATEWAY_URL@"; %>
+<html>
+	<head>
+		<meta charset="UTF-8" />
+	</head>
+	<body>
+		<div id="cspace-browser"></div>
+    <script src="/cspace-ui/@PUBLIC_BROWSER_FILENAME@"></script>
+    <script>
+      cspacePublicBrowser({
+        basename: '@BASENAME@/public',
+        baseConfig: '@TENANT_SHORTNAME@',
+        gatewayUrl: '<%=
+          configuredGatewayUrl.length() > 0
+            ? configuredGatewayUrl
+            : request.getRequestURL().substring(0, request.getRequestURL().length() - request.getRequestURI().length()) + "/gateway/@TENANT_SHORTNAME@"
+        %>',
+      });
+    </script>
+	</body>
+</html>

--- a/cspace-ui/build.xml
+++ b/cspace-ui/build.xml
@@ -29,6 +29,7 @@
 	<property environment="env" />
 	<property file="${services.trunk}/build.properties" />
 	<propertycopy name="cspace.ui.build" from="env.CSPACE_UI_BUILD" />
+	<propertycopy name="cspace.public.browser.build" from="env.CSPACE_UI_BUILD" />
 
 	<target name="clean">
 		<delete includeEmptyDirs="true">
@@ -51,14 +52,14 @@
 		</exec>
 	</target>
 
-	<target name="install_node" depends="install_nvm" if="${cspace.ui.build}">
+	<target name="install_cspace_ui_node" depends="install_nvm" if="${cspace.ui.build}">
 		<exec executable="bash" failonerror="true">
 			<arg value="-c" />
 			<arg value='source "$HOME/.nvm/nvm.sh" &amp;&amp; nvm install ${cspace.ui.build.node.ver} &amp;&amp; nvm use ${cspace.ui.build.node.ver} &amp;&amp; nvm install-latest-npm' />
 		</exec>
 	</target>
 
-	<target name="build_cspace_ui_js" depends="ensure_staging_dir,ensure_source_dir,install_node" if="${cspace.ui.build}">
+	<target name="build_cspace_ui_js" depends="ensure_staging_dir,ensure_source_dir,install_cspace_ui_node" if="${cspace.ui.build}">
 		<exec executable="bash" failonerror="true">
 			<arg value="-c" />
 			<arg value="./build_js.sh ${cspace.ui.package.name} ${cspace.ui.build.branch} ${source.dir} ${staging.dir} ${cspace.ui.library.name} ${service.ui.library.name}"/>
@@ -67,13 +68,7 @@
 
 	<target name="download_cspace_ui_js" depends="ensure_staging_dir" unless="${cspace.ui.build}">
 		<exec executable="curl" failonerror="true">
-			<arg line="-o ${staging.dir}/${cspace.ui.library.name}@${cspace.ui.version}.min.js --fail --insecure --location https://cdn.jsdelivr.net/npm/cspace-ui@${cspace.ui.version}/dist/${cspace.ui.library.name}.min.js"/>
-		</exec>
-	</target>
-
-	<target name="download_service_ui_js" depends="ensure_staging_dir" unless="${cspace.ui.build}">
-		<exec executable="curl" failonerror="true">
-			<arg line="-o ${staging.dir}/${service.ui.library.name}@${cspace.ui.version}.min.js --fail --insecure --location https://cdn.jsdelivr.net/npm/cspace-ui@${cspace.ui.version}/dist/${service.ui.library.name}.min.js"/>
+			<arg line="-o ${staging.dir}/${cspace.ui.library.name}@${cspace.ui.version}.min.js --fail --insecure --location https://cdn.jsdelivr.net/npm/${cspace.ui.package.name}@${cspace.ui.version}/dist/${cspace.ui.library.name}.min.js"/>
 		</exec>
 	</target>
 
@@ -89,6 +84,12 @@
 		<copy file="${staging.dir}/${cspace.ui.install.filename}" todir="${jee.deploy.cspace.ui.shared}" />
 	</target>
 
+	<target name="download_service_ui_js" depends="ensure_staging_dir" unless="${cspace.ui.build}">
+		<exec executable="curl" failonerror="true">
+			<arg line="-o ${staging.dir}/${service.ui.library.name}@${cspace.ui.version}.min.js --fail --insecure --location https://cdn.jsdelivr.net/npm/${cspace.ui.package.name}@${cspace.ui.version}/dist/${service.ui.library.name}.min.js"/>
+		</exec>
+	</target>
+
 	<target name="deploy_service_ui_js" depends="build_cspace_ui_js,download_service_ui_js">
 		<pathconvert property="service.ui.install.filename" targetos="unix">
 			<first>
@@ -101,7 +102,39 @@
 		<copy file="${staging.dir}/${service.ui.install.filename}" todir="${jee.deploy.cspace.ui.shared}" />
 	</target>
 
-	<target name="deploy_tenants" depends="deploy_cspace_ui_js">
+	<target name="install_cspace_public_browser_node" depends="install_nvm" if="${cspace.public.browser.build}">
+		<exec executable="bash" failonerror="true">
+			<arg value="-c" />
+			<arg value='source "$HOME/.nvm/nvm.sh" &amp;&amp; nvm install ${cspace.public.browser.build.node.ver} &amp;&amp; nvm use ${cspace.public.browser.build.node.ver} &amp;&amp; nvm install-latest-npm' />
+		</exec>
+	</target>
+
+	<target name="build_cspace_public_browser_js" depends="ensure_staging_dir,ensure_source_dir,install_cspace_public_browser_node" if="${cspace.public.browser.build}">
+		<exec executable="bash" failonerror="true">
+			<arg value="-c" />
+			<arg value="./build_js.sh ${cspace.public.browser.package.name} ${cspace.public.browser.build.branch} ${source.dir} ${staging.dir} ${cspace.public.browser.library.name}"/>
+		</exec>
+	</target>
+
+	<target name="download_cspace_public_browser_js" depends="ensure_staging_dir" unless="${cspace.public.browser.build}">
+		<exec executable="curl" failonerror="true">
+			<arg line="-o ${staging.dir}/${cspace.public.browser.library.name}@${cspace.public.browser.version}.min.js --fail --insecure --location https://cdn.jsdelivr.net/npm/${cspace.public.browser.package.name}@${cspace.public.browser.version}/dist/${cspace.public.browser.library.name}.min.js"/>
+		</exec>
+	</target>
+
+	<target name="deploy_cspace_public_browser_js" depends="build_cspace_public_browser_js,download_cspace_public_browser_js">
+		<pathconvert property="cspace.public.browser.install.filename" targetos="unix">
+			<first>
+				<fileset dir="${staging.dir}" includes="${cspace.public.browser.library.name}@*.min.js" />
+			</first>
+
+			<mapper type="flatten" />
+		</pathconvert>
+
+		<copy file="${staging.dir}/${cspace.public.browser.install.filename}" todir="${jee.deploy.cspace.ui.shared}" />
+	</target>
+
+	<target name="deploy_tenants" depends="deploy_cspace_ui_js,deploy_cspace_public_browser_js">
 		<subant target="deploy_tenant" genericantfile="${ant.file}" inheritall="true">
 			<dirset dir="." includes="*" excludes="${build.dir.name}" />
 		</subant>
@@ -155,7 +188,7 @@
 		</condition>
 	</target>
 
-	<target name="build_tenant_js" depends="check_build_tenant_js,ensure_staging_dir,ensure_source_dir,install_node" if="should.build.tenant.js">
+	<target name="build_tenant_js" depends="check_build_tenant_js,ensure_staging_dir,ensure_source_dir,install_cspace_ui_node" if="should.build.tenant.js">
 		<fail message="Build branch not found for ${tenant.shortname}. Set the tenant.ui.profile.plugin.build.branch property in ${basedir}/build.properties.">
 			<condition>
 				<not>
@@ -199,11 +232,17 @@
 	</target>
 
 	<target name="deploy_tenant_webapp" depends="deploy_tenant_js" unless="${tenant.create.disabled}">
+		<!-- Default values, in case these weren't set in the tenant's build.properties. -->
+		<property name="tenant.public.browser.gateway.url" value="" />
+
 		<filter token="UI_FILENAME" value="${cspace.ui.install.filename}" />
 		<filter token="UI_PROFILE_PLUGIN_FILENAME" value="${tenant.ui.profile.plugin.install.filename}" />
 		<filter token="UI_PROFILE_PLUGIN_LIBRARY_NAME" value="${tenant.ui.profile.plugin.library.name}" />
 		<filter token="BASENAME" value="${tenant.ui.basename}" />
+		<filter token="PUBLIC_BROWSER_FILENAME" value="${cspace.public.browser.install.filename}" />
+		<filter token="GATEWAY_URL" value="${tenant.public.browser.gateway.url}" />
 		<filter token="TENANT_ID" value="${resolved.tenant.id}" />
+		<filter token="TENANT_SHORTNAME" value="${tenant.shortname}" />
 
 		<copy todir="${jee.deploy.cspace}/${tenant.ui.webapp.dir}" failonerror="false" filtering="true" overwrite="true">
 			<fileset dir="${basedir}">

--- a/cspace-ui/build_js.sh
+++ b/cspace-ui/build_js.sh
@@ -7,12 +7,13 @@ OUTPUT_DIR=$4
 LIBRARY_NAME=$5
 SERVICE_LIBRARY_NAME=$6
 
-CODE_DIR=$CHECKOUT_DIR/$PACKAGE_NAME.js
+UNORG_PACKAGE_NAME=`echo $PACKAGE_NAME | sed -e 's/^@.*\///'`
+CODE_DIR=$CHECKOUT_DIR/$UNORG_PACKAGE_NAME.js
 
 . "$HOME/.nvm/nvm.sh"
 
 rm -r $CODE_DIR
-git clone --branch $BRANCH_NAME --depth 1 https://github.com/collectionspace/$PACKAGE_NAME.js.git $CODE_DIR
+git clone --branch $BRANCH_NAME --depth 1 https://github.com/collectionspace/$UNORG_PACKAGE_NAME.js.git $CODE_DIR
 
 pushd $CODE_DIR
 COMMIT_HASH=`git rev-parse --short HEAD`

--- a/cspace-ui/core/WEB-INF/web.xml
+++ b/cspace-ui/core/WEB-INF/web.xml
@@ -8,6 +8,20 @@
                 <filter-name>FallbackResourceFilter</filter-name>
                 <url-pattern>/*</url-pattern>
         </filter-mapping>
+
+        <filter>
+                <filter-name>PublicBrowserFallbackResourceFilter</filter-name>
+                <filter-class>org.collectionspace.services.common.filter.FallbackResourceFilter</filter-class>
+                <init-param>
+                        <param-name>file</param-name>
+                        <param-value>/public/index.jsp</param-value>
+                </init-param>
+        </filter>
+        <filter-mapping>
+                <filter-name>PublicBrowserFallbackResourceFilter</filter-name>
+                <url-pattern>/public/*</url-pattern>
+        </filter-mapping>
+
         <filter>
                 <filter-name>ExpiresFilter</filter-name>
                 <filter-class>org.apache.catalina.filters.ExpiresFilter</filter-class>

--- a/cspace-ui/core/build.properties
+++ b/cspace-ui/core/build.properties
@@ -1,2 +1,5 @@
 tenant.ui.webapp.dir=cspace#${tenant.shortname}
 tenant.ui.basename=/cspace/${tenant.shortname}
+
+# If not set, defaults to /gateway/${tenant.shortname} on the current host.
+# tenant.public.browser.gateway.url=https://core.dev.collectionspace.org/gateway/${tenant.shortname}

--- a/cspace-ui/core/public/index.jsp
+++ b/cspace-ui/core/public/index.jsp
@@ -1,0 +1,21 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%! String configuredGatewayUrl = "@GATEWAY_URL@"; %>
+<html>
+	<head>
+		<meta charset="UTF-8" />
+	</head>
+	<body>
+		<div id="cspace-browser"></div>
+    <script src="/cspace-ui/@PUBLIC_BROWSER_FILENAME@"></script>
+    <script>
+      cspacePublicBrowser({
+        basename: '@BASENAME@/public',
+        gatewayUrl: '<%=
+          configuredGatewayUrl.length() > 0
+            ? configuredGatewayUrl
+            : request.getRequestURL().substring(0, request.getRequestURL().length() - request.getRequestURI().length()) + "/gateway/@TENANT_SHORTNAME@"
+        %>',
+      });
+    </script>
+	</body>
+</html>

--- a/cspace-ui/fcart/WEB-INF/web.xml
+++ b/cspace-ui/fcart/WEB-INF/web.xml
@@ -8,6 +8,20 @@
                 <filter-name>FallbackResourceFilter</filter-name>
                 <url-pattern>/*</url-pattern>
         </filter-mapping>
+
+        <filter>
+                <filter-name>PublicBrowserFallbackResourceFilter</filter-name>
+                <filter-class>org.collectionspace.services.common.filter.FallbackResourceFilter</filter-class>
+                <init-param>
+                        <param-name>file</param-name>
+                        <param-value>/public/index.jsp</param-value>
+                </init-param>
+        </filter>
+        <filter-mapping>
+                <filter-name>PublicBrowserFallbackResourceFilter</filter-name>
+                <url-pattern>/public/*</url-pattern>
+        </filter-mapping>
+
         <filter>
                 <filter-name>ExpiresFilter</filter-name>
                 <filter-class>org.apache.catalina.filters.ExpiresFilter</filter-class>

--- a/cspace-ui/fcart/build.properties
+++ b/cspace-ui/fcart/build.properties
@@ -5,3 +5,6 @@ tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-fcart
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileFCart
 tenant.ui.profile.plugin.version=7.0.0
 tenant.ui.profile.plugin.build.branch=master
+
+# If not set, defaults to /gateway/${tenant.shortname} on the current host.
+# tenant.public.browser.gateway.url=https://core.dev.collectionspace.org/gateway/${tenant.shortname}

--- a/cspace-ui/fcart/public/index.jsp
+++ b/cspace-ui/fcart/public/index.jsp
@@ -1,0 +1,22 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%! String configuredGatewayUrl = "@GATEWAY_URL@"; %>
+<html>
+	<head>
+		<meta charset="UTF-8" />
+	</head>
+	<body>
+		<div id="cspace-browser"></div>
+    <script src="/cspace-ui/@PUBLIC_BROWSER_FILENAME@"></script>
+    <script>
+      cspacePublicBrowser({
+        basename: '@BASENAME@/public',
+        baseConfig: '@TENANT_SHORTNAME@',
+        gatewayUrl: '<%=
+          configuredGatewayUrl.length() > 0
+            ? configuredGatewayUrl
+            : request.getRequestURL().substring(0, request.getRequestURL().length() - request.getRequestURI().length()) + "/gateway/@TENANT_SHORTNAME@"
+        %>',
+      });
+    </script>
+	</body>
+</html>

--- a/cspace-ui/herbarium/WEB-INF/web.xml
+++ b/cspace-ui/herbarium/WEB-INF/web.xml
@@ -8,6 +8,20 @@
                 <filter-name>FallbackResourceFilter</filter-name>
                 <url-pattern>/*</url-pattern>
         </filter-mapping>
+
+        <filter>
+                <filter-name>PublicBrowserFallbackResourceFilter</filter-name>
+                <filter-class>org.collectionspace.services.common.filter.FallbackResourceFilter</filter-class>
+                <init-param>
+                        <param-name>file</param-name>
+                        <param-value>/public/index.jsp</param-value>
+                </init-param>
+        </filter>
+        <filter-mapping>
+                <filter-name>PublicBrowserFallbackResourceFilter</filter-name>
+                <url-pattern>/public/*</url-pattern>
+        </filter-mapping>
+
         <filter>
                 <filter-name>ExpiresFilter</filter-name>
                 <filter-class>org.apache.catalina.filters.ExpiresFilter</filter-class>

--- a/cspace-ui/herbarium/build.properties
+++ b/cspace-ui/herbarium/build.properties
@@ -5,3 +5,6 @@ tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-herbarium
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileHerbarium
 tenant.ui.profile.plugin.version=2.0.12
 tenant.ui.profile.plugin.build.branch=master
+
+# If not set, defaults to /gateway/${tenant.shortname} on the current host.
+# tenant.public.browser.gateway.url=https://core.dev.collectionspace.org/gateway/${tenant.shortname}

--- a/cspace-ui/herbarium/public/index.jsp
+++ b/cspace-ui/herbarium/public/index.jsp
@@ -1,0 +1,22 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%! String configuredGatewayUrl = "@GATEWAY_URL@"; %>
+<html>
+	<head>
+		<meta charset="UTF-8" />
+	</head>
+	<body>
+		<div id="cspace-browser"></div>
+    <script src="/cspace-ui/@PUBLIC_BROWSER_FILENAME@"></script>
+    <script>
+      cspacePublicBrowser({
+        basename: '@BASENAME@/public',
+        baseConfig: '@TENANT_SHORTNAME@',
+        gatewayUrl: '<%=
+          configuredGatewayUrl.length() > 0
+            ? configuredGatewayUrl
+            : request.getRequestURL().substring(0, request.getRequestURL().length() - request.getRequestURI().length()) + "/gateway/@TENANT_SHORTNAME@"
+        %>',
+      });
+    </script>
+	</body>
+</html>

--- a/cspace-ui/lhmc/WEB-INF/web.xml
+++ b/cspace-ui/lhmc/WEB-INF/web.xml
@@ -8,6 +8,20 @@
                 <filter-name>FallbackResourceFilter</filter-name>
                 <url-pattern>/*</url-pattern>
         </filter-mapping>
+
+        <filter>
+                <filter-name>PublicBrowserFallbackResourceFilter</filter-name>
+                <filter-class>org.collectionspace.services.common.filter.FallbackResourceFilter</filter-class>
+                <init-param>
+                        <param-name>file</param-name>
+                        <param-value>/public/index.jsp</param-value>
+                </init-param>
+        </filter>
+        <filter-mapping>
+                <filter-name>PublicBrowserFallbackResourceFilter</filter-name>
+                <url-pattern>/public/*</url-pattern>
+        </filter-mapping>
+
         <filter>
                 <filter-name>ExpiresFilter</filter-name>
                 <filter-class>org.apache.catalina.filters.ExpiresFilter</filter-class>

--- a/cspace-ui/lhmc/build.properties
+++ b/cspace-ui/lhmc/build.properties
@@ -5,3 +5,6 @@ tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-lhmc
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileLHMC
 tenant.ui.profile.plugin.version=7.0.0
 tenant.ui.profile.plugin.build.branch=master
+
+# If not set, defaults to /gateway/${tenant.shortname} on the current host.
+# tenant.public.browser.gateway.url=https://core.dev.collectionspace.org/gateway/${tenant.shortname}

--- a/cspace-ui/lhmc/public/index.jsp
+++ b/cspace-ui/lhmc/public/index.jsp
@@ -1,0 +1,22 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%! String configuredGatewayUrl = "@GATEWAY_URL@"; %>
+<html>
+	<head>
+		<meta charset="UTF-8" />
+	</head>
+	<body>
+		<div id="cspace-browser"></div>
+    <script src="/cspace-ui/@PUBLIC_BROWSER_FILENAME@"></script>
+    <script>
+      cspacePublicBrowser({
+        basename: '@BASENAME@/public',
+        baseConfig: '@TENANT_SHORTNAME@',
+        gatewayUrl: '<%=
+          configuredGatewayUrl.length() > 0
+            ? configuredGatewayUrl
+            : request.getRequestURL().substring(0, request.getRequestURL().length() - request.getRequestURI().length()) + "/gateway/@TENANT_SHORTNAME@"
+        %>',
+      });
+    </script>
+	</body>
+</html>

--- a/cspace-ui/materials/WEB-INF/web.xml
+++ b/cspace-ui/materials/WEB-INF/web.xml
@@ -8,6 +8,20 @@
                 <filter-name>FallbackResourceFilter</filter-name>
                 <url-pattern>/*</url-pattern>
         </filter-mapping>
+
+        <filter>
+                <filter-name>PublicBrowserFallbackResourceFilter</filter-name>
+                <filter-class>org.collectionspace.services.common.filter.FallbackResourceFilter</filter-class>
+                <init-param>
+                        <param-name>file</param-name>
+                        <param-value>/public/index.jsp</param-value>
+                </init-param>
+        </filter>
+        <filter-mapping>
+                <filter-name>PublicBrowserFallbackResourceFilter</filter-name>
+                <url-pattern>/public/*</url-pattern>
+        </filter-mapping>
+
         <filter>
                 <filter-name>ExpiresFilter</filter-name>
                 <filter-class>org.apache.catalina.filters.ExpiresFilter</filter-class>

--- a/cspace-ui/materials/build.properties
+++ b/cspace-ui/materials/build.properties
@@ -5,3 +5,6 @@ tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-materials
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileMaterials
 tenant.ui.profile.plugin.version=4.0.0
 tenant.ui.profile.plugin.build.branch=master
+
+# If not set, defaults to /gateway/${tenant.shortname} on the current host.
+# tenant.public.browser.gateway.url=https://core.dev.collectionspace.org/gateway/${tenant.shortname}

--- a/cspace-ui/materials/public/index.jsp
+++ b/cspace-ui/materials/public/index.jsp
@@ -1,0 +1,22 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%! String configuredGatewayUrl = "@GATEWAY_URL@"; %>
+<html>
+	<head>
+		<meta charset="UTF-8" />
+	</head>
+	<body>
+		<div id="cspace-browser"></div>
+    <script src="/cspace-ui/@PUBLIC_BROWSER_FILENAME@"></script>
+    <script>
+      cspacePublicBrowser({
+        basename: '@BASENAME@/public',
+        baseConfig: '@TENANT_SHORTNAME@',
+        gatewayUrl: '<%=
+          configuredGatewayUrl.length() > 0
+            ? configuredGatewayUrl
+            : request.getRequestURL().substring(0, request.getRequestURL().length() - request.getRequestURI().length()) + "/gateway/@TENANT_SHORTNAME@"
+        %>',
+      });
+    </script>
+	</body>
+</html>

--- a/cspace-ui/publicart/WEB-INF/web.xml
+++ b/cspace-ui/publicart/WEB-INF/web.xml
@@ -8,6 +8,20 @@
                 <filter-name>FallbackResourceFilter</filter-name>
                 <url-pattern>/*</url-pattern>
         </filter-mapping>
+
+        <filter>
+                <filter-name>PublicBrowserFallbackResourceFilter</filter-name>
+                <filter-class>org.collectionspace.services.common.filter.FallbackResourceFilter</filter-class>
+                <init-param>
+                        <param-name>file</param-name>
+                        <param-value>/public/index.jsp</param-value>
+                </init-param>
+        </filter>
+        <filter-mapping>
+                <filter-name>PublicBrowserFallbackResourceFilter</filter-name>
+                <url-pattern>/public/*</url-pattern>
+        </filter-mapping>
+
         <filter>
                 <filter-name>ExpiresFilter</filter-name>
                 <filter-class>org.apache.catalina.filters.ExpiresFilter</filter-class>

--- a/cspace-ui/publicart/build.properties
+++ b/cspace-ui/publicart/build.properties
@@ -5,3 +5,6 @@ tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-publicart
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfilePublicArt
 tenant.ui.profile.plugin.version=6.0.0
 tenant.ui.profile.plugin.build.branch=master
+
+# If not set, defaults to /gateway/${tenant.shortname} on the current host.
+# tenant.public.browser.gateway.url=https://core.dev.collectionspace.org/gateway/${tenant.shortname}

--- a/cspace-ui/publicart/public/index.jsp
+++ b/cspace-ui/publicart/public/index.jsp
@@ -1,0 +1,22 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%! String configuredGatewayUrl = "@GATEWAY_URL@"; %>
+<html>
+	<head>
+		<meta charset="UTF-8" />
+	</head>
+	<body>
+		<div id="cspace-browser"></div>
+    <script src="/cspace-ui/@PUBLIC_BROWSER_FILENAME@"></script>
+    <script>
+      cspacePublicBrowser({
+        basename: '@BASENAME@/public',
+        baseConfig: '@TENANT_SHORTNAME@',
+        gatewayUrl: '<%=
+          configuredGatewayUrl.length() > 0
+            ? configuredGatewayUrl
+            : request.getRequestURL().substring(0, request.getRequestURL().length() - request.getRequestURI().length()) + "/gateway/@TENANT_SHORTNAME@"
+        %>',
+      });
+    </script>
+	</body>
+</html>


### PR DESCRIPTION
**What does this do?**

This adds deployment scripts to deploy the public browser front-end alongside the staff UI for each tenant. Like the staff UI, the public browser front-end can optionally be built from source, rather than pulling a pre-built release from npm. This is controlled by setting the environment variable `CSPACE_UI_BUILD` to `true`.

Once deployed via `ant deploy`, public browsers are available at `/cspace/{tenant short name}/public`. By default, the gateway is expected to be located at the same scheme, host, and port as the public browser front end, at the path `/gateway/{tenant short name}`. If a different gateway URL is required, it can be set by modifying the ant property `tenant.public.browser.gateway.url` in the file `cspace-ui/{tenant short name}/build.properties`.

This PR does not install the public gateway. That still must be done separately. A future PR will install the public gateway servlet along with the services.

**Why are we doing this? (with JIRA link)**

Multi-tenant deployments, e.g. Lyrasis' development, demo, and qa servers, need to have public browsers available for testing.

JIRA: https://collectionspace.atlassian.net/browse/DRYD-1516

**How should this be tested? Do these changes have associated tests?**

- Deploy the services using `ant deploy`
- Start CollectionSpace
- In a browser, visit `/cspace/{tenant short name}/public/search` for various tenants. A public browser should appear.

**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

I will add developer documentation, probably as a readme in the cspace-ui directory.

**Did someone actually run this code to verify it works?**

@ray-lee tested locally.