### PR TITLE
DRYD-1355: Deaccession Service

### DIFF
--- a/services/JaxRsServiceProvider/pom.xml
+++ b/services/JaxRsServiceProvider/pom.xml
@@ -451,6 +451,12 @@
             <artifactId>org.collectionspace.services.consultation.service</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+          <groupId>org.collectionspace.services</groupId>
+          <artifactId>org.collectionspace.services.deaccession.service</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+
 
       <!--dependency>
           <groupId>org.collectionspace.services</groupId>

--- a/services/JaxRsServiceProvider/src/main/java/org/collectionspace/services/jaxrs/CollectionSpaceJaxRsApplication.java
+++ b/services/JaxRsServiceProvider/src/main/java/org/collectionspace/services/jaxrs/CollectionSpaceJaxRsApplication.java
@@ -28,6 +28,7 @@ import org.collectionspace.services.blob.BlobResource;
 import org.collectionspace.services.chronology.ChronologyAuthorityResource;
 import org.collectionspace.services.collectionobject.CollectionObjectResource;
 import org.collectionspace.services.consultation.ConsultationResource;
+import org.collectionspace.services.deaccession.DeaccessionResource;
 import org.collectionspace.services.dutyofcare.DutyofcareResource;
 import org.collectionspace.services.heldintrust.HeldInTrustResource;
 import org.collectionspace.services.id.IDResource;
@@ -175,6 +176,7 @@ public class CollectionSpaceJaxRsApplication extends Application
         addResourceToMapAndSingletons(new SummaryDocumentationResource());
         addResourceToMapAndSingletons(new HeldInTrustResource());
         addResourceToMapAndSingletons(new ConsultationResource());
+        addResourceToMapAndSingletons(new DeaccessionResource());
 
         singletons.add(new IDResource());
 

--- a/services/JaxRsServiceProvider/src/main/java/org/collectionspace/services/jaxrs/CollectionSpaceJaxRsApplication.java
+++ b/services/JaxRsServiceProvider/src/main/java/org/collectionspace/services/jaxrs/CollectionSpaceJaxRsApplication.java
@@ -104,8 +104,7 @@ import org.collectionspace.services.common.security.SecurityInterceptor;
  * $LastChangedRevision$
  * $LastChangedDate$
  */
-public class CollectionSpaceJaxRsApplication extends Application
-					implements ResourceMapHolder {
+public class CollectionSpaceJaxRsApplication extends Application implements ResourceMapHolder {
 
     private Set<Object> singletons = new HashSet<Object>();
     private Set<Class<?>> empty = new HashSet<Class<?>>();
@@ -113,9 +112,9 @@ public class CollectionSpaceJaxRsApplication extends Application
     private ServletContext servletContext = null;
 
     public CollectionSpaceJaxRsApplication() {
-    	//
-    	// Instantiate all our JaxRS resources
-    	//
+        //
+        // Instantiate all our JaxRS resources
+        //
         singletons.add(new SecurityInterceptor());
 
         singletons.add(new AccountResource());

--- a/services/build.xml
+++ b/services/build.xml
@@ -211,6 +211,7 @@
         <ant antfile="citation/build.xml" target="undeploy" inheritAll="false"/>
         <ant antfile="organization/build.xml" target="undeploy" inheritAll="false"/>
         <ant antfile="person/build.xml" target="undeploy" inheritAll="false"/>
+        <ant antfile="deaccession/build.xml" target="undeploy" inheritAll="false"/>
         <ant antfile="transport/build.xml" target="undeploy" inheritAll="false"/>
         <ant antfile="uoc/build.xml" target="undeploy" inheritAll="false"/>
         <ant antfile="publicitem/build.xml" target="undeploy" inheritAll="false"/>

--- a/services/common/src/main/resources/db/postgresql/load_id_generators.sql
+++ b/services/common/src/main/resources/db/postgresql/load_id_generators.sql
@@ -1270,3 +1270,39 @@ INSERT INTO id_generators
         SELECT  csid
         FROM    id_generators
         );
+
+-- DEACCESSION_NUMBER
+
+INSERT INTO id_generators
+    (csid, displayname, description, priority, last_generated_id, id_generator_state)
+  SELECT
+     '0b508d05-67df-4b63-b4ce-7319a3029baa',
+     'Deaccession Number',
+     'Identifies a consultation document.',
+     '9',
+     '',
+'<org.collectionspace.services.id.SettableIDGenerator>
+  <parts>
+    <org.collectionspace.services.id.StringIDGeneratorPart>
+      <initialValue>DE</initialValue>
+      <currentValue>DE</currentValue>
+    </org.collectionspace.services.id.StringIDGeneratorPart>
+    <org.collectionspace.services.id.YearIDGeneratorPart>
+      <currentValue></currentValue>
+    </org.collectionspace.services.id.YearIDGeneratorPart>
+    <org.collectionspace.services.id.StringIDGeneratorPart>
+      <initialValue>.</initialValue>
+      <currentValue>.</currentValue>
+    </org.collectionspace.services.id.StringIDGeneratorPart>
+    <org.collectionspace.services.id.NumericIDGeneratorPart>
+      <maxLength>6</maxLength>
+      <initialValue>1</initialValue>
+      <currentValue>-1</currentValue>
+    </org.collectionspace.services.id.NumericIDGeneratorPart>
+  </parts>
+</org.collectionspace.services.id.SettableIDGenerator>'
+  WHERE '0b508d05-67df-4b63-b4ce-7319a3029baa' NOT IN
+        (
+        SELECT  csid
+        FROM    id_generators
+        );

--- a/services/common/src/main/resources/db/postgresql/load_id_generators.sql
+++ b/services/common/src/main/resources/db/postgresql/load_id_generators.sql
@@ -1278,7 +1278,7 @@ INSERT INTO id_generators
   SELECT
      '0b508d05-67df-4b63-b4ce-7319a3029baa',
      'Deaccession Number',
-     'Identifies a consultation document.',
+     'Identifies a deaccession document.',
      '9',
      '',
 '<org.collectionspace.services.id.SettableIDGenerator>

--- a/services/deaccession/build.xml
+++ b/services/deaccession/build.xml
@@ -10,6 +10,9 @@
   <property name="mvn.opts" value="-V" />
   <property name="src" location="src" />
 
+  <property name="nuxeo.deaccession.doctype.jars.all" value="collectionspace.deaccession.doctype.*.jar" />
+  <property name="nuxeo.deaccession.schema.jars.all" value="collectionspace.deaccession.schema.*.jar" />
+
   <condition property="osfamily-unix">
     <os family="unix" />
   </condition>
@@ -102,5 +105,18 @@
       <arg value="test" />
       <arg value="${mvn.opts}" />
     </exec>
+  </target>
+
+  <target name="undeploy"
+    description="undeploy deaccession doctype from ${jee.server.nuxeo}">
+    <delete>
+      <!-- Undeploy doctype and schema artifacts -->
+      <fileset dir="${jee.deploy.nuxeo.plugins}">
+        <include name="${nuxeo.deaccession.doctype.jars.all}" />
+      </fileset>
+      <fileset dir="${jee.deploy.nuxeo.plugins}">
+        <include name="${nuxeo.deaccession.schema.jars.all}" />
+      </fileset>
+    </delete>
   </target>
 </project>

--- a/services/deaccession/build.xml
+++ b/services/deaccession/build.xml
@@ -1,0 +1,106 @@
+<project name="deaccession" default="package" basedir=".">
+  <description>
+    deaccession service
+  </description>
+  <!-- set global properties for this build -->
+  <property name="services.trunk" value="../.." />
+  <!-- environment should be declared before reading build.properties -->
+  <property environment="env" />
+  <property file="${services.trunk}/build.properties" />
+  <property name="mvn.opts" value="-V" />
+  <property name="src" location="src" />
+
+  <condition property="osfamily-unix">
+    <os family="unix" />
+  </condition>
+  <condition property="osfamily-windows">
+    <os family="windows" />
+  </condition>
+
+  <target name="package" depends="package-unix,package-windows"
+    description="Package CollectionSpace Services" />
+
+  <target name="package-unix" if="osfamily-unix">
+    <exec executable="mvn" failonerror="true">
+      <arg value="package" />
+      <arg value="-Dmaven.test.skip=true" />
+      <arg value="-f" />
+      <arg value="${basedir}/pom.xml" />
+      <arg value="-N" />
+      <arg value="${mvn.opts}" />
+    </exec>
+  </target>
+
+  <target name="package-windows" if="osfamily-windows">
+    <exec executable="cmd" failonerror="true">
+      <arg value="/c" />
+      <arg value="mvn" />
+      <arg value="package" />
+      <arg value="-Dmaven.test.skip=true" />
+      <arg value="-f" />
+      <arg value="${basedir}/pom.xml" />
+      <arg value="-N" />
+      <arg value="${mvn.opts}" />
+    </exec>
+  </target>
+
+  <target name="install" depends="install-unix,install-windows"
+    description="Install" />
+  <target name="install-unix" if="osfamily-unix">
+    <exec executable="mvn" failonerror="true">
+      <arg value="install" />
+      <arg value="-Dmaven.test.skip=true" />
+      <arg value="-f" />
+      <arg value="${basedir}/pom.xml" />
+      <arg value="-N" />
+      <arg value="${mvn.opts}" />
+    </exec>
+  </target>
+  <target name="install-windows" if="osfamily-windows">
+    <exec executable="cmd" failonerror="true">
+      <arg value="/c" />
+      <arg value="mvn" />
+      <arg value="install" />
+      <arg value="-Dmaven.test.skip=true" />
+      <arg value="-f" />
+      <arg value="${basedir}/pom.xml" />
+      <arg value="-N" />
+      <arg value="${mvn.opts}" />
+    </exec>
+  </target>
+
+  <target name="clean" depends="clean-unix,clean-windows"
+    description="Delete target directories">
+    <delete dir="${build}" />
+  </target>
+  <target name="clean-unix" if="osfamily-unix">
+    <exec executable="mvn" failonerror="true">
+      <arg value="clean" />
+      <arg value="${mvn.opts}" />
+    </exec>
+  </target>
+  <target name="clean-windows" if="osfamily-windows">
+    <exec executable="cmd" failonerror="true">
+      <arg value="/c" />
+      <arg value="mvn" />
+      <arg value="clean" />
+      <arg value="${mvn.opts}" />
+    </exec>
+  </target>
+
+  <target name="test" depends="test-unix,test-windows" description="Run tests" />
+  <target name="test-unix" if="osfamily-unix">
+    <exec executable="mvn" failonerror="true">
+      <arg value="test" />
+      <arg value="${mvn.opts}" />
+    </exec>
+  </target>
+  <target name="test-windows" if="osfamily-windows">
+    <exec executable="cmd" failonerror="true">
+      <arg value="/c" />
+      <arg value="mvn" />
+      <arg value="test" />
+      <arg value="${mvn.opts}" />
+    </exec>
+  </target>
+</project>

--- a/services/deaccession/client/pom.xml
+++ b/services/deaccession/client/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <groupId>org.collectionspace.services</groupId>
+    <artifactId>org.collectionspace.services.deaccession</artifactId>
+    <version>${revision}</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>org.collectionspace.services.deaccession.client</artifactId>
+  <name>services.deaccession.client</name>
+
+  <dependencies>
+    <!-- CollectionSpace dependencies -->
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.authority.jaxb</artifactId>
+      <optional>true</optional>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.jaxb</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.common</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.client</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.deaccession.jaxb</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.person.client</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- External dependencies -->
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxrs</artifactId>
+      <!-- filter out unwanted jars -->
+      <exclusions>
+        <exclusion>
+          <groupId>tjws</groupId>
+          <artifactId>webserver</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxb-provider</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-multipart-provider</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-httpclient</groupId>
+      <artifactId>commons-httpclient</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>collectionspace-services-deaccession-client</finalName>
+  </build>
+</project>

--- a/services/deaccession/client/pom.xml
+++ b/services/deaccession/client/pom.xml
@@ -16,33 +16,12 @@
     <!-- CollectionSpace dependencies -->
     <dependency>
       <groupId>org.collectionspace.services</groupId>
-      <artifactId>org.collectionspace.services.authority.jaxb</artifactId>
-      <optional>true</optional>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.collectionspace.services</groupId>
-      <artifactId>org.collectionspace.services.jaxb</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.collectionspace.services</groupId>
-      <artifactId>org.collectionspace.services.common</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>org.collectionspace.services</groupId>
       <artifactId>org.collectionspace.services.client</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.collectionspace.services</groupId>
       <artifactId>org.collectionspace.services.deaccession.jaxb</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.collectionspace.services</groupId>
-      <artifactId>org.collectionspace.services.person.client</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/services/deaccession/client/src/main/java/org/collectionspace/services/client/DeaccessionClient.java
+++ b/services/deaccession/client/src/main/java/org/collectionspace/services/client/DeaccessionClient.java
@@ -48,5 +48,4 @@ public class DeaccessionClient extends AbstractCommonListPoxServiceClientImpl<De
     public Class<DeaccessionProxy> getProxyClass() {
         return DeaccessionProxy.class;
     }
-
 }

--- a/services/deaccession/client/src/main/java/org/collectionspace/services/client/DeaccessionClient.java
+++ b/services/deaccession/client/src/main/java/org/collectionspace/services/client/DeaccessionClient.java
@@ -25,7 +25,6 @@ public class DeaccessionClient extends AbstractCommonListPoxServiceClientImpl<De
     public static final String SERVICE_PATH_COMPONENT = SERVICE_NAME;
     public static final String SERVICE_PATH = "/" + SERVICE_PATH_COMPONENT;
     public static final String SERVICE_PATH_PROXY = SERVICE_PATH + "/";
-    public static final String SERVICE_PAYLOAD_NAME = SERVICE_NAME;
 
     public DeaccessionClient() throws Exception {
         super();

--- a/services/deaccession/client/src/main/java/org/collectionspace/services/client/DeaccessionClient.java
+++ b/services/deaccession/client/src/main/java/org/collectionspace/services/client/DeaccessionClient.java
@@ -1,0 +1,53 @@
+/*
+ * This document is a part of the source code and related artifacts
+ * for CollectionSpace, an open source collections management system
+ * for museums and related institutions:
+ *
+ * http://www.collectionspace.org
+ * http://wiki.collectionspace.org
+ *
+ * Licensed under the Educational Community License (ECL), Version 2.0.
+ * You may not use this file except in compliance with this License.
+ *
+ * You may obtain a copy of the ECL 2.0 License at
+ * https://source.collectionspace.org/collection-space/LICENSE.txt
+ */
+package org.collectionspace.services.client;
+
+import org.collectionspace.services.deaccession.DeaccessionsCommon;
+
+/**
+ * DeaccessionClient.java
+ */
+public class DeaccessionClient extends AbstractCommonListPoxServiceClientImpl<DeaccessionProxy, DeaccessionsCommon> {
+
+    public static final String SERVICE_NAME = "deaccessions";
+    public static final String SERVICE_PATH_COMPONENT = SERVICE_NAME;
+    public static final String SERVICE_PATH = "/" + SERVICE_PATH_COMPONENT;
+    public static final String SERVICE_PATH_PROXY = SERVICE_PATH + "/";
+    public static final String SERVICE_PAYLOAD_NAME = SERVICE_NAME;
+
+    public DeaccessionClient() throws Exception {
+        super();
+    }
+
+    public DeaccessionClient(String clientPropertiesFilename) throws Exception {
+        super(clientPropertiesFilename);
+    }
+
+    @Override
+    public String getServicePathComponent() {
+        return SERVICE_PATH_COMPONENT;
+    }
+
+    @Override
+    public String getServiceName() {
+        return SERVICE_NAME;
+    }
+
+    @Override
+    public Class<DeaccessionProxy> getProxyClass() {
+        return DeaccessionProxy.class;
+    }
+
+}

--- a/services/deaccession/client/src/main/java/org/collectionspace/services/client/DeaccessionProxy.java
+++ b/services/deaccession/client/src/main/java/org/collectionspace/services/client/DeaccessionProxy.java
@@ -24,5 +24,4 @@ import javax.ws.rs.Produces;
 @Path(DeaccessionClient.SERVICE_PATH_PROXY)
 @Produces({"application/xml"})
 @Consumes({"application/xml"})
-public interface DeaccessionProxy extends CollectionSpaceCommonListPoxProxy {
-}
+public interface DeaccessionProxy extends CollectionSpaceCommonListPoxProxy {}

--- a/services/deaccession/client/src/main/java/org/collectionspace/services/client/DeaccessionProxy.java
+++ b/services/deaccession/client/src/main/java/org/collectionspace/services/client/DeaccessionProxy.java
@@ -1,0 +1,28 @@
+/*
+ * This document is a part of the source code and related artifacts
+ * for CollectionSpace, an open source collections management system
+ * for museums and related institutions:
+ *
+ * http://www.collectionspace.org
+ * http://wiki.collectionspace.org
+ *
+ * Licensed under the Educational Community License (ECL), Version 2.0.
+ * You may not use this file except in compliance with this License.
+ *
+ * You may obtain a copy of the ECL 2.0 License at
+ * https://source.collectionspace.org/collection-space/LICENSE.txt
+ */
+package org.collectionspace.services.client;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+/**
+ * DeaccessionProxy.java
+ */
+@Path(DeaccessionClient.SERVICE_PATH_PROXY)
+@Produces({"application/xml"})
+@Consumes({"application/xml"})
+public interface DeaccessionProxy extends CollectionSpaceCommonListPoxProxy {
+}

--- a/services/deaccession/client/src/test/java/org/collectionspace/services/client/DeaccessionServiceTest.java
+++ b/services/deaccession/client/src/test/java/org/collectionspace/services/client/DeaccessionServiceTest.java
@@ -1,0 +1,492 @@
+/*
+ * This document is a part of the source code and related artifacts
+ * for CollectionSpace, an open source collections management system
+ * for museums and related institutions:
+ *
+ * http://www.collectionspace.org
+ * http://wiki.collectionspace.org
+ *
+ * Copyright © 2009 Regents of the University of California
+ *
+ * Licensed under the Educational Community License (ECL), Version 2.0.
+ * You may not use this file except in compliance with this License.
+ *
+ * You may obtain a copy of the ECL 2.0 License at
+ * https://source.collectionspace.org/collection-space/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.collectionspace.services.client;
+
+import javax.ws.rs.core.Response;
+import org.collectionspace.services.client.test.AbstractPoxServiceTestImpl;
+import org.collectionspace.services.client.test.ServiceRequestType;
+import org.collectionspace.services.deaccession.DeaccessionsCommon;
+import org.collectionspace.services.jaxb.AbstractCommonList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+
+public class DeaccessionServiceTest extends AbstractPoxServiceTestImpl<AbstractCommonList, DeaccessionsCommon> {
+
+    private final Logger logger = LoggerFactory.getLogger(DeaccessionServiceTest.class);
+
+    /** The service path component. */
+    final String SERVICE_NAME = "deaccessions";
+
+    final String SERVICE_PATH_COMPONENT = "deaccessions";
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.BaseServiceTest#getClientInstance()
+     */
+    @Override
+    protected CollectionSpaceClient getClientInstance() throws Exception {
+        return new DeaccessionClient();
+    }
+
+    @Override
+    protected CollectionSpaceClient getClientInstance(String clientPropertiesFilename) throws Exception {
+        return new DeaccessionClient(clientPropertiesFilename);
+    }
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.BaseServiceTest#getAbstractCommonList(org.jboss.resteasy.client.ClientResponse)
+     */
+    @Override
+    protected AbstractCommonList getCommonList(Response response) {
+        return response.readEntity(AbstractCommonList.class);
+    }
+
+    // ---------------------------------------------------------------
+    // CRUD tests : CREATE tests
+    // ---------------------------------------------------------------
+
+    // Success outcomes
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.ServiceTest#create(java.lang.String)
+     */
+    @Override
+    public void create(String testName) throws Exception {
+        DeaccessionClient client = new DeaccessionClient();
+
+        // Perform setup, such as initializing the type of service request
+        // (e.g. CREATE, DELETE), its valid and expected status codes, and
+        // its associated HTTP method name (e.g. POST, DELETE).
+        setupCreate();
+
+        // Submit the request to the service and store the response.
+        String newID;
+        String identifier = createIdentifier();
+        PoxPayloadOut multipart = createDeaccessionInstance(identifier);
+        Response res = client.create(multipart);
+        try {
+            int statusCode = res.getStatus();
+
+            // Check the status code of the response: does it match
+            // the expected response(s)?
+            //
+            // Specifically:
+            // Does it fall within the set of valid status codes?
+            // Does it exactly match the expected status code?
+            logger.debug("{}: status = {}", testName, statusCode);
+            Assert.assertTrue(
+                    testRequestType.isValidStatusCode(statusCode),
+                    invalidStatusCodeMessage(testRequestType, statusCode));
+            Assert.assertEquals(statusCode, testExpectedStatusCode);
+
+            newID = extractId(res);
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+
+        // Store the ID returned from the first resource created
+        // for additional tests below.
+        if (knownResourceId == null) {
+            knownResourceId = newID;
+            logger.debug("{}: knownResourceId={}", testName, knownResourceId);
+        }
+
+        // Store the IDs from every resource created by tests,
+        // so they can be deleted after tests have been run.
+        allResourceIdsCreated.add(newID);
+    }
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.AbstractServiceTestImpl#createList(java.lang.String)
+     */
+    @Override
+    public void createList(String testName) throws Exception {
+        for (int i = 0; i < 3; i++) {
+            create(testName);
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // CRUD tests : READ tests
+    // ---------------------------------------------------------------
+
+    // Success outcomes
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.AbstractServiceTestImpl#read(java.lang.String)
+     */
+    @Override
+    public void read(String testName) throws Exception {
+        // Perform setup.
+        setupRead();
+
+        // Submit the request to the service and store the response.
+        DeaccessionClient client = new DeaccessionClient();
+        Response res = client.read(knownResourceId);
+        PoxPayloadIn input;
+        try {
+            assertStatusCode(res, testName);
+            input = new PoxPayloadIn(res.readEntity(String.class));
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+
+        // Get the common part of the response and verify that it is not null.
+        PayloadInputPart payloadInputPart = input.getPart(client.getCommonPartName());
+        DeaccessionsCommon deaccessionCommon = null;
+        if (payloadInputPart != null) {
+            deaccessionCommon = (DeaccessionsCommon) payloadInputPart.getBody();
+        }
+        Assert.assertNotNull(deaccessionCommon);
+    }
+
+    // Failure outcomes
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.AbstractServiceTestImpl#readNonExistent(java.lang.String)
+     */
+    @Override
+    public void readNonExistent(String testName) throws Exception {
+        // Perform setup.
+        setupReadNonExistent();
+
+        // Submit the request to the service and store the response.
+        DeaccessionClient client = new DeaccessionClient();
+        Response res = client.read(NON_EXISTENT_ID);
+        try {
+            int statusCode = res.getStatus();
+
+            // Check the status code of the response: does it match
+            // the expected response(s)?
+            logger.debug("{}: status = {}", testName, statusCode);
+            Assert.assertTrue(
+                    testRequestType.isValidStatusCode(statusCode),
+                    invalidStatusCodeMessage(testRequestType, statusCode));
+            Assert.assertEquals(statusCode, testExpectedStatusCode);
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // CRUD tests : READ_LIST tests
+    // ---------------------------------------------------------------
+
+    // Success outcomes
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.AbstractServiceTestImpl#readList(java.lang.String)
+     */
+    @Override
+    public void readList(String testName) throws Exception {
+        // Perform setup.
+        setupReadList();
+
+        // Submit the request to the service and store the response.
+        AbstractCommonList list;
+        DeaccessionClient client = new DeaccessionClient();
+        Response res = client.readList();
+        assertStatusCode(res, testName);
+        try {
+            int statusCode = res.getStatus();
+
+            // Check the status code of the response: does it match
+            // the expected response(s)?
+            logger.debug("{}: status = {}", testName, statusCode);
+            Assert.assertTrue(
+                    testRequestType.isValidStatusCode(statusCode),
+                    invalidStatusCodeMessage(testRequestType, statusCode));
+            Assert.assertEquals(statusCode, testExpectedStatusCode);
+
+            list = res.readEntity(getCommonListType());
+        } finally {
+            res.close();
+        }
+
+        // Optionally output additional data about list members for debugging.
+        AbstractCommonListUtils.ListItemsInAbstractCommonList(list, logger, testName);
+    }
+
+    // Failure outcomes
+    // None at present.
+
+    // ---------------------------------------------------------------
+    // CRUD tests : UPDATE tests
+    // ---------------------------------------------------------------
+
+    // Success outcomes
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.AbstractServiceTestImpl#update(java.lang.String)
+     */
+    @Override
+    public void update(String testName) throws Exception {
+        // Perform setup.
+        setupRead();
+
+        // Retrieve the contents of a resource to update.
+        DeaccessionClient client = new DeaccessionClient();
+        Response res = client.read(knownResourceId);
+        PoxPayloadIn input;
+        try {
+            assertStatusCode(res, testName);
+            input = new PoxPayloadIn(res.readEntity(String.class));
+            logger.debug("got object to update with ID: {}", knownResourceId);
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+
+        // Extract the common part from the response.
+        PayloadInputPart payloadInputPart = input.getPart(client.getCommonPartName());
+        DeaccessionsCommon deaccessionCommon = null;
+        if (payloadInputPart != null) {
+            deaccessionCommon = (DeaccessionsCommon) payloadInputPart.getBody();
+        }
+        Assert.assertNotNull(deaccessionCommon);
+
+        // Update the content of this resource.
+        deaccessionCommon.setDeaccessionNote("updated-" + deaccessionCommon.getDeaccessionNumber());
+
+        logger.debug("to be updated object");
+        logger.debug(objectAsXmlString(deaccessionCommon, DeaccessionsCommon.class));
+
+        setupUpdate();
+
+        // Submit the updated common part in an update request to the service
+        // and store the response.
+        PoxPayloadOut output = new PoxPayloadOut(this.getServicePathComponent());
+        output.addPart(client.getCommonPartName(), deaccessionCommon);
+        res = client.update(knownResourceId, output);
+        try {
+            assertStatusCode(res, testName);
+            int statusCode = res.getStatus();
+            // Check the status code of the response: does it match the expected response(s)?
+            logger.debug("{}: status = {}", testName, statusCode);
+            Assert.assertTrue(
+                    testRequestType.isValidStatusCode(statusCode),
+                    invalidStatusCodeMessage(testRequestType, statusCode));
+            Assert.assertEquals(statusCode, testExpectedStatusCode);
+            input = new PoxPayloadIn(res.readEntity(String.class));
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+
+        // Extract the updated common part from the response.
+        payloadInputPart = input.getPart(client.getCommonPartName());
+        DeaccessionsCommon updatedDeaccessionCommon = null;
+        if (payloadInputPart != null) {
+            updatedDeaccessionCommon = (DeaccessionsCommon) payloadInputPart.getBody();
+        }
+        Assert.assertNotNull(updatedDeaccessionCommon);
+
+        // Check selected fields in the updated common part.
+        Assert.assertEquals(
+                updatedDeaccessionCommon.getDeaccessionNumber(),
+                deaccessionCommon.getDeaccessionNumber(),
+                "Data in updated object did not match submitted data.");
+    }
+
+    @Override
+    public void updateNonExistent(String testName) throws Exception {
+        // Perform setup.
+        setupUpdateNonExistent();
+
+        // Submit the request to the service and store the response.
+        // Note: The ID used in this 'create' call may be arbitrary.
+        // The only relevant ID may be the one used in update(), below.
+        DeaccessionClient client = new DeaccessionClient();
+        PoxPayloadOut multipart = createDeaccessionInstance(NON_EXISTENT_ID);
+        Response res = client.update(NON_EXISTENT_ID, multipart);
+        try {
+            int statusCode = res.getStatus();
+
+            // Check the status code of the response: does it match
+            // the expected response(s)?
+            logger.debug("{}: status = {}", testName, statusCode);
+            Assert.assertTrue(
+                    testRequestType.isValidStatusCode(statusCode),
+                    invalidStatusCodeMessage(testRequestType, statusCode));
+            Assert.assertEquals(statusCode, testExpectedStatusCode);
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // CRUD tests : DELETE tests
+    // ---------------------------------------------------------------
+
+    // Success outcomes
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.AbstractServiceTestImpl#delete(java.lang.String)
+     */
+    @Override
+    public void delete(String testName) throws Exception {
+        // Perform setup.
+        setupDelete();
+
+        // Submit the request to the service and store the response.
+        DeaccessionClient client = new DeaccessionClient();
+        Response res = client.delete(knownResourceId);
+        try {
+            int statusCode = res.getStatus();
+
+            // Check the status code of the response: does it match
+            // the expected response(s)?
+            logger.debug("{}: status = {}", testName, statusCode);
+            Assert.assertTrue(
+                    testRequestType.isValidStatusCode(statusCode),
+                    invalidStatusCodeMessage(testRequestType, statusCode));
+            Assert.assertEquals(statusCode, testExpectedStatusCode);
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+    }
+
+    // Failure outcomes
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.AbstractServiceTestImpl#deleteNonExistent(java.lang.String)
+     */
+    @Override
+    public void deleteNonExistent(String testName) throws Exception {
+        // Perform setup.
+        setupDeleteNonExistent();
+
+        // Submit the request to the service and store the response.
+        DeaccessionClient client = new DeaccessionClient();
+        Response res = client.delete(NON_EXISTENT_ID);
+        try {
+            int statusCode = res.getStatus();
+
+            // Check the status code of the response: does it match
+            // the expected response(s)?
+            logger.debug("{}: status = {}", testName, statusCode);
+            Assert.assertTrue(
+                    testRequestType.isValidStatusCode(statusCode),
+                    invalidStatusCodeMessage(testRequestType, statusCode));
+            Assert.assertEquals(statusCode, testExpectedStatusCode);
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Utility tests : tests of code used in tests above
+    // ---------------------------------------------------------------
+
+    /**
+     * Tests the code for manually submitting data that is used by several
+     * of the methods above.
+     */
+    public void testSubmitRequest() {
+
+        // Expected status code: 200 OK
+        final int EXPECTED_STATUS = Response.Status.OK.getStatusCode();
+
+        // Submit the request to the service and store the response.
+        String method = ServiceRequestType.READ.httpMethodName();
+        String url = getResourceURL(knownResourceId);
+        int statusCode = submitRequest(method, url);
+
+        // Check the status code of the response: does it match
+        // the expected response(s)?
+        logger.debug("testSubmitRequest: url={} status={}", url, statusCode);
+        Assert.assertEquals(statusCode, EXPECTED_STATUS);
+    }
+
+    // ---------------------------------------------------------------
+    // Utility methods used by tests above
+    // ---------------------------------------------------------------
+
+    @Override
+    public String getServiceName() {
+        return SERVICE_NAME;
+    }
+
+    /* (non-Javadoc)
+     * @see org.collectionspace.services.client.test.BaseServiceTest#getServicePathComponent()
+     */
+    @Override
+    public String getServicePathComponent() {
+        return SERVICE_PATH_COMPONENT;
+    }
+
+    @Override
+    protected PoxPayloadOut createInstance(String identifier) throws Exception {
+        return createDeaccessionInstance(identifier);
+    }
+
+    /**
+     * Creates the deaccession instance.
+     *
+     * @param deaccessionNumber the deaccession number
+     * @return the multipart output
+     * @throws Exception
+     */
+    private PoxPayloadOut createDeaccessionInstance(String deaccessionNumber) throws Exception {
+        DeaccessionsCommon deaccessionCommon = new DeaccessionsCommon();
+        deaccessionCommon.setDeaccessionNumber(deaccessionNumber);
+
+        PoxPayloadOut multipart = new PoxPayloadOut(this.getServicePathComponent());
+        multipart.addPart(new DeaccessionClient().getCommonPartName(), deaccessionCommon);
+
+        logger.debug("to be created, deaccession common");
+        logger.debug(objectAsXmlString(deaccessionCommon, DeaccessionsCommon.class));
+
+        return multipart;
+    }
+
+    @Override
+    public void CRUDTests(String testName) {}
+
+    @Override
+    protected PoxPayloadOut createInstance(String commonPartName, String identifier) throws Exception {
+        return createDeaccessionInstance(identifier);
+    }
+
+    @Override
+    protected DeaccessionsCommon updateInstance(DeaccessionsCommon commonPartObject) {
+        return null;
+    }
+
+    @Override
+    protected void compareUpdatedInstances(DeaccessionsCommon original, DeaccessionsCommon updated) {}
+}

--- a/services/deaccession/jaxb/pom.xml
+++ b/services/deaccession/jaxb/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <artifactId>org.collectionspace.services.deaccession</artifactId>
+    <groupId>org.collectionspace.services</groupId>
+    <version>${revision}</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>org.collectionspace.services.deaccession.jaxb</artifactId>
+  <name>services.deaccession.jaxb</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.jaxb</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>collectionspace-services-deaccession-jaxb</finalName>
+    <defaultGoal>install</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>org.jvnet.jaxb2.maven2</groupId>
+        <artifactId>maven-jaxb2-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/services/deaccession/jaxb/src/main/resources/deaccessions_common.xsd
+++ b/services/deaccession/jaxb/src/main/resources/deaccessions_common.xsd
@@ -11,22 +11,20 @@
 <xs:schema
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-  jaxb:version="1.0" elementFormDefault="unqualified"
-  xmlns:ns="http://collectionspace.org/services/deaccession"
+  jaxb:version="2.0"
   xmlns="http://collectionspace.org/services/deaccession"
   targetNamespace="http://collectionspace.org/services/deaccession"
   version="0.1"
 >
-
-<!--
-    Avoid XmlRootElement nightmare:
-    See http://weblogs.java.net/blog/kohsuke/archive/2006/03/why_does_jaxb_p.html
--->
-
   <!--  Deaccession Information Group -->
   <xs:element name="deaccessions_common">
     <xs:complexType>
       <xs:sequence>
+        <xs:element name="deaccessionNumber" type="xs:string" />
+        <xs:element name="deaccessionDate" type="xs:date" />
+        <xs:element name="deaccessionRationale" type="xs:string" />
+        <xs:element name="deaccessionNote" type="xs:string" />
+        <!-- todo: complex types -->
       </xs:sequence>
     </xs:complexType>
   </xs:element>

--- a/services/deaccession/jaxb/src/main/resources/deaccessions_common.xsd
+++ b/services/deaccession/jaxb/src/main/resources/deaccessions_common.xsd
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+<!--
+    Deaccession schema (XSD)
+
+    Entity  : Deaccession
+    Part    : Common
+    Used for: JAXB binding between XML and Java objects
+-->
+
+<xs:schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+  jaxb:version="1.0" elementFormDefault="unqualified"
+  xmlns:ns="http://collectionspace.org/services/deaccession"
+  xmlns="http://collectionspace.org/services/deaccession"
+  targetNamespace="http://collectionspace.org/services/deaccession"
+  version="0.1"
+>
+
+<!--
+    Avoid XmlRootElement nightmare:
+    See http://weblogs.java.net/blog/kohsuke/archive/2006/03/why_does_jaxb_p.html
+-->
+
+  <!--  Deaccession Information Group -->
+  <xs:element name="deaccessions_common">
+    <xs:complexType>
+      <xs:sequence>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/services/deaccession/jaxb/src/main/resources/deaccessions_common.xsd
+++ b/services/deaccession/jaxb/src/main/resources/deaccessions_common.xsd
@@ -7,7 +7,6 @@
     Part    : Common
     Used for: JAXB binding between XML and Java objects
 -->
-
 <xs:schema
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
@@ -24,8 +23,46 @@
         <xs:element name="deaccessionDate" type="xs:date" />
         <xs:element name="deaccessionRationale" type="xs:string" />
         <xs:element name="deaccessionNote" type="xs:string" />
-        <!-- todo: complex types -->
+        <xs:element name="exitDate" type="xs:date" />
+
+        <xs:element name="deaccessionReasons" type="deaccessionReasons" />
+        <xs:element name="exitRecipients" type="exitRecipients" />
+        <xs:element name="exitMethods" type="exitMethods" />
       </xs:sequence>
     </xs:complexType>
   </xs:element>
+
+  <xs:complexType name="deaccessionReasons">
+    <xs:sequence>
+      <xs:element name="deaccessionReason" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="exitRecipients">
+    <xs:sequence>
+      <xs:element name="exitRecipient" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="exitMethods">
+    <xs:sequence>
+      <xs:element name="exitMethod" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="deaccessionApprovalGroupList">
+    <xs:sequence>
+      <xs:element name="deaccessionApprovalGroup" type="deaccessionApprovalGroup" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="deaccessionApprovalGroup">
+    <xs:sequence>
+      <xs:element name="deaccessionApprovalGroup" type="xs:string" />
+      <xs:element name="deaccessionApprovalIndividual" type="xs:string" />
+      <xs:element name="deaccessionApprovalStatus" type="xs:string" />
+      <xs:element name="deaccessionApprovalDate" type="xs:date" />
+      <xs:element name="deaccessionApprovalNote" type="xs:string" />
+    </xs:sequence>
+  </xs:complexType>
 </xs:schema>

--- a/services/deaccession/pom.xml
+++ b/services/deaccession/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <groupId>org.collectionspace.services</groupId>
+    <artifactId>org.collectionspace.services.main</artifactId>
+    <version>${revision}</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>org.collectionspace.services.deaccession</artifactId>
+  <name>services.deaccession</name>
+  <packaging>pom</packaging>
+
+  <properties>
+    <!-- spotless 2.30.0 is the last version that supports java 8 -->
+    <spotless.version>2.30.0</spotless.version>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>${spotless.version}</version>
+        <configuration>
+          <formats>
+            <!-- you can define as many formats as you want, each is independent -->
+            <format>
+              <includes>
+                <include>src/main/java/**/*.java</include>
+                <include>src/test/java/**/*.java</include>
+              </includes>
+              <trimTrailingWhitespace />
+              <endWithNewline />
+              <indent>
+                <spaces>true</spaces>
+                <spacesPerTab>4</spacesPerTab>
+              </indent>
+            </format>
+          </formats>
+          <!-- define a language-specific format -->
+          <java>
+            <palantirJavaFormat />
+          </java>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <modules>
+    <module>jaxb</module>
+    <module>service</module>
+    <module>client</module>
+  </modules>
+
+</project>

--- a/services/deaccession/service/pom.xml
+++ b/services/deaccession/service/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <parent>
+    <groupId>org.collectionspace.services</groupId>
+    <artifactId>org.collectionspace.services.deaccession</artifactId>
+    <version>${revision}</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>org.collectionspace.services.deaccession.service</artifactId>
+  <name>services.deaccession.service</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.deaccession.jaxb</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.collectionspace.services</groupId>
+      <artifactId>org.collectionspace.services.deaccession.client</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- External dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- javax -->
+    <dependency>
+      <groupId>javax.security</groupId>
+      <artifactId>jaas</artifactId>
+      <version>1.0.01</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- jboss -->
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxrs</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>tjws</groupId>
+          <artifactId>webserver</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxb-provider</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-multipart-provider</artifactId>
+    </dependency>
+
+    <!-- nuxeo -->
+    <dependency>
+      <groupId>org.nuxeo.ecm.core</groupId>
+      <artifactId>nuxeo-core-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <artifactId>jboss-remoting</artifactId>
+          <groupId>jboss</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>collectionspace-services-deaccession</finalName>
+  </build>
+</project>

--- a/services/deaccession/service/src/main/java/org/collectionspace/services/deaccession/DeaccessionResource.java
+++ b/services/deaccession/service/src/main/java/org/collectionspace/services/deaccession/DeaccessionResource.java
@@ -1,0 +1,55 @@
+/*
+ *  This document is a part of the source code and related artifacts
+ *  for CollectionSpace, an open source collections management system
+ *  for museums and related institutions:
+ *
+ *  http://www.collectionspace.org
+ *  http://wiki.collectionspace.org
+ *
+ *  Licensed under the Educational Community License (ECL), Version 2.0.
+ *  You may not use this file except in compliance with this License.
+ *
+ *  You may obtain a copy of the ECL 2.0 License at
+ *
+ *  https://source.collectionspace.org/collection-space/LICENSE.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.collectionspace.services.deaccession;
+
+import org.collectionspace.services.client.DeaccessionClient;
+import org.collectionspace.services.common.NuxeoBasedResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+@Path(DeaccessionClient.SERVICE_PATH)
+@Consumes("application/xml")
+@Produces("application/xml")
+public class DeaccessionResource extends NuxeoBasedResource {
+
+    final Logger logger = LoggerFactory.getLogger(DeaccessionResource.class);
+
+    @Override
+    protected String getVersionString() {
+        final String lastChangeRevision = "$LastChangedRevision$";
+        return lastChangeRevision;
+    }
+
+    @Override
+    public String getServiceName() {
+        return DeaccessionClient.SERVICE_NAME;
+    }
+
+    @Override
+    public Class<DeaccessionsCommon> getCommonPartClass() {
+        return DeaccessionsCommon.class;
+    }
+}

--- a/services/deaccession/service/src/main/java/org/collectionspace/services/deaccession/DeaccessionResource.java
+++ b/services/deaccession/service/src/main/java/org/collectionspace/services/deaccession/DeaccessionResource.java
@@ -21,12 +21,11 @@
  */
 package org.collectionspace.services.deaccession;
 
-import org.collectionspace.services.client.DeaccessionClient;
-import org.collectionspace.services.common.NuxeoBasedResource;
-
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import org.collectionspace.services.client.DeaccessionClient;
+import org.collectionspace.services.common.NuxeoBasedResource;
 
 @Path(DeaccessionClient.SERVICE_PATH)
 @Consumes("application/xml")

--- a/services/deaccession/service/src/main/java/org/collectionspace/services/deaccession/DeaccessionResource.java
+++ b/services/deaccession/service/src/main/java/org/collectionspace/services/deaccession/DeaccessionResource.java
@@ -23,8 +23,6 @@ package org.collectionspace.services.deaccession;
 
 import org.collectionspace.services.client.DeaccessionClient;
 import org.collectionspace.services.common.NuxeoBasedResource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Path;
@@ -35,12 +33,9 @@ import javax.ws.rs.Produces;
 @Produces("application/xml")
 public class DeaccessionResource extends NuxeoBasedResource {
 
-    final Logger logger = LoggerFactory.getLogger(DeaccessionResource.class);
-
     @Override
     protected String getVersionString() {
-        final String lastChangeRevision = "$LastChangedRevision$";
-        return lastChangeRevision;
+        return "$LastChangedRevision$";
     }
 
     @Override

--- a/services/deaccession/service/src/main/java/org/collectionspace/services/deaccession/nuxeo/DeaccessionDocumentModelHandler.java
+++ b/services/deaccession/service/src/main/java/org/collectionspace/services/deaccession/nuxeo/DeaccessionDocumentModelHandler.java
@@ -1,0 +1,31 @@
+/*
+ *  This document is a part of the source code and related artifacts
+ *  for CollectionSpace, an open source collections management system
+ *  for museums and related institutions:
+ *
+ *  http://www.collectionspace.org
+ *  http://wiki.collectionspace.org
+ *
+ *  Licensed under the Educational Community License (ECL), Version 2.0.
+ *  You may not use this file except in compliance with this License.
+ *
+ *  You may obtain a copy of the ECL 2.0 License at
+ *
+ *  https://source.collectionspace.org/collection-space/LICENSE.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.collectionspace.services.deaccession.nuxeo;
+
+import org.collectionspace.services.deaccession.DeaccessionsCommon;
+import org.collectionspace.services.nuxeo.client.java.NuxeoDocumentModelHandler;
+
+/** DeaccessionDocumentModelHandler
+ */
+public class DeaccessionDocumentModelHandler
+        extends NuxeoDocumentModelHandler<DeaccessionsCommon> {
+}

--- a/services/deaccession/service/src/main/java/org/collectionspace/services/deaccession/nuxeo/DeaccessionDocumentModelHandler.java
+++ b/services/deaccession/service/src/main/java/org/collectionspace/services/deaccession/nuxeo/DeaccessionDocumentModelHandler.java
@@ -27,6 +27,4 @@ import org.collectionspace.services.nuxeo.client.java.NuxeoDocumentModelHandler;
 /**
  * DeaccessionDocumentModelHandler
  */
-public class DeaccessionDocumentModelHandler
-        extends NuxeoDocumentModelHandler<DeaccessionsCommon> {
-}
+public class DeaccessionDocumentModelHandler extends NuxeoDocumentModelHandler<DeaccessionsCommon> {}

--- a/services/deaccession/service/src/main/java/org/collectionspace/services/deaccession/nuxeo/DeaccessionDocumentModelHandler.java
+++ b/services/deaccession/service/src/main/java/org/collectionspace/services/deaccession/nuxeo/DeaccessionDocumentModelHandler.java
@@ -24,7 +24,8 @@ package org.collectionspace.services.deaccession.nuxeo;
 import org.collectionspace.services.deaccession.DeaccessionsCommon;
 import org.collectionspace.services.nuxeo.client.java.NuxeoDocumentModelHandler;
 
-/** DeaccessionDocumentModelHandler
+/**
+ * DeaccessionDocumentModelHandler
  */
 public class DeaccessionDocumentModelHandler
         extends NuxeoDocumentModelHandler<DeaccessionsCommon> {

--- a/services/deaccession/service/src/main/java/org/collectionspace/services/deaccession/nuxeo/DeaccessionValidatorHandler.java
+++ b/services/deaccession/service/src/main/java/org/collectionspace/services/deaccession/nuxeo/DeaccessionValidatorHandler.java
@@ -14,19 +14,40 @@
  */
 package org.collectionspace.services.deaccession.nuxeo;
 
-import org.collectionspace.services.common.context.ServiceContext;
+import org.collectionspace.services.client.PoxPayloadIn;
+import org.collectionspace.services.client.PoxPayloadOut;
 import org.collectionspace.services.common.document.InvalidDocumentException;
-import org.collectionspace.services.common.document.ValidatorHandler;
-import org.collectionspace.services.common.document.DocumentHandler.Action;
+import org.collectionspace.services.common.document.ValidatorHandlerImpl;
 
-public class DeaccessionValidatorHandler implements ValidatorHandler {
+public class DeaccessionValidatorHandler extends ValidatorHandlerImpl<PoxPayloadIn, PoxPayloadOut> {
 
     @Override
-    public void validate(Action action, ServiceContext ctx)
-                throws InvalidDocumentException {
-        // TODO Auto-generated method stub
-        System.out.println("DeaccessionValidatorHandler executed.");
+    protected Class<?> getCommonPartClass() {
+        return null;
+    }
+
+    @Override
+    protected void handleCreate() throws InvalidDocumentException {
 
     }
 
+    @Override
+    protected void handleGet() throws InvalidDocumentException {
+
+    }
+
+    @Override
+    protected void handleGetAll() throws InvalidDocumentException {
+
+    }
+
+    @Override
+    protected void handleUpdate() throws InvalidDocumentException {
+
+    }
+
+    @Override
+    protected void handleDelete() throws InvalidDocumentException {
+
+    }
 }

--- a/services/deaccession/service/src/main/java/org/collectionspace/services/deaccession/nuxeo/DeaccessionValidatorHandler.java
+++ b/services/deaccession/service/src/main/java/org/collectionspace/services/deaccession/nuxeo/DeaccessionValidatorHandler.java
@@ -1,0 +1,32 @@
+/*
+ * This document is a part of the source code and related artifacts
+ * for CollectionSpace, an open source collections management system
+ * for museums and related institutions:
+ *
+ * http://www.collectionspace.org
+ * http://wiki.collectionspace.org
+ *
+ * Licensed under the Educational Community License (ECL), Version 2.0.
+ * You may not use this file except in compliance with this License.
+ *
+ * You may obtain a copy of the ECL 2.0 License at
+ * https://source.collectionspace.org/collection-space/LICENSE.txt
+ */
+package org.collectionspace.services.deaccession.nuxeo;
+
+import org.collectionspace.services.common.context.ServiceContext;
+import org.collectionspace.services.common.document.InvalidDocumentException;
+import org.collectionspace.services.common.document.ValidatorHandler;
+import org.collectionspace.services.common.document.DocumentHandler.Action;
+
+public class DeaccessionValidatorHandler implements ValidatorHandler {
+
+    @Override
+    public void validate(Action action, ServiceContext ctx)
+                throws InvalidDocumentException {
+        // TODO Auto-generated method stub
+        System.out.println("DeaccessionValidatorHandler executed.");
+
+    }
+
+}

--- a/services/deaccession/service/src/main/java/org/collectionspace/services/deaccession/nuxeo/DeaccessionValidatorHandler.java
+++ b/services/deaccession/service/src/main/java/org/collectionspace/services/deaccession/nuxeo/DeaccessionValidatorHandler.java
@@ -18,36 +18,47 @@ import org.collectionspace.services.client.PoxPayloadIn;
 import org.collectionspace.services.client.PoxPayloadOut;
 import org.collectionspace.services.common.document.InvalidDocumentException;
 import org.collectionspace.services.common.document.ValidatorHandlerImpl;
+import org.collectionspace.services.deaccession.DeaccessionsCommon;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DeaccessionValidatorHandler extends ValidatorHandlerImpl<PoxPayloadIn, PoxPayloadOut> {
 
+    private final Logger logger = LoggerFactory.getLogger(DeaccessionValidatorHandler.class);
+
+    private static final String COMMON_PART_MISSING = "Validation exception: deaccessions_common part is missing";
+    private static final String DEACCESSION_NUMBER_MISSING =
+        "Validation exception: The field \"deaccessionNumber\" cannot be empty or missing";
+
     @Override
     protected Class<?> getCommonPartClass() {
-        return null;
+        return DeaccessionsCommon.class;
     }
 
     @Override
     protected void handleCreate() throws InvalidDocumentException {
+        final DeaccessionsCommon common = (DeaccessionsCommon) getCommonPart();
+        if (common == null) {
+            logger.error(COMMON_PART_MISSING);
+            throw new InvalidDocumentException(COMMON_PART_MISSING);
+        }
 
+        final String deaccessionNumber = common.getDeaccessionNumber();
+        if (deaccessionNumber == null || deaccessionNumber.isEmpty()) {
+            logger.error(DEACCESSION_NUMBER_MISSING);
+            throw new InvalidDocumentException(DEACCESSION_NUMBER_MISSING);
+        }
     }
 
     @Override
-    protected void handleGet() throws InvalidDocumentException {
-
-    }
+    protected void handleGet() {}
 
     @Override
-    protected void handleGetAll() throws InvalidDocumentException {
-
-    }
+    protected void handleGetAll() {}
 
     @Override
-    protected void handleUpdate() throws InvalidDocumentException {
-
-    }
+    protected void handleUpdate() {}
 
     @Override
-    protected void handleDelete() throws InvalidDocumentException {
-
-    }
+    protected void handleDelete() {}
 }

--- a/services/deaccession/service/src/main/java/org/collectionspace/services/deaccession/nuxeo/DeaccessionValidatorHandler.java
+++ b/services/deaccession/service/src/main/java/org/collectionspace/services/deaccession/nuxeo/DeaccessionValidatorHandler.java
@@ -28,7 +28,7 @@ public class DeaccessionValidatorHandler extends ValidatorHandlerImpl<PoxPayload
 
     private static final String COMMON_PART_MISSING = "Validation exception: deaccessions_common part is missing";
     private static final String DEACCESSION_NUMBER_MISSING =
-        "Validation exception: The field \"deaccessionNumber\" cannot be empty or missing";
+            "Validation exception: The field \"deaccessionNumber\" cannot be empty or missing";
 
     @Override
     protected Class<?> getCommonPartClass() {

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -104,6 +104,7 @@
 		<module>summarydocumentation</module>
 		<module>heldintrust</module>
 		<module>consultation</module>
+		<module>deaccession</module>
 		<module>IntegrationTests</module>
 		<module>PerformanceTests</module>
 		<module>security</module>


### PR DESCRIPTION
**What does this do?**
* Creates a deaccession service
* Creates a deaccession id_generator

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1355

The Deaccession procedure adds the ability to capture the decision making around removing an accessioned object. Previously this was part of the ObjectExit procedure, and this is breaking it out into it's own data structure.

**How should this be tested? Do these changes have associated tests?**
* Rebuild and start collectionspace with all tenants required for integration tests
* Run the integration tests and ensure they pass

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally