### PR TITLE
Add relatedLinks, featuredCollection displayName to elastic index

### DIFF
--- a/services/common/src/main/cspace/config/services/tenants/fcart/fcart-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/fcart/fcart-tenant-bindings.delta.xml
@@ -53,6 +53,7 @@
 							"collectionobjects_common:objectStatusList",
 							"collectionobjects_common:otherNumberList",
 							"collectionobjects_common:ownersContributionNote",
+							"collectionobjects_common:publishedRelatedLinkGroupList",
 							"collectionobjects_common:publishToList",
 							"collectionobjects_common:responsibleDepartments",
 							"collectionobjects_common:rightsGroupList.rightStatement",

--- a/services/common/src/main/cspace/config/services/tenants/materials/materials-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/materials/materials-tenant-bindings.delta.xml
@@ -190,7 +190,13 @@
                     "properties": {
                       "featuredCollection": {
                         "type": "keyword",
-                        "copy_to": "all_field"
+                        "copy_to": "all_field",
+                        "fields": {
+                          "displayName": {
+                            "type": "keyword",
+                            "normalizer": "refname_displayname_normalizer"
+                          }
+                        }
                       }
                     }
                   },

--- a/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
+++ b/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
@@ -1195,6 +1195,7 @@
 							"collectionobjects_common:objectStatusList",
 							"collectionobjects_common:otherNumberList",
 							"collectionobjects_common:ownersContributionNote",
+							"collectionobjects_common:publishedRelatedLinkGroupList",
 							"collectionobjects_common:publishToList",
 							"collectionobjects_common:responsibleDepartments",
 							"collectionobjects_common:rightsGroupList.rightStatement",


### PR DESCRIPTION
**What does this do?**
* Index new related link fields
* Index displayName for featuredCollection

**Why are we doing this? (with JIRA link)**
Jira:
* https://collectionspace.atlassian.net/browse/DRYD-1455
* https://collectionspace.atlassian.net/browse/DRYD-1456

The related link group list is a new field for 8.1 which is meant for the public browser. This adds the field to the elastic index so it can be... indexed.

Likewise there was a request to have the Featured collection be clickable with the link bringing you to the search results on the featured collection. Since the filtering is normally done using a human readable name, this adds the displayName field to the index for featuredCollections so that it may be queried on.

**How should this be tested? Do these changes have associated tests?**
I need to do a write up for deploying ElasticSearch and the cspace-public-gateway to the wiki as configuration needs to be updated for both CollectionSpace and the gateway in order to index + retrieve. 

Currently there are no tests for elasticsearch - we could look into using TestContainers with their elasticsearch support in the future.

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No; new indexes should be documented

**Did someone actually run this code to verify it works?**
@mikejritter tested the `publishedRelatedLinkGroupList`, however I ran into issues when testing materials. My intent here is to use dev to test if the fields are being indexed correctly.