### PR TITLE
Support for deurning arrays in reports

### DIFF
--- a/services/report/service/src/main/java/org/collectionspace/services/report/jasperreports/CSpaceReportScriptlet.java
+++ b/services/report/service/src/main/java/org/collectionspace/services/report/jasperreports/CSpaceReportScriptlet.java
@@ -119,7 +119,7 @@ public class CSpaceReportScriptlet extends JRDefaultScriptlet {
 			logger.warn("{}: array could not be read for field: {}", getReportName(), field.getName(), e);
 		}
 
-		field.setValue(deurned);
+		field.setValue(new DeurnArray(deurned));
 	}
 
 	private void deurnField(JRFillField field) {

--- a/services/report/service/src/main/java/org/collectionspace/services/report/jasperreports/CSpaceReportScriptlet.java
+++ b/services/report/service/src/main/java/org/collectionspace/services/report/jasperreports/CSpaceReportScriptlet.java
@@ -79,19 +79,14 @@ public class CSpaceReportScriptlet extends JRDefaultScriptlet {
 					continue;
 				}
 
-				// kind of janky - we want the correct type in the jrxml (java.util.List), so we can't check the
-				// value class. Instead, get the value which should be a java.sql.Array.
-				if (field.getValue() instanceof Array) {
+				if (field.getValueClass().equals(String.class)) {
+					deurnField(field);
+				} else if (field.getValueClass().equals(Array.class)) {
 					deurnArray(field);
-				}
-
-				if (!field.getValueClass().equals(String.class)) {
+				} else {
 					logger.warn("{}: deurn field is not a string or array: {}", getReportName(), fieldName);
-
-					continue;
 				}
 
-				deurnField(field);
 			}
 		}
 	}

--- a/services/report/service/src/main/java/org/collectionspace/services/report/jasperreports/CSpaceReportScriptlet.java
+++ b/services/report/service/src/main/java/org/collectionspace/services/report/jasperreports/CSpaceReportScriptlet.java
@@ -107,7 +107,9 @@ public class CSpaceReportScriptlet extends JRDefaultScriptlet {
 
 			for (String value : (String[]) array.getArray()) {
 				try {
-					deurned.add(RefNameUtils.getDisplayName(value));
+					if (value != null) {
+						deurned.add(RefNameUtils.getDisplayName(value));
+					}
 				} catch (IllegalArgumentException ex) {
 					logger.debug("{}: skipping {}", getReportName(), value);
 					deurned.add(value);

--- a/services/report/service/src/main/java/org/collectionspace/services/report/jasperreports/CSpaceReportScriptlet.java
+++ b/services/report/service/src/main/java/org/collectionspace/services/report/jasperreports/CSpaceReportScriptlet.java
@@ -95,6 +95,10 @@ public class CSpaceReportScriptlet extends JRDefaultScriptlet {
 		Array array = (Array) field.getValue();
 		List<String> deurned = new ArrayList<String>();
 		try {
+			if (array == null) {
+				return;
+			}
+
 			if (!array.getBaseTypeName().equals("varchar")) {
 				logger.warn("{}: array base type is not varchar: {}", getReportName(), field.getName());
 				return;

--- a/services/report/service/src/main/java/org/collectionspace/services/report/jasperreports/CSpaceReportScriptlet.java
+++ b/services/report/service/src/main/java/org/collectionspace/services/report/jasperreports/CSpaceReportScriptlet.java
@@ -101,7 +101,7 @@ public class CSpaceReportScriptlet extends JRDefaultScriptlet {
 		List<String> deurned = new ArrayList<String>();
 		try {
 			if (!array.getBaseTypeName().equals("varchar")) {
-				logger.warn("{}: array field is not a string: {}", getReportName(), field.getName());
+				logger.warn("{}: array base type is not varchar: {}", getReportName(), field.getName());
 				return;
 			}
 

--- a/services/report/service/src/main/java/org/collectionspace/services/report/jasperreports/DeurnArray.java
+++ b/services/report/service/src/main/java/org/collectionspace/services/report/jasperreports/DeurnArray.java
@@ -1,0 +1,73 @@
+package org.collectionspace.services.report.jasperreports;
+
+import java.sql.Array;
+import java.sql.ResultSet;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A java.sql.Array of deurned refnames. Only supports varchar arrays.
+ */
+public class DeurnArray implements Array {
+
+    private final String[] array;
+
+    public DeurnArray(final List<String> array) {
+        this.array = array.toArray(new String[0]);
+    }
+
+    @Override
+    public String getBaseTypeName() {
+        return "varchar";
+    }
+
+    @Override
+    public int getBaseType() {
+        return 12;
+    }
+
+    @Override
+    public Object getArray() {
+        return array;
+    }
+
+    @Override
+    public Object getArray(Map<String, Class<?>> map) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getArray(long index, int count) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getArray(long index, int count, Map<String, Class<?>> map) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ResultSet getResultSet() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ResultSet getResultSet(Map<String, Class<?>> map) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ResultSet getResultSet(long index, int count) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ResultSet getResultSet(long index, int count, Map<String, Class<?>> map) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void free() {
+        // no-op
+    }
+}


### PR DESCRIPTION
**What does this do?**
* Add deurn function for arrays

**Why are we doing this? (with JIRA link)**
This is to support new reports [DRYD-1334](https://collectionspace.atlassian.net/browse/DRYD-1334) and [DRYD-1335](https://collectionspace.atlassian.net/browse/DRYD-1334). It allows us to deurn in the services layer rather than the database. 

**How should this be tested? Do these changes have associated tests?**
* Pass an array in to the deurn fields
* See that it is deurned

**Dependencies for merging? Releasing to production?**
@ray-lee I wanted to get this in first before doing the reports as I have a few thoughts/concerns on it first.

I opted to set the field to a List, but I'm still debating this. This is fine for groovy, but when using Rhino for the jasper expressions there isn't really good support for Lists. I think instead we probably should just do an array which seems like it will work better for both.

Likewise the jrxml has some pain points as well. When defining the class for the field, java.sql.Array is normally used, which makes sense. However, to create a new sql Array you need the db connection then you can assign the primitive array to it. I opted not to do this and instead just set the field type to java.util.List. It works, but is kind of quirky and was something I wanted to bring up. If you need an example of it lmk and I'll add some samples.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter used these for the new reports