### PR TITLE
DRYD-1431: Add descriptions to reports

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/accessions.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/accessions.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Accesssions</name>
-    <notes>accessions</notes>
+    <notes>The accession report includes basic accession information from the Acquistion Procedure paired with a list of related objects.</notes>
     <forDocTypes>
       <forDocType>Acquisition</forDocType>
     </forDocTypes>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/artwork_description.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/artwork_description.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Artwork Description</name>
-    <notes>Artwork Description</notes>
+    <notes>This object description report for art collections includes tombstone description details.</notes>
     <forDocTypes>
       <forDocType>CollectionObject</forDocType>
     </forDocTypes>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/borrowing_receipt.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/borrowing_receipt.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Borrowing Receipt</name>
-    <notes>Borrowing Receipt</notes>
+    <notes>This loan out report includes fields for generating a borrowing receipt.</notes>
     <forDocTypes>
       <forDocType>Loanout</forDocType>
     </forDocTypes>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/box_list.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/box_list.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Box List</name>
-    <notes>Box List Report</notes>
+    <notes>This location report includes a list of objects assigned to a single LMI in a one to many relationship.</notes>
     <forDocTypes>
       <forDocType>Movement</forDocType>
     </forDocTypes>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/condition.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/condition.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Condition</name>
-    <notes>Object with Condition Check</notes>
+    <notes>This condition report includes fields for describing the condition of objects.</notes>
     <forDocTypes>
       <forDocType>CollectionObject</forDocType>
     </forDocTypes>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/deaccessions.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/deaccessions.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Deaccessions</name>
-    <notes>Deaccession</notes>
+    <notes>This deaccession report includes fields documenting deaccession workflows.</notes>
     <forDocTypes>
       <forDocType>ObjectExit</forDocType>
     </forDocTypes>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/deed_of_gift.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/deed_of_gift.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Deed of Gift</name>
-    <notes>Deed of Gift</notes>
+    <notes>This intake report includes fields for generating a deed of gift statement or letter.</notes>
     <forDocTypes>
       <forDocType>Intake</forDocType>
     </forDocTypes>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/incoming_loan.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/incoming_loan.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Incoming Loan</name>
-    <notes>Incoming Loan</notes>
+    <notes>This loan report includes fields for generating an incoming loan report.</notes>
     <forDocTypes>
       <forDocType>Loanin</forDocType>
     </forDocTypes>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/incoming_loan_letter.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/incoming_loan_letter.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Incoming Loan Letter</name>
-    <notes>Incoming Loan Letter</notes>
+    <notes>This loan report includes fields for generating loan letters.</notes>
     <forDocTypes>
       <forDocType>Loanin</forDocType>
     </forDocTypes>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/obj_computed_location.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/obj_computed_location.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Basic Object with Current Location</name>
-    <notes>Object with Computed Current Location</notes>
+    <notes>This object report for the Public Art profile includes fields for storage/display locations.</notes>
     <forDocTypes>
       <forDocType>CollectionObject</forDocType>
     </forDocTypes>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/obj_current_place_details.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/obj_current_place_details.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Object with Current Place</name>
-    <notes>Object with Full Current Place Details (Public Art Profile)</notes>
+    <notes>This object report for the Public Art profile includes fields for storage/display locations.</notes>
     <forDocTypes>
       <forDocType>CollectionObject</forDocType>
     </forDocTypes>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/outgoing_loan.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/outgoing_loan.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Outgoing Loan</name>
-    <notes>Outgoing Loan</notes>
+    <notes>This loan report includes the fields for outgoing loans.</notes>
     <forDocTypes>
       <forDocType>Loanout</forDocType>
     </forDocTypes>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/outgoing_loan_letter.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/outgoing_loan_letter.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Outgoing Loan Letter</name>
-    <notes>outgoing loan letter</notes>
+    <notes>This loan report includes fields for creating outgoing loan letter.</notes>
     <forDocTypes>
       <forDocType>Loanout</forDocType>
     </forDocTypes>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/referral.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/referral.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Referral</name>
-    <notes>referral</notes>
+    <notes>This intake report includes fields for generating an accession recommendation.</notes>
     <forDocTypes>
       <forDocType>Intake</forDocType>
     </forDocTypes>


### PR DESCRIPTION
**What does this do?**
* Adds descriptions to reports

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1431

This adds descriptions to reports which had placeholders. Note that this is only for older reports, not newer ones for 8.1.

**How should this be tested? Do these changes have associated tests?**
* Build a clean install for CollectionSpace
* See that the reports have appropriate descriptions

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Also no.