### PR TITLE
DRYD-1420: Check for existing terms by display name when initializing…

### DIFF
--- a/services/authority/service/src/main/java/org/collectionspace/services/common/vocabulary/AuthorityResource.java
+++ b/services/authority/service/src/main/java/org/collectionspace/services/common/vocabulary/AuthorityResource.java
@@ -23,6 +23,10 @@
  */
 package org.collectionspace.services.common.vocabulary;
 
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -36,6 +40,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.PathSegment;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
@@ -78,6 +83,7 @@ import org.collectionspace.services.common.document.DocumentReferenceException;
 import org.collectionspace.services.common.document.DocumentWrapper;
 import org.collectionspace.services.common.document.Hierarchy;
 import org.collectionspace.services.common.query.QueryManager;
+import org.collectionspace.services.common.query.UriInfoImpl;
 import org.collectionspace.services.common.repository.RepositoryClient;
 import org.collectionspace.services.common.vocabulary.RefNameServiceUtils.AuthorityItemSpecifier;
 import org.collectionspace.services.common.vocabulary.RefNameServiceUtils.Specifier;
@@ -97,6 +103,7 @@ import org.collectionspace.services.nuxeo.client.java.NuxeoDocumentFilter;
 import org.collectionspace.services.nuxeo.client.java.NuxeoRepositoryClientImpl;
 import org.collectionspace.services.nuxeo.util.NuxeoUtils;
 import org.collectionspace.services.workflow.WorkflowCommon;
+import org.jboss.resteasy.specimpl.PathSegmentImpl;
 import org.jboss.resteasy.util.HttpResponseCodes;
 import org.nuxeo.ecm.core.api.DocumentModel;
 import org.nuxeo.ecm.core.api.DocumentModelList;
@@ -1289,6 +1296,28 @@ public abstract class AuthorityResource<AuthCommon, AuthItemHandler>
         }
 
         return result;
+    }
+
+    public boolean hasAuthorityItemWithShortNameOrDisplayName(String authorityIdentifier, String shortName, String displayName) throws Exception {
+        String as = RefNameServiceUtils.buildWhereForAuthItemByNameOrDisplayName(
+            authorityItemCommonSchemaName,
+            shortName,
+            getPartialTermMatchField(NULL_CONTEXT),
+            displayName,
+            null
+        );
+
+        UriInfo uriInfo = new UriInfoImpl(
+            new URI(""),
+            new URI(""),
+            "",
+            "pgSz=1&as=" + URLEncoder.encode(as, StandardCharsets.UTF_8.toString()),
+            Arrays.asList((PathSegment) new PathSegmentImpl("", false))
+        );
+
+        AbstractCommonList result = getAuthorityItemList(NULL_CONTEXT, authorityIdentifier, uriInfo);
+
+        return (result.getTotalItems() > 0);
     }
 
     /**

--- a/services/common/src/test/java/org/collectionspace/services/common/test/RefNameServiceUtilsTest.java
+++ b/services/common/src/test/java/org/collectionspace/services/common/test/RefNameServiceUtilsTest.java
@@ -1,0 +1,117 @@
+package org.collectionspace.services.common.test;
+
+import org.testng.annotations.Test;
+import org.collectionspace.services.common.vocabulary.RefNameServiceUtils;
+import org.testng.Assert;
+
+public class RefNameServiceUtilsTest {
+
+  @Test
+  public void buildWhereForAuthItemByName() {
+    String commonSchemaName = "common";
+    String shortId = "shortId";
+    String parentCsid = "1234";
+
+    Assert.assertEquals(
+      RefNameServiceUtils.buildWhereForAuthItemByName(commonSchemaName, shortId, parentCsid),
+      "common:shortIdentifier='shortId' AND common:inAuthority='1234'");
+  }
+
+  @Test
+  public void buildWhereForAuthItemByNameWithNullParent() {
+    String commonSchemaName = "common";
+    String shortId = "shortId";
+    String parentCsid = null;
+
+    Assert.assertEquals(
+      RefNameServiceUtils.buildWhereForAuthItemByName(commonSchemaName, shortId, parentCsid),
+      "common:shortIdentifier='shortId'"
+    );
+  }
+
+  @Test
+  public void buildWhereForAuthItemByDisplayName() {
+    String displayNameField = "common:displayName";
+    String displayName = "foo";
+
+    Assert.assertEquals(
+      RefNameServiceUtils.buildWhereForAuthItemByDisplayName(displayNameField, displayName),
+      "common:displayName ILIKE 'foo'");
+  }
+
+  @Test
+  public void buildWhereForAuthItemByDisplayNameEscapesDisplayNameQuote() {
+    String displayNameField = "common:displayName";
+    String displayName = "who's there";
+
+    Assert.assertEquals(
+      RefNameServiceUtils.buildWhereForAuthItemByDisplayName(displayNameField, displayName),
+      "common:displayName ILIKE 'who\\'s there'");
+  }
+
+  @Test
+  public void buildWhereForAuthItemByDisplayNameEscapesDisplayNamePercent() {
+    String displayNameField = "common:displayName";
+    String displayName = "100%";
+
+    Assert.assertEquals(
+      RefNameServiceUtils.buildWhereForAuthItemByDisplayName(displayNameField, displayName),
+      "common:displayName ILIKE '100\\%'");
+  }
+
+  @Test
+  public void buildWhereForAuthItemByDisplayNameEscapesDisplayNameUnderscore() {
+    String displayNameField = "common:displayName";
+    String displayName = "foo_bar";
+
+    Assert.assertEquals(
+      RefNameServiceUtils.buildWhereForAuthItemByDisplayName(displayNameField, displayName),
+      "common:displayName ILIKE 'foo\\_bar'");
+  }
+
+  @Test
+  public void buildWhereForAuthItemByDisplayNameEscapesDisplayNameBackslash() {
+    String displayNameField = "common:displayName";
+    String displayName = "foo\\bar";
+
+    Assert.assertEquals(
+      RefNameServiceUtils.buildWhereForAuthItemByDisplayName(displayNameField, displayName),
+      "common:displayName ILIKE 'foo\\\\bar'");
+  }
+
+  @Test
+  public void buildWhereForAuthItemByDisplayNameEscapesDisplayName() {
+    String displayNameField = "common:displayName";
+    String displayName = "50% of Megan's files are in C:\\Users\\megan or C:\\Temp\\megans_files";
+
+    Assert.assertEquals(
+      RefNameServiceUtils.buildWhereForAuthItemByDisplayName(displayNameField, displayName),
+      "common:displayName ILIKE '50\\% of Megan\\'s files are in C:\\\\Users\\\\megan or C:\\\\Temp\\\\megans\\_files'");
+  }
+
+  @Test
+  public void buildWhereForAuthItemByNameOrDisplayName() {
+    String commonSchemaName = "common";
+    String shortId = "shortId";
+    String displayNameField = "common:displayName";
+    String displayName = "foo";
+    String parentCsid = "1234";
+
+    Assert.assertEquals(
+      RefNameServiceUtils.buildWhereForAuthItemByNameOrDisplayName(commonSchemaName, shortId, displayNameField, displayName, parentCsid),
+      "(common:shortIdentifier='shortId' OR common:displayName ILIKE 'foo') AND common:inAuthority='1234'");
+  }
+
+  @Test
+  public void buildWhereForAuthItemByNameOrDisplayNameWithNullParent() {
+    String commonSchemaName = "common";
+    String shortId = "shortId";
+    String displayNameField = "common:displayName";
+    String displayName = "foo";
+    String parentCsid = null;
+
+    Assert.assertEquals(
+      RefNameServiceUtils.buildWhereForAuthItemByNameOrDisplayName(commonSchemaName, shortId, displayNameField, displayName, parentCsid),
+      "(common:shortIdentifier='shortId' OR common:displayName ILIKE 'foo')");
+  }
+}

--- a/services/vocabulary/service/src/main/java/org/collectionspace/services/vocabulary/VocabularyResource.java
+++ b/services/vocabulary/service/src/main/java/org/collectionspace/services/vocabulary/VocabularyResource.java
@@ -79,17 +79,17 @@ import javax.ws.rs.core.UriInfo;
 import javax.xml.bind.DatatypeConverter;
 
 @Path("/" + VocabularyClient.SERVICE_PATH_COMPONENT)
-public class VocabularyResource extends 
+public class VocabularyResource extends
 	AuthorityResource<VocabulariesCommon, VocabularyItemDocumentModelHandler> {
 
 	private enum Method {
         POST, PUT;
     }
-	
+
     private final static String vocabularyServiceName = VocabularyClient.SERVICE_PATH_COMPONENT;
 
 	private final static String VOCABULARIES_COMMON = "vocabularies_common";
-    
+
     private final static String vocabularyItemServiceName = "vocabularyitems";
 	private final static String VOCABULARYITEMS_COMMON = "vocabularyitems_common";
 
@@ -118,10 +118,10 @@ public class VocabularyResource extends
 	            PoxPayloadIn input = new PoxPayloadIn(xmlPayload);
 	            ServiceContext<PoxPayloadIn, PoxPayloadOut> ctx = createServiceContext(input);
 				RepositoryClient<PoxPayloadIn, PoxPayloadOut> repoClient = this.getRepositoryClient(ctx);
-				
+
 				CoreSessionInterface repoSession = repoClient.getRepositorySession(ctx);
 				try {
-		            DocumentHandler<?, AbstractCommonList, DocumentModel, DocumentModelList> handler = createDocumentHandler(ctx);		            
+		            DocumentHandler<?, AbstractCommonList, DocumentModel, DocumentModelList> handler = createDocumentHandler(ctx);
 		            String csid = repoClient.create(ctx, handler);
 		            //
 		            // Handle any supplied list of items/terms
@@ -142,7 +142,7 @@ public class VocabularyResource extends
 	        }
     	}
     }
-        
+
     @PUT
     @Path("{csid}")
     @Override
@@ -188,7 +188,7 @@ public class VocabularyResource extends
         }
         return result.getBytes();
     }
-    
+
     private void updateWithItemsPayload(
     		AbstractCommonList itemsList,
     		ServiceContext<PoxPayloadIn, PoxPayloadOut> existingCtx,
@@ -196,7 +196,7 @@ public class VocabularyResource extends
     		ResourceMap resourceMap,
     		UriInfo uriInfo,
     		PoxPayloadIn input) throws Exception {
-    	
+
     	CoreSessionInterface repoSession = (CoreSessionInterface) existingCtx.getCurrentRepositorySession();
 		Set<String> shortIdsInPayload = getListOfShortIds(itemsList); // record the list of existing or new terms/items
 
@@ -276,13 +276,13 @@ public class VocabularyResource extends
 			}
 		}
 	}
-    
+
     private String getShortId(PoxPayloadIn itemXmlPayload) {
 		String result = null;
-		
+
 		VocabularyitemsCommon vocabularyItemsCommon = (VocabularyitemsCommon) itemXmlPayload.getPart(VOCABULARYITEMS_COMMON).getBody();
 		result = vocabularyItemsCommon.getShortIdentifier();
-		
+
 		return result;
 	}
 
@@ -291,35 +291,35 @@ public class VocabularyResource extends
     		AbstractCommonList abstractCommonList,
     		Set<String> shortIdsInPayload,
     		String parentIdentifier) throws Exception {
-    	
+
 		for (ListItem item : abstractCommonList.getListItem()) {
 			String shortId = getShortId(item);
 			if (shortIdsInPayload.contains(shortId) == false) {
 				deleteAuthorityItem(existingCtx, parentIdentifier, getCsid(item), AuthorityServiceUtils.UPDATE_REV);
 			}
-		}    	
+		}
     }
-    
+
     private void sotfDeleteAuthorityItems(
     		ServiceContext<PoxPayloadIn, PoxPayloadOut> existingCtx,
     		AbstractCommonList abstractCommonList,
     		Set<String> shortIdsInPayload,
     		String parentIdentifier) throws Exception {
-    	
+
 		for (ListItem item : abstractCommonList.getListItem()) {
 			String shortId = getShortId(item);
 			if (shortIdsInPayload.contains(shortId) == false) {
 				//deleteAuthorityItem(existingCtx, parentIdentifier, getCsid(item), AuthorityServiceUtils.UPDATE_REV);
-				this.updateItemWorkflowWithTransition(existingCtx, parentIdentifier, getCsid(item), 
+				this.updateItemWorkflowWithTransition(existingCtx, parentIdentifier, getCsid(item),
 						WorkflowClient.WORKFLOWTRANSITION_DELETE, AuthorityServiceUtils.UPDATE_REV);
 			}
-		}    	
+		}
     }
-        
+
     private boolean shouldDeleteOmittedItems(UriInfo uriInfo) throws DocumentException {
     	boolean result = false;
-    	
-		String omittedItemAction = getOmittedItemAction(uriInfo);		
+
+		String omittedItemAction = getOmittedItemAction(uriInfo);
 		if (Tools.isEmpty(omittedItemAction) == false) {
 			switch (omittedItemAction) {
 				case VocabularyClient.DELETE_OMITTED_ITEMS:
@@ -334,10 +334,10 @@ public class VocabularyResource extends
 					throw new DocumentException(msg);
 			}
 		}
-		
+
 		return result;
 	}
-    
+
     private String getOmittedItemAction(UriInfo uriInfo) {
 		MultivaluedMap<String,String> queryParams = uriInfo.getQueryParameters();
 		String omittedItemAction = queryParams.getFirst(VocabularyClient.OMITTED_ITEM_ACTION_QP);
@@ -349,24 +349,24 @@ public class VocabularyResource extends
      */
     private Set<String> getListOfShortIds(AbstractCommonList itemsList) {
 		HashSet<String> result = new HashSet<String>();
-		
+
 		for (ListItem item : itemsList.getListItem()) {
 			String shortId = getShortId(item);
 			if (Tools.isEmpty(shortId) == false) {
 				result.add(shortId);
 			}
 		}
-		
+
 		return result;
 	}
 
 	private void createWithItemsPayload(
 			AbstractCommonList itemsList,
-			ServiceContext<PoxPayloadIn, 
-			PoxPayloadOut> existingCtx, 
-			String parentIdentifier, 
+			ServiceContext<PoxPayloadIn,
+			PoxPayloadOut> existingCtx,
+			String parentIdentifier,
 			ResourceMap resourceMap,
-			UriInfo uriInfo, 
+			UriInfo uriInfo,
 			PoxPayloadIn input) throws Exception {
 
 		for (ListItem item : itemsList.getListItem()) {
@@ -388,8 +388,8 @@ public class VocabularyResource extends
 				throw new DocumentException(errMsg);
 			}
 		}
-	}   
-    
+	}
+
     private boolean handleItemsPayload(
     		Method method,
     		ServiceContext<PoxPayloadIn, PoxPayloadOut> existingCtx,
@@ -398,7 +398,7 @@ public class VocabularyResource extends
     		UriInfo uriInfo,
     		PoxPayloadIn input) throws Exception {
     	boolean result = false;
-    	
+
     	PayloadInputPart abstractCommonListPart  = input.getPart(PoxPayload.ABSTRACT_COMMON_LIST_ROOT_ELEMENT_LABEL);
     	if (abstractCommonListPart != null) {
     		AbstractCommonList itemsList = (AbstractCommonList) abstractCommonListPart.getBody();
@@ -408,17 +408,17 @@ public class VocabularyResource extends
         			break;
     			case PUT:
 		            updateWithItemsPayload(itemsList, existingCtx, parentIdentifier, resourceMap, uriInfo, input);
-        			break;	        			
+        			break;
 			}
 			result = true; // mark that we've handled an items-list payload
     	}
-    	
+
     	return result;
 	}
-    
+
     private String getFieldValue(ListItem item, String lookingFor) {
     	String result = null;
-    	
+
 		for (Element ele : item.getAny()) {
 			String fieldName = ele.getTagName();
 			String fieldValue = ele.getTextContent();
@@ -426,26 +426,26 @@ public class VocabularyResource extends
 				result = fieldValue;
 				break;
 			}
-		}    	
-    	
+		}
+
     	return result;
     }
-    
+
     public String getCsid(ListItem item) {
     	return getFieldValue(item, "csid");
     }
-    
+
     private String getShortId(ListItem item) {
     	return getFieldValue(item, "shortIdentifier");
     }
-    
+
     private String getDisplayName(ListItem item) {
     	return getFieldValue(item, "displayName");
     }
-    
+
     /**
      * We'll return null if we can create a specifier from the list item.
-     * 
+     *
      * @param item
      * @return
      */
@@ -454,7 +454,7 @@ public class VocabularyResource extends
 
 		String csid = result = getCsid(item);
 		if (csid == null) {
-			String shortId = getShortId(item);			
+			String shortId = getShortId(item);
 			if (shortId != null) {
 				result = Specifier.createShortIdURNValue(shortId);
 			}
@@ -466,10 +466,10 @@ public class VocabularyResource extends
 	/**
      * This is very brittle.  If the class VocabularyitemsCommon changed with new fields we'd have to
      * update this method.
-     * 
+     *
      * @param item
      * @return
-     * @throws DocumentException 
+     * @throws DocumentException
      */
 	private PoxPayloadIn getItemXmlPayload(ListItem item) throws DocumentException {
 		PoxPayloadIn result = null;
@@ -482,31 +482,31 @@ public class VocabularyResource extends
 				case "displayName":
 					vocabularyItem.setDisplayName(fieldValue);
 					break;
-					
+
 				case "shortIdentifier":
 					vocabularyItem.setShortIdentifier(fieldValue);
 					break;
-					
+
 				case "order":
 					vocabularyItem.setOrder(fieldValue);
 					break;
-					
+
 				case "source":
 					vocabularyItem.setSource(fieldValue);
 					break;
-					
+
 				case "sourcePage":
 					vocabularyItem.setSourcePage(fieldValue);
 					break;
-					
+
 				case "description":
 					vocabularyItem.setDescription(fieldValue);
 					break;
-					
+
 				case "csid":
 					vocabularyItem.setCsid(fieldValue);
 					break;
-					
+
 				case "termStatus":
 					vocabularyItem.setTermStatus(fieldValue);
 					break;
@@ -523,13 +523,13 @@ public class VocabularyResource extends
 			vocabularyItem.setShortIdentifier(AuthorityIdentifierUtils.generateShortIdentifierFromDisplayName(
 					vocabularyItem.getDisplayName() , null)); ;
 		}
-		
-		result = new PoxPayloadIn(VocabularyClient.SERVICE_ITEM_PAYLOAD_NAME, vocabularyItem, 
+
+		result = new PoxPayloadIn(VocabularyClient.SERVICE_ITEM_PAYLOAD_NAME, vocabularyItem,
     			VOCABULARYITEMS_COMMON);
 
-		return result; 
+		return result;
 	}
-    
+
 	private Response createAuthorityItem(
     		CoreSessionInterface repoSession,
     		ResourceMap resourceMap,
@@ -537,16 +537,16 @@ public class VocabularyResource extends
     		String parentIdentifier, // Either a CSID or a URN form -e.g., a8ad38ec-1d7d-4bf2-bd31 or urn:cspace:name(bugsbunny)
     		PoxPayloadIn input) throws Exception {
     	Response result = null;
-    	
+
         ServiceContext<PoxPayloadIn, PoxPayloadOut> ctx = createServiceContext(getItemServiceName(), input, resourceMap, uriInfo);
         ctx.setCurrentRepositorySession(repoSession);
-        
+
         result = createAuthorityItem(ctx, parentIdentifier, AuthorityServiceUtils.UPDATE_REV,
         		AuthorityServiceUtils.PROPOSED, AuthorityServiceUtils.NOT_SAS_ITEM);
 
         return result;
     }
-	
+
 	private PoxPayloadOut updateAuthorityItem(
     		CoreSessionInterface repoSession,
     		ResourceMap resourceMap,
@@ -555,10 +555,10 @@ public class VocabularyResource extends
     		String itemSpecifier, 	// Either a CSID or a URN form.
     		PoxPayloadIn theUpdate) throws Exception {
     	PoxPayloadOut result = null;
-    	
+
         ServiceContext<PoxPayloadIn, PoxPayloadOut> ctx = createServiceContext(getItemServiceName(), theUpdate, resourceMap, uriInfo);
         ctx.setCurrentRepositorySession(repoSession);
-        
+
         result = updateAuthorityItem(ctx, resourceMap, uriInfo, parentSpecifier, itemSpecifier, theUpdate,
         		AuthorityServiceUtils.UPDATE_REV,			// passing TRUE so rev num increases, passing
         		AuthorityServiceUtils.NO_CHANGE,	// don't change the state of the "proposed" field -we could be performing a sync or just a plain update
@@ -572,12 +572,12 @@ public class VocabularyResource extends
     @Override
     public Response get(
             @Context Request request,
-            @Context ResourceMap resourceMap, 
+            @Context ResourceMap resourceMap,
             @Context UriInfo uriInfo,
             @PathParam("csid") String specifier) {
     	Response result = null;
     	uriInfo = new UriInfoWrapper(uriInfo);
-        
+
         try {
         	MultivaluedMap<String,String> queryParams = uriInfo.getQueryParameters();
         	String showItemsValue = (String)queryParams.getFirst(VocabularyClient.SHOW_ITEMS_QP);
@@ -613,7 +613,7 @@ public class VocabularyResource extends
 
         return result;
     }
-    
+
     @Override
     public String getServiceName() {
         return vocabularyServiceName;
@@ -623,7 +623,7 @@ public class VocabularyResource extends
     public String getItemServiceName() {
         return vocabularyItemServiceName;
     }
-    
+
 	@Override
 	public Class<VocabulariesCommon> getCommonPartClass() {
 		return VocabulariesCommon.class;
@@ -638,16 +638,16 @@ public class VocabularyResource extends
     protected String getRefPropName() {
     	return ServiceBindingUtils.TERM_REF_PROP;
     }
-	
+
 	@Override
 	protected String getOrderByField(ServiceContext<PoxPayloadIn, PoxPayloadOut> ctx) {
 		String result = null;
 
-		result = ctx.getCommonPartLabel() + ":" + AuthorityItemJAXBSchema.DISPLAY_NAME;
+		result = authorityItemCommonSchemaName + ":" + AuthorityItemJAXBSchema.DISPLAY_NAME;
 
 		return result;
 	}
-	
+
 	@Override
 	protected String getPartialTermMatchField(ServiceContext<PoxPayloadIn, PoxPayloadOut> ctx) {
 		return getOrderByField(ctx);


### PR DESCRIPTION
**What does this do?**

When initializing term lists (and authorities), this checks if a term with the display name already exists. If so, the term is not added. Previously, the check was only on short name.

**Why are we doing this? (with JIRA link)**

This fixes confusion caused when a term previously added by a user becomes a default term in a term list. Upon initialization, the new default term is likely to have a different short name than the user-added term, even though they have the same display name. Previously, the term would be added, resulting in what looked like a duplicate term, with no easy way to tell which one to use. A default term will now not be added if it has the same display name as a different term, even if it has a different short name.

JIRA: https://collectionspace.atlassian.net/browse/DRYD-1420

**How should this be tested? Do these changes have associated tests?**

- In a local CSpace installation, add a term to a term list.
- In the application configuration, define a new default term in that term list, with the same display name and a different short name.
- Redeploy and restart CSpace.

The new default term should not be created.

**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran this locally.