### PR TITLE
Set compiler target to 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,8 +188,8 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.1</version>
 					<configuration>
-						<source>1.7</source>
-						<target>1.7</target>
+						<source>1.8</source>
+						<target>1.8</target>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
**What does this do?**
Update the compiler to target Java 8

**Why are we doing this? (with JIRA link)**
We've been running Java 8 in production for a while and with some of the dependency updates recently we've been able to target Java 8. Ideally we'd move to the latest version but since that will be a bigger target we're doing this for some better quality of life.

**How should this be tested? Do these changes have associated tests?**
* Rebuild collectionspace with tenants enabled for integration testing
* Start collectionspace
* Run the integration tests for the services layer

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter built and ran integration tests against a local instance