### PR TITLE
DRYD-1351: API For Supporting Create Page Update

### DIFF
--- a/services/servicegroup/jaxb/src/main/resources/servicegroup_common.xsd
+++ b/services/servicegroup/jaxb/src/main/resources/servicegroup_common.xsd
@@ -11,34 +11,31 @@
     $LastChangedDate: 2010-06-02 16:03:51 -0700 (Wed, 02 Jun 2010) $
 -->
 
-<xs:schema 
+<xs:schema
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
   jaxb:version="1.0" elementFormDefault="unqualified"
-  xmlns:ns="http://collectionspace.org/services/servicegroup"
   xmlns="http://collectionspace.org/services/servicegroup"
   targetNamespace="http://collectionspace.org/services/servicegroup"
   version="0.1"
 >
 
-    <!-- servicegroup -->
-    <xs:element name="servicegroups_common">
-        <xs:complexType>
+  <!-- servicegroup -->
+  <xs:element name="servicegroups_common">
+    <xs:complexType>
+      <xs:sequence>
+        <!--  ServiceGroup Information Group -->
+        <xs:element name="name" type="xs:string" />
+        <xs:element name="uri" type="xs:string" />
+        <xs:element name="hasDocTypes">
+          <xs:complexType>
             <xs:sequence>
-                <!--  ServiceGroup Information Group -->
-                <xs:element name="name" type="xs:string"/>
-                <xs:element name="uri" type="xs:string"/>
-				<xs:element name="hasDocTypes">
-					<xs:complexType>
-						<xs:sequence>
-							<xs:element name="hasDocType" type="xs:string"
-								minOccurs="1" maxOccurs="unbounded" />
-						</xs:sequence>
-					</xs:complexType>
-				</xs:element>
+              <xs:element name="hasDocType" type="xs:string" minOccurs="1" maxOccurs="unbounded" />
             </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-    
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
 </xs:schema>
 

--- a/services/servicegroup/service/src/main/java/org/collectionspace/services/servicegroup/ServiceGroupResource.java
+++ b/services/servicegroup/service/src/main/java/org/collectionspace/services/servicegroup/ServiceGroupResource.java
@@ -2,19 +2,19 @@
  *  This document is a part of the source code and related artifacts
  *  for CollectionSpace, an open source collections management system
  *  for museums and related institutions:
-
+ *
  *  http://www.collectionspace.org
  *  http://wiki.collectionspace.org
-
+ *
  *  Copyright 2009 University of California at Berkeley
-
+ *
  *  Licensed under the Educational Community License (ECL), Version 2.0.
  *  You may not use this file except in compliance with this License.
-
+ *
  *  You may obtain a copy of the ECL 2.0 License at
-
+ *
  *  https://source.collectionspace.org/collection-space/LICENSE.txt
-
+ *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,14 +25,24 @@ package org.collectionspace.services.servicegroup;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
-
+import java.util.Set;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import javax.xml.parsers.ParserConfigurationException;
 import org.collectionspace.services.ServiceGroupListItemJAXBSchema;
 import org.collectionspace.services.client.IQueryManager;
 import org.collectionspace.services.client.PoxPayloadIn;
 import org.collectionspace.services.client.PoxPayloadOut;
 import org.collectionspace.services.client.ServiceGroupClient;
-import org.collectionspace.services.jaxb.AbstractCommonList;
 import org.collectionspace.services.common.AbstractCollectionSpaceResourceImpl;
 import org.collectionspace.services.common.CSWebApplicationException;
 import org.collectionspace.services.common.NuxeoBasedResource;
@@ -48,26 +58,14 @@ import org.collectionspace.services.common.context.ServiceContext;
 import org.collectionspace.services.common.context.ServiceContextFactory;
 import org.collectionspace.services.common.document.DocumentFilter;
 import org.collectionspace.services.common.query.QueryManager;
-import org.collectionspace.services.common.vocabulary.RefNameServiceUtils;
-import org.collectionspace.services.common.vocabulary.RefNameServiceUtils.Specifier;
-import org.collectionspace.services.common.vocabulary.RefNameServiceUtils.SpecifierForm;
 import org.collectionspace.services.config.service.ServiceBindingType;
 import org.collectionspace.services.config.service.ServiceObjectType;
+import org.collectionspace.services.jaxb.AbstractCommonList;
 import org.collectionspace.services.nuxeo.client.java.CommonList;
 import org.collectionspace.services.nuxeo.client.java.NuxeoDocumentFilter;
 import org.collectionspace.services.servicegroup.nuxeo.ServiceGroupDocumentModelHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriInfo;
 
 @Path(ServiceGroupClient.SERVICE_PATH)
 @Produces({"application/xml"})
@@ -75,31 +73,31 @@ import javax.ws.rs.core.UriInfo;
 public class ServiceGroupResource extends AbstractCollectionSpaceResourceImpl<PoxPayloadIn, PoxPayloadOut> {
 
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
-    
-    private final static boolean EXCLUDE_AUTHORITIES = false;
-    private final static boolean INCLUDE_AUTHORITIES = true;
-    
+
+    private static final boolean EXCLUDE_AUTHORITIES = false;
+    private static final boolean INCLUDE_AUTHORITIES = true;
+
     @Override
-    public String getServiceName(){
+    public String getServiceName() {
         return ServiceGroupClient.SERVICE_NAME;
     }
 
-    public String getServicePathComponent(){
+    public String getServicePathComponent() {
         return ServiceGroupClient.SERVICE_NAME.toLowerCase();
     }
 
     @Override
     protected String getVersionString() {
-    	final String lastChangeRevision = "$LastChangedRevision: 2108 $";
-    	return lastChangeRevision;
+        final String lastChangeRevision = "$LastChangedRevision: 2108 $";
+        return lastChangeRevision;
     }
 
     @Override
-    //public Class<ServicegroupsCommon> getCommonPartClass() {
+    // public Class<ServicegroupsCommon> getCommonPartClass() {
     public Class<?> getCommonPartClass() {
-    	try {
-            return Class.forName("org.collectionspace.services.servicegroup.ServicegroupsCommon");//.class;
-        } catch (ClassNotFoundException e){
+        try {
+            return Class.forName("org.collectionspace.services.servicegroup.ServicegroupsCommon"); // .class;
+        } catch (ClassNotFoundException e) {
             return null;
         }
     }
@@ -109,53 +107,47 @@ public class ServiceGroupResource extends AbstractCollectionSpaceResourceImpl<Po
         return MultipartServiceContextFactory.get();
     }
 
-
-    //======================= GET without specifier: List  =====================================
+    // ======================= GET without specifier: List  =====================================
     @GET
     public AbstractCommonList getList(@Context UriInfo ui) {
         try {
             CommonList commonList = new CommonList();
-            AbstractCommonList list = (AbstractCommonList)commonList;
-	    	ArrayList<String> svcGroups = new ArrayList<String>();
-	    	svcGroups.add("procedure");
-	    	svcGroups.add("object");
-	    	svcGroups.add("authority");
-	    	// Fetch the list of groups from the tenant-bindings config, and prepare a list item
-	    	// for each one.
-	        // We always declare this a full list, of the size that we are returning. 
-	    	// Not quite in the spirit of what paging means, but tells callers not to ask for more.
-	    	list.setPageNum(0);
-	    	list.setPageSize(svcGroups.size());
-	        list.setItemsInPage(svcGroups.size());
-	        list.setTotalItems(svcGroups.size());
-	        String fields[] = new String[2];
-	        fields[0] = ServiceGroupListItemJAXBSchema.NAME;
-	        fields[1] = ServiceGroupListItemJAXBSchema.URI;
-	        commonList.setFieldsReturned(fields);
-			HashMap<String, Object> item = new HashMap<String, Object>();
-	        for(String groupName:svcGroups){
-	            item.put(ServiceGroupListItemJAXBSchema.NAME, groupName);
-	            String uri = "/" + getServiceName().toLowerCase() + "/" + groupName;
-	            item.put(ServiceGroupListItemJAXBSchema.URI, uri);
-	            commonList.addItem(item);
-	            item.clear();
-	        }
-	        return list;
+            AbstractCommonList list = (AbstractCommonList) commonList;
+            ArrayList<String> svcGroups = new ArrayList<String>();
+            svcGroups.add("procedure");
+            svcGroups.add("object");
+            svcGroups.add("authority");
+            // Fetch the list of groups from the tenant-bindings config, and prepare a list item
+            // for each one.
+            // We always declare this a full list, of the size that we are returning.
+            // Not quite in the spirit of what paging means, but tells callers not to ask for more.
+            list.setPageNum(0);
+            list.setPageSize(svcGroups.size());
+            list.setItemsInPage(svcGroups.size());
+            list.setTotalItems(svcGroups.size());
+            String fields[] = new String[2];
+            fields[0] = ServiceGroupListItemJAXBSchema.NAME;
+            fields[1] = ServiceGroupListItemJAXBSchema.URI;
+            commonList.setFieldsReturned(fields);
+            HashMap<String, Object> item = new HashMap<String, Object>();
+            for (String groupName : svcGroups) {
+                item.put(ServiceGroupListItemJAXBSchema.NAME, groupName);
+                String uri = "/" + getServiceName().toLowerCase() + "/" + groupName;
+                item.put(ServiceGroupListItemJAXBSchema.URI, uri);
+                commonList.addItem(item);
+                item.clear();
+            }
+            return list;
         } catch (Exception e) {
             throw bigReThrow(e, ServiceMessages.LIST_FAILED);
         }
-        
     }
 
-    
-    //======================= GET ====================================================
-    // NOTE that csid is not a good name for the specifier, but if we name it anything else, 
-    // our AuthZ gets confused!!!
+    // ======================= GET ====================================================
+    // NOTE that csid is not a good name for the specifier, but if we name it anything else our AuthZ gets confused!!!
     @GET
     @Path("{csid}")
-    public byte[] get(
-            @Context UriInfo ui,
-            @PathParam("csid") String groupname) {
+    public byte[] get(@Context UriInfo ui, @PathParam("csid") String groupname) {
         PoxPayloadOut result = null;
         ensureCSID(groupname, NuxeoBasedResource.READ);
         try {
@@ -163,21 +155,23 @@ public class ServiceGroupResource extends AbstractCollectionSpaceResourceImpl<Po
             ServiceGroupDocumentModelHandler handler = (ServiceGroupDocumentModelHandler) createDocumentHandler(ctx);
             TenantBindingConfigReaderImpl tReader = ServiceMain.getInstance().getTenantBindingConfigReader();
             // We need to get all the procedures, authorities, and objects.
-	        ArrayList<String> groupsList = null;  
-	        if("common".equalsIgnoreCase(groupname)) {
-	        	groupsList = ServiceBindingUtils.getCommonServiceTypes(INCLUDE_AUTHORITIES);
-	        } else {
-	        	groupsList = new ArrayList<String>();
-	        	groupsList.add(groupname);
-	        }
-            List<ServiceBindingType> servicebindings = tReader.getServiceBindingsByType(ctx.getTenantId(), groupsList);
-            if (servicebindings == null || servicebindings.isEmpty()) {
-            	// 404 if there are no mappings.
-                Response response = Response.status(Response.Status.NOT_FOUND).entity(
-                        ServiceMessages.READ_FAILED + ServiceMessages.resourceNotFoundMsg(groupname)).type("text/plain").build();
+            ArrayList<String> groupsList = null;
+            if ("common".equalsIgnoreCase(groupname)) {
+                groupsList = ServiceBindingUtils.getCommonServiceTypes(INCLUDE_AUTHORITIES);
+            } else {
+                groupsList = new ArrayList<String>();
+                groupsList.add(groupname);
+            }
+            List<ServiceBindingType> bindings = tReader.getServiceBindingsByType(ctx.getTenantId(), groupsList);
+            if (bindings == null || bindings.isEmpty()) {
+                // 404 if there are no mappings.
+                Response response = Response.status(Response.Status.NOT_FOUND)
+                        .entity(ServiceMessages.READ_FAILED + ServiceMessages.resourceNotFoundMsg(groupname))
+                        .type("text/plain")
+                        .build();
                 throw new CSWebApplicationException(response);
             }
-        	//Otherwise, build the response with a list
+            // Otherwise, build the response with a list
             ServicegroupsCommon common = new ServicegroupsCommon();
             common.setName(groupname);
             String uri = "/" + getServicePathComponent() + "/" + groupname;
@@ -272,69 +266,67 @@ public class ServiceGroupResource extends AbstractCollectionSpaceResourceImpl<Po
     @GET
     @Path("{csid}/items")
     public AbstractCommonList getResourceItemList(
-            @Context UriInfo uriInfo,
-            @PathParam("csid") String serviceGroupName) {
-    	UriInfoWrapper ui = new UriInfoWrapper(uriInfo);
+            @Context UriInfo uriInfo, @PathParam("csid") String serviceGroupName) {
+        UriInfoWrapper ui = new UriInfoWrapper(uriInfo);
         ensureCSID(serviceGroupName, NuxeoBasedResource.READ);
         AbstractCommonList list = null;
         try {
             ServiceContext<PoxPayloadIn, PoxPayloadOut> ctx = createServiceContext(ui);
-	        ServiceGroupDocumentModelHandler handler = (ServiceGroupDocumentModelHandler)
-	        				createDocumentHandler(ctx);
-	        ArrayList<String> groupsList = null;  
-	        if("common".equalsIgnoreCase(serviceGroupName)) {
-	        	groupsList = ServiceBindingUtils.getCommonServiceTypes(INCLUDE_AUTHORITIES);
-	        } else {
-	        	groupsList = new ArrayList<String>();
-	        	groupsList.add(serviceGroupName);
-	        }
-	        
-	        // check first for a csid query parameter
+            ServiceGroupDocumentModelHandler handler = (ServiceGroupDocumentModelHandler) createDocumentHandler(ctx);
+            ArrayList<String> groupsList = null;
+            if ("common".equalsIgnoreCase(serviceGroupName)) {
+                groupsList = ServiceBindingUtils.getCommonServiceTypes(INCLUDE_AUTHORITIES);
+            } else {
+                groupsList = new ArrayList<String>();
+                groupsList.add(serviceGroupName);
+            }
+
+            // check first for a csid query parameter
             MultivaluedMap<String, String> queryParams = ctx.getQueryParams();
-	        String csid = queryParams.getFirst(IQueryManager.CSID_QUERY_PARAM);
-	        if (csid != null && !csid.isEmpty()) {
-	            String whereClause = QueryManager.createWhereClauseFromCsid(csid);
-	            if (Tools.isEmpty(whereClause)) {
-	                if (logger.isDebugEnabled()) {
-	                	logger.debug("The WHERE clause is empty for csid: ["+csid+"]");
-	                }
-	            } else {
-		            DocumentFilter documentFilter = handler.getDocumentFilter();
-		            documentFilter.appendWhereClause(whereClause, IQueryManager.SEARCH_QUALIFIER_AND);
-		            if (logger.isDebugEnabled()) {
-		                logger.debug("The WHERE clause is: " + documentFilter.getWhereClause());
-		            }
-	            }
-	        } else {
-		        // check to see if we have to set up a keyword search
-	            String keywords = queryParams.getFirst(IQueryManager.SEARCH_TYPE_KEYWORDS_KW);
-		        if (keywords != null && !keywords.isEmpty()) {
-		            String whereClause = QueryManager.createWhereClauseFromKeywords(keywords);
-		            if(Tools.isEmpty(whereClause)) {
-		                if (logger.isDebugEnabled()) {
-		                	logger.debug("The WHERE clause is empty for keywords: ["+keywords+"]");
-		                }
-		            } else {
-			            DocumentFilter documentFilter = handler.getDocumentFilter();
-			            documentFilter.appendWhereClause(whereClause, IQueryManager.SEARCH_QUALIFIER_AND);
-			            if (logger.isDebugEnabled()) {
-			                logger.debug("The WHERE clause is: " + documentFilter.getWhereClause());
-			            }
-		            }
-		        }	        	
-	        }
-	        
+            String csid = queryParams.getFirst(IQueryManager.CSID_QUERY_PARAM);
+            if (csid != null && !csid.isEmpty()) {
+                String whereClause = QueryManager.createWhereClauseFromCsid(csid);
+                if (Tools.isEmpty(whereClause)) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("The WHERE clause is empty for csid: [" + csid + "]");
+                    }
+                } else {
+                    DocumentFilter documentFilter = handler.getDocumentFilter();
+                    documentFilter.appendWhereClause(whereClause, IQueryManager.SEARCH_QUALIFIER_AND);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("The WHERE clause is: " + documentFilter.getWhereClause());
+                    }
+                }
+            } else {
+                // check to see if we have to set up a keyword search
+                String keywords = queryParams.getFirst(IQueryManager.SEARCH_TYPE_KEYWORDS_KW);
+                if (keywords != null && !keywords.isEmpty()) {
+                    String whereClause = QueryManager.createWhereClauseFromKeywords(keywords);
+                    if (Tools.isEmpty(whereClause)) {
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("The WHERE clause is empty for keywords: [" + keywords + "]");
+                        }
+                    } else {
+                        DocumentFilter documentFilter = handler.getDocumentFilter();
+                        documentFilter.appendWhereClause(whereClause, IQueryManager.SEARCH_QUALIFIER_AND);
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("The WHERE clause is: " + documentFilter.getWhereClause());
+                        }
+                    }
+                }
+            }
+
             String advancedSearch = queryParams.getFirst(IQueryManager.SEARCH_TYPE_KEYWORDS_AS);
-	        if (advancedSearch != null && !advancedSearch.isEmpty()) {
-	            DocumentFilter documentFilter = handler.getDocumentFilter();
-	            String whereClause = QueryManager.createWhereClauseFromAdvancedSearch(advancedSearch);
-	            documentFilter.appendWhereClause(whereClause, IQueryManager.SEARCH_QUALIFIER_AND);
-	            if (logger.isDebugEnabled()) {
-	                logger.debug("The WHERE clause is: " + documentFilter.getWhereClause());
-	            }
-	        }
-	        
-	        // make the query
+            if (advancedSearch != null && !advancedSearch.isEmpty()) {
+                DocumentFilter documentFilter = handler.getDocumentFilter();
+                String whereClause = QueryManager.createWhereClauseFromAdvancedSearch(advancedSearch);
+                documentFilter.appendWhereClause(whereClause, IQueryManager.SEARCH_QUALIFIER_AND);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("The WHERE clause is: " + documentFilter.getWhereClause());
+                }
+            }
+
+            // make the query
             list = handler.getItemListForGroup(ctx, groupsList);
         } catch (Exception e) {
             throw bigReThrow(e, ServiceMessages.READ_FAILED, serviceGroupName);
@@ -346,30 +338,29 @@ public class ServiceGroupResource extends AbstractCollectionSpaceResourceImpl<Po
     @GET
     @Path("{csid}/items/{specifier}")
     public byte[] getResourceItem(
-    		@Context ResourceMap resourceMap,
+            @Context ResourceMap resourceMap,
             @Context UriInfo uriInfo,
             @PathParam("csid") String serviceGroupName,
             @PathParam("specifier") String specifier) {
-    	UriInfoWrapper ui = new UriInfoWrapper(uriInfo);
+        UriInfoWrapper ui = new UriInfoWrapper(uriInfo);
         ensureCSID(serviceGroupName, NuxeoBasedResource.READ);
         PoxPayloadOut result = null;
-        
+
         try {
             ServiceContext<PoxPayloadIn, PoxPayloadOut> ctx = createServiceContext(ui);
-	        ServiceGroupDocumentModelHandler handler = (ServiceGroupDocumentModelHandler)
-	        				createDocumentHandler(ctx);
-	        ArrayList<String> groupsList = null;  
-	        if("common".equalsIgnoreCase(serviceGroupName)) {
-	        	groupsList = ServiceBindingUtils.getCommonServiceTypes(INCLUDE_AUTHORITIES);
-	        } else {
-	        	groupsList = new ArrayList<String>();
-	        	groupsList.add(serviceGroupName);
-	        }
-	        
+            ServiceGroupDocumentModelHandler handler = (ServiceGroupDocumentModelHandler) createDocumentHandler(ctx);
+            ArrayList<String> groupsList = null;
+            if ("common".equalsIgnoreCase(serviceGroupName)) {
+                groupsList = ServiceBindingUtils.getCommonServiceTypes(INCLUDE_AUTHORITIES);
+            } else {
+                groupsList = new ArrayList<String>();
+                groupsList.add(serviceGroupName);
+            }
+
             String whereClause = QueryManager.createWhereClauseFromCsid(specifier);
             DocumentFilter myFilter = new NuxeoDocumentFilter(whereClause, 0, 1);
-            handler.setDocumentFilter(myFilter);    
-	        
+            handler.setDocumentFilter(myFilter);
+
             result = handler.getResourceItemForCsid(ctx, groupsList, specifier);
         } catch (Exception e) {
             throw bigReThrow(e, ServiceMessages.READ_FAILED, serviceGroupName);

--- a/services/servicegroup/service/src/main/java/org/collectionspace/services/servicegroup/ServiceGroupResource.java
+++ b/services/servicegroup/service/src/main/java/org/collectionspace/services/servicegroup/ServiceGroupResource.java
@@ -93,10 +93,9 @@ public class ServiceGroupResource extends AbstractCollectionSpaceResourceImpl<Po
     }
 
     @Override
-    // public Class<ServicegroupsCommon> getCommonPartClass() {
     public Class<?> getCommonPartClass() {
         try {
-            return Class.forName("org.collectionspace.services.servicegroup.ServicegroupsCommon"); // .class;
+            return Class.forName("org.collectionspace.services.servicegroup.ServicegroupsCommon");
         } catch (ClassNotFoundException e) {
             return null;
         }

--- a/services/servicegroup/service/src/main/java/org/collectionspace/services/servicegroup/ServiceGroupResource.java
+++ b/services/servicegroup/service/src/main/java/org/collectionspace/services/servicegroup/ServiceGroupResource.java
@@ -151,7 +151,7 @@ public class ServiceGroupResource extends AbstractCollectionSpaceResourceImpl<Po
         PoxPayloadOut result = null;
         ensureCSID(groupname, NuxeoBasedResource.READ);
         try {
-            ServiceContext<PoxPayloadIn, PoxPayloadOut> ctx = createServiceContext();
+            ServiceContext<PoxPayloadIn, PoxPayloadOut> ctx = createServiceContext(ui);
             ServiceGroupDocumentModelHandler handler = (ServiceGroupDocumentModelHandler) createDocumentHandler(ctx);
             TenantBindingConfigReaderImpl tReader = ServiceMain.getInstance().getTenantBindingConfigReader();
             // We need to get all the procedures, authorities, and objects.

--- a/services/servicegroup/service/src/main/java/org/collectionspace/services/servicegroup/nuxeo/ServiceGroupDocumentModelHandler.java
+++ b/services/servicegroup/service/src/main/java/org/collectionspace/services/servicegroup/nuxeo/ServiceGroupDocumentModelHandler.java
@@ -268,6 +268,10 @@ public class ServiceGroupDocumentModelHandler
 	 * @return true if the ServiceBinding contains all query parameters, false otherwise
 	 */
 	public boolean acceptServiceBinding(ServiceBindingType binding, String queryTag) {
+		if (queryTag == null || queryTag.isEmpty()) {
+			return true;
+		}
+
 		final Tags tags = binding.getTags();
 		final List<String> tagList = tags == null ? Collections.<String>emptyList() : tags.getTag();
 


### PR DESCRIPTION
**What does this do?**
* Add new endpoint /servicegroups/:group/tags
* Add servicetag query param to /servicegroups/:group
* Apply spotless

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1351

We want to be able to organize procedures on the Create New page into groups. In order to do this we added support for tagging procedures, but didn't update the API to support what tags exist and displaying record types which have a given tag. These changes add both of those to the ServiceGroupResource which allows us to finish the workflow in the ui.

**How should this be tested? Do these changes have associated tests?**
* Rebuild and deploy collectionspace
* Test the new `/servicegroups/:group/tags` endpoint
  * e.g. `curl -H "Accept: application/json" -v --user admin@core.collectionspace.org:Administrator http://localhost:8180/cspace-services/servicegroups/procedure/tags`
  * `curl -H "Accept: application/json" -v --user admin@core.collectionspace.org:Administrator http://localhost:8180/cspace-services/servicegroups/authority/tags`
* Test the query parameter on `/servicegroups/:group`
  * `curl -H "Accept: application/json" -v --user admin@core.collectionspace.org:Administrator "http://localhost:8180/cspace-services/servicegroups/procedure?servicetag=nagpra"`

**Dependencies for merging? Releasing to production?**
This lacks tests, though some could be added to the `ServiceGroupServiceTest`.

**Has the application documentation been updated for these changes?**
No. API documentation will need to be updated for the new endpoint and query parameter.

**Did someone actually run this code to verify it works?**
@mikejritter tested locally 
