### PR TITLE
8.1 Reports QA

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/Exhibition_List_Basic.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/Exhibition_List_Basic.jrxml
@@ -13,7 +13,7 @@
 	<style name="Column header" forecolor="#666666" fontName="SansSerif" fontSize="12" isBold="true"/>
 	<style name="Detail" fontName="SansSerif" fontSize="12"/>
 	<parameter name="deurnfields" class="java.lang.String" isForPrompting="false">
-		<defaultValueExpression><![CDATA["objectname,objectproductionorganizationrole,objectproductionpersonrole,computedcurrentlocation"]]></defaultValueExpression>
+		<defaultValueExpression><![CDATA["objectname,objectproductionorganizationrole,objectproductionpersonrole,objectproductionpeople,computedcurrentlocation"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="tenantid" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA["101"]]></defaultValueExpression>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/inventory_consultation.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/inventory_consultation.jrxml
@@ -257,14 +257,14 @@ $P!{whereclause}]]>
 				<text><![CDATA[AFO Count]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="700" y="0" width="100" height="60" uuid="c3bc7e35-43d8-4446-acba-f7ef559a54b2">
+				<reportElement style="Column header" x="700" y="0" width="95" height="60" uuid="c3bc7e35-43d8-4446-acba-f7ef559a54b2">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
 				<text><![CDATA[Site(s) Related to Requested Objects]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="800" y="0" width="100" height="60" uuid="1ccb6b44-add8-4be3-8b1e-6babd829939c">
+				<reportElement style="Column header" x="800" y="0" width="95" height="60" uuid="1ccb6b44-add8-4be3-8b1e-6babd829939c">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/inventory_consultation.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/inventory_consultation.jrxml
@@ -261,21 +261,21 @@ $P!{whereclause}]]>
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
-				<text><![CDATA[Archaeological Sites Related to NAGPRA Inventory]]></text>
+				<text><![CDATA[Site(s) Related to Requested Objects]]></text>
 			</staticText>
 			<staticText>
 				<reportElement style="Column header" x="800" y="0" width="100" height="60" uuid="1ccb6b44-add8-4be3-8b1e-6babd829939c">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
-				<text><![CDATA[Number of Associated Consultation Log Entries]]></text>
+				<text><![CDATA[Number of Related Consultation Log Entries]]></text>
 			</staticText>
 			<staticText>
 				<reportElement style="Column header" x="900" y="0" width="100" height="60" uuid="77fe4cfa-6cd6-406e-9125-dd513caf64db">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
-				<text><![CDATA[Exit Record - Current Owner with Exit Date]]></text>
+				<text><![CDATA[Exit Owner with Date]]></text>
 			</staticText>
 		</band>
 	</columnHeader>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/inventory_consultation.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/inventory_consultation.jrxml
@@ -321,13 +321,13 @@ $P!{whereclause}]]>
 				<reportElement style="Detail" x="500" y="0" width="100" height="30" uuid="c2c43e42-0fc1-4fad-b5bb-d8c62b534524">
 					<property name="com.jaspersoft.studio.unit.y" value="px" />
 				</reportElement>
-				<textFieldExpression><![CDATA[$F{afo_count}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{mni_count}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="600" y="0" width="100" height="30" uuid="411e6813-d586-4190-b721-7a22c00691ea">
 					<property name="com.jaspersoft.studio.unit.y" value="px" />
 				</reportElement>
-				<textFieldExpression><![CDATA[$F{mni_count}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{afo_count}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="700" y="0" width="100" height="30" uuid="659569aa-1ff0-4aa9-beaa-294337bd8315">

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/inventory_consultation.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/inventory_consultation.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Inventory Consultation</name>
-    <notes>Placeholder</notes>
+    <notes>This report provides an overview of consultations associated with NAGPRA summary documentation workflows.</notes>
     <forDocTypes>
       <forDocType>NagpraInventory</forDocType>
     </forDocTypes>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/notice_of_intent_to_repatriate.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/notice_of_intent_to_repatriate.jrxml
@@ -520,15 +520,17 @@ WHERE summary_hierarchy.primarytype = 'SummaryDocumentation' $P!{whereclause}]]>
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[var archObjects = $F{object_names}.getArray().filter((name) => !!name).join('; ');
+					var collectors = $F{collectors}.getArray().filter((collector) => !!collector).join('; ');
 					var donors = $F{acquisition_sources}.getArray().filter((donor) => !!donor).join('; ');
 					var removalDates = $F{dates}.getArray().filter((date) => !!date).join('; ');
 					var accessDates = $F{accession_dates}.getArray().filter((date) => !!date).join('; ');
 
 					var objString = 'Archaeological objects including: ' + archObjects + '\n\n';
-					var donorString = 'Collector Names: ' + donors + '\n\n';
+					var collectorString = 'Collector Names: ' + collectors + '\n\n';
+					var donorString = 'Donor Names: ' + donors + '\n\n';
 					var dateString = 'Date(s) Removed From Sites: ' + removalDates + '\n\n';
 					var accessString = 'Accession Date(s): ' + accessDates;
-					objString + donorString + dateString + accessString]]>
+					objString + collectorString + donorString + dateString + accessString]]>
 				</textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/notice_of_intent_to_repatriate.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/notice_of_intent_to_repatriate.jrxml
@@ -80,10 +80,10 @@ FROM hierarchy summary_hierarchy
   LEFT JOIN summarydocumentations_common_consultationnotes consultation ON consultation.id = summary.id AND consultation.pos = 0
   LEFT JOIN summarydocumentations_common_treatmentnotes treatment ON treatment.id = summary.id AND treatment.pos = 0
   LEFT JOIN LATERAL (
-    SELECT DISTINCT ON (hierarchy.parentid) hierarchy.parentid,
-      party.involvedparty,
-      ptg.title,
-      email.email
+    SELECT hierarchy.parentid,
+      array_agg(party.involvedparty) as involvedparty,
+      array_agg(ptg.title) as title,
+      array_agg(email.email) as email
     FROM hierarchy
       INNER JOIN partiesinvolvedgroup party ON party.id = hierarchy.id AND
         (party.involvedrole LIKE '%lineal_descendant%' OR party.involvedrole LIKE '%tribal_rep%')
@@ -93,10 +93,9 @@ FROM hierarchy summary_hierarchy
       INNER JOIN persontermgroup ptg on ptg.id = ptg_hierarchy.id
       LEFT JOIN contacts_common contact ON contact.initem = person_hierarchy.name
       LEFT JOIN hierarchy email_hier ON email_hier.parentid = contact.id AND email_hier.name = 'contacts_common:emailGroupList' AND email_hier.pos = 0
-      INNER JOIN emailgroup email ON email.id = email_hier.id
+      LEFT JOIN emailgroup email ON email.id = email_hier.id
     WHERE hierarchy.name = 'summarydocumentations_common:partiesInvolvedGroupList' AND hierarchy.parentid = summary.id
-    ORDER BY hierarchy.parentid,
-      hierarchy.pos
+    GROUP BY hierarchy.parentid
   ) partiesinvolved ON partiesinvolved.parentid = summary.id -- affiliation
   LEFT JOIN LATERAL (
     SELECT hierarchy.parentid,
@@ -259,20 +258,17 @@ WHERE summary_hierarchy.primarytype = 'SummaryDocumentation' $P!{whereclause}]]>
 		<property name="com.jaspersoft.studio.field.name" value="culture"/>
 		<property name="com.jaspersoft.studio.field.label" value="culture"/>
 	</field>
-	<field name="involved_party" class="java.lang.String">
+	<field name="involved_party" class="java.sql.Array">
 		<property name="com.jaspersoft.studio.field.name" value="involved_party"/>
 		<property name="com.jaspersoft.studio.field.label" value="involved_party"/>
-		<property name="com.jaspersoft.studio.field.tree.path" value="partiesinvolvedgroup"/>
 	</field>
-	<field name="involved_party_title" class="java.lang.String">
+	<field name="involved_party_title" class="java.sql.Array">
 		<property name="com.jaspersoft.studio.field.name" value="involved_party_title"/>
 		<property name="com.jaspersoft.studio.field.label" value="involved_party_title"/>
-		<property name="com.jaspersoft.studio.field.tree.path" value="persontermgroup"/>
 	</field>
-	<field name="involved_party_email" class="java.lang.String">
+	<field name="involved_party_email" class="java.sql.Array">
 		<property name="com.jaspersoft.studio.field.name" value="involved_party_email"/>
 		<property name="com.jaspersoft.studio.field.label" value="involved_party_email"/>
-		<property name="com.jaspersoft.studio.field.tree.path" value="emailgroup"/>
 	</field>
 	<field name="status" class="java.lang.String">
 		<property name="com.jaspersoft.studio.field.name" value="status"/>
@@ -472,7 +468,7 @@ WHERE summary_hierarchy.primarytype = 'SummaryDocumentation' $P!{whereclause}]]>
 					<property name="com.jaspersoft.studio.unit.width" value="px"/>
 				</reportElement>
 				<textElement markup="styled"/>
-				<text><![CDATA[Contact First Name]]></text>
+				<text><![CDATA[Contact Name]]></text>
 			</staticText>
 			<staticText>
 				<reportElement style="Column header" x="2000" y="0" width="100" height="60" uuid="db276d0d-15d2-4af3-b76c-f959370d7755">
@@ -480,7 +476,7 @@ WHERE summary_hierarchy.primarytype = 'SummaryDocumentation' $P!{whereclause}]]>
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 				</reportElement>
 				<textElement markup="styled"/>
-				<text><![CDATA[Contact email]]></text>
+				<text><![CDATA[Contact Email]]></text>
 			</staticText>
 			<staticText>
 				<reportElement style="Column header" x="2100" y="0" width="100" height="60" uuid="c455fd38-e37e-4572-a29b-342c208349a6">
@@ -627,19 +623,19 @@ WHERE summary_hierarchy.primarytype = 'SummaryDocumentation' $P!{whereclause}]]>
 				<reportElement style="Detail" x="1800" y="0" width="100" height="30" uuid="72d91ad9-c47f-4836-a213-b8b1f141c671">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
-				<textFieldExpression><![CDATA[$F{involved_party_title}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{involved_party_title}.getArray().filter((title) => !!title).join('; ')]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="1900" y="0" width="100" height="30" uuid="48b5bc79-166f-484b-bad7-cc6a81046cd2">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
-				<textFieldExpression><![CDATA[$F{involved_party}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{involved_party}.getArray().filter((party) => !!party).join('; ')]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="2000" y="0" width="100" height="30" uuid="18cf7052-4d5c-4c1d-bf37-c19cd4f0f9c7">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
-				<textFieldExpression><![CDATA[$F{involved_party_email}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{involved_party_email}.getArray().filter((email) => !!email).join('; ')]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
 				<reportElement style="Detail" x="2100" y="0" width="100" height="30" uuid="f406adee-b418-401d-9797-526656e2bdca">

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/notice_of_intent_to_repatriate.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/notice_of_intent_to_repatriate.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Notice of Intent to Repatriate</name>
-    <notes>first pass for notice of intent to repatriate</notes>
+    <notes>This report includes the fields for creating a Notice of Intent to Repatriate report to comply with NAGPRA.</notes>
     <forDocTypes>
       <forDocType>SummaryDocumentation</forDocType>
     </forDocTypes>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/notice_of_inventory_completion.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/notice_of_inventory_completion.jrxml
@@ -321,14 +321,14 @@ $P!{whereclause}]]>
 				<reportElement style="Column header" x="800" y="0" width="100" height="44" uuid="e35dabef-0dbc-4f08-a744-8894d2fe25be">
 					<property name="com.jaspersoft.studio.unit.width" value="px"/>
 				</reportElement>
-				<text><![CDATA[MNI]]></text>
+				<text><![CDATA[MNI Count]]></text>
 			</staticText>
 			<staticText>
 				<reportElement style="Column header" x="900" y="0" width="100" height="44" uuid="b82d695d-276a-44e0-8a1f-40a125e32ca1">
 					<property name="com.jaspersoft.studio.unit.width" value="px"/>
 				</reportElement>
 				<textElement markup="styled"/>
-				<text><![CDATA[AFO]]></text>
+				<text><![CDATA[AFO Count]]></text>
 			</staticText>
 			<staticText>
 				<reportElement style="Column header" x="1000" y="0" width="100" height="44" uuid="568843fe-0306-4803-8c67-672056ae406e">

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/notice_of_inventory_completion.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/notice_of_inventory_completion.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Notice of Inventory Completion</name>
-    <notes>First pass notice of inventory completion</notes>
+    <notes>This report includes the fields for creating a Notice of Inventory Completion report to comply with NAGPRA.</notes>
     <forDocTypes>
       <forDocType>NagpraInventory</forDocType>
     </forDocTypes>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/repatriation_request_consultation.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/repatriation_request_consultation.jrxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 6.20.1.final using JasperReports Library version 6.20.1-7584acb244139816654f64e2fd57a00d3e31921e  -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="repatriation_request_consultation" language="javascript" pageWidth="1600" pageHeight="800" orientation="Landscape" columnWidth="100" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isIgnorePagination="true" uuid="6a52b090-4ec9-4176-a09a-8af53b7323f0">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="repatriation_request_consultation" language="javascript" pageWidth="1700" pageHeight="800" orientation="Landscape" columnWidth="100" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isIgnorePagination="true" uuid="6a52b090-4ec9-4176-a09a-8af53b7323f0">
 	<property name="com.jaspersoft.studio.data.sql.tables" value="" />
 	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="nuxeo" />
 	<property name="com.jaspersoft.studio.data.sql.SQLQueryDesigner.sash.w1" value="193" />
@@ -333,35 +333,35 @@ FROM hierarchy rr_hierarchy
 				<text><![CDATA[Site(s) Related to Repatriation Request]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="1000" y="0" width="100" height="60" uuid="8d8d804b-e4f2-4cb7-84a1-0fc343babd25">
+				<reportElement style="Column header" x="1000" y="0" width="150" height="60" uuid="8d8d804b-e4f2-4cb7-84a1-0fc343babd25">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
 				<text><![CDATA[Number of Associated NAGPRA Inventory Record(s)]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="1100" y="0" width="100" height="60" uuid="9ba161bf-860a-4d46-9914-34ccd4072209">
+				<reportElement style="Column header" x="1150" y="0" width="100" height="60" uuid="9ba161bf-860a-4d46-9914-34ccd4072209">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
-				<text><![CDATA[Title of NAGPRA Inventory Record(s)]]></text>
+				<text><![CDATA[Title of NAGPRA Inventory Records]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="1200" y="0" width="100" height="60" uuid="dd4ef24d-c3fd-4f1c-ac95-bbe21171030a">
+				<reportElement style="Column header" x="1250" y="0" width="150" height="60" uuid="dd4ef24d-c3fd-4f1c-ac95-bbe21171030a">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
 				<text><![CDATA[Number of Associated Summary Documentation Records]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="1300" y="0" width="100" height="60" uuid="711eac26-05f5-4868-bbab-9a77bfb223d0">
+				<reportElement style="Column header" x="1400" y="0" width="100" height="60" uuid="711eac26-05f5-4868-bbab-9a77bfb223d0">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
 				<text><![CDATA[Summary Documentation Title]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="1400" y="0" width="100" height="60" uuid="3806b552-a19e-4535-b2f5-cee59f3410b4">
+				<reportElement style="Column header" x="1500" y="0" width="150" height="60" uuid="3806b552-a19e-4535-b2f5-cee59f3410b4">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
@@ -439,25 +439,25 @@ FROM hierarchy rr_hierarchy
 				<textFieldExpression><![CDATA[$F{inventory_count}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" x="1100" y="0" width="100" height="30" uuid="a8f2a24f-31fc-46e8-a52d-175e372223a8">
+				<reportElement style="Detail" x="1150" y="0" width="100" height="30" uuid="a8f2a24f-31fc-46e8-a52d-175e372223a8">
 					<property name="com.jaspersoft.studio.unit.y" value="px" />
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{inventory_titles}.getArray().filter(val => !!val).join('; ')]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" x="1200" y="0" width="100" height="30" uuid="a84fbf28-7959-412f-b391-d7a1a222c9d0">
+				<reportElement style="Detail" x="1250" y="0" width="100" height="30" uuid="a84fbf28-7959-412f-b391-d7a1a222c9d0">
 					<property name="com.jaspersoft.studio.unit.y" value="px" />
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{summary_count}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" x="1300" y="0" width="100" height="30" uuid="38c63f53-35bf-4b7b-8e17-11287df5e98c">
+				<reportElement style="Detail" x="1400" y="0" width="100" height="30" uuid="38c63f53-35bf-4b7b-8e17-11287df5e98c">
 					<property name="com.jaspersoft.studio.unit.y" value="px" />
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{summary_titles}.getArray().filter((val) => !!val).join('; ')]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" x="1400" y="0" width="100" height="30" uuid="c39e0311-64b2-425e-a63d-31279c0eeb07">
+				<reportElement style="Detail" x="1500" y="0" width="100" height="30" uuid="c39e0311-64b2-425e-a63d-31279c0eeb07">
 					<property name="com.jaspersoft.studio.unit.y" value="px" />
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{log_total}]]></textFieldExpression>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/repatriation_request_consultation.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/repatriation_request_consultation.jrxml
@@ -89,6 +89,7 @@ FROM hierarchy rr_hierarchy
 		GROUP BY hierarchy.parentid
 	) partiesinvolved ON partiesinvolved.parentid = rr_hierarchy.id
 	LEFT JOIN (
+		-- Production People is overridden on anthro to use ethculture and archculture
 		SELECT related_objects.repatriation_csid,
 			array_agg(people.objectproductionpeople) AS cultures
 		FROM hierarchy

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/repatriation_request_consultation.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/repatriation_request_consultation.jrxml
@@ -89,13 +89,14 @@ FROM hierarchy rr_hierarchy
 		GROUP BY hierarchy.parentid
 	) partiesinvolved ON partiesinvolved.parentid = rr_hierarchy.id
 	LEFT JOIN (
-		SELECT hierarchy.parentid,
-		 array_agg(culturalgroup.culture) AS cultures
+		SELECT related_objects.repatriation_csid,
+			array_agg(people.objectproductionpeople) AS cultures
 		FROM hierarchy
-			INNER JOIN culturalgroup ON culturalgroup.id = hierarchy.id
-			AND hierarchy.name = 'repatriationrequests_common:culturalGroupList'
-		GROUP BY hierarchy.parentid
-	) culturalgroup ON culturalgroup.parentid = rr_hierarchy.id --LEFT JOIN LATERAL (
+			INNER JOIN related_objects on related_objects.object_id = hierarchy.parentid
+			INNER JOIN objectproductionpeoplegroup people ON people.id = hierarchy.id
+		WHERE hierarchy.name = 'collectionobjects_common:objectProductionPeopleGroupList'
+		GROUP BY related_objects.repatriation_csid
+	) culturalgroup ON culturalgroup.repatriation_csid = rr_hierarchy.name
 	LEFT JOIN LATERAL (
 		-- Related Object data
 		-- Use regex matching because the refnames can contain subsets of the others,

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/repatriation_request_consultation.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/repatriation_request_consultation.jrxml
@@ -339,7 +339,7 @@ FROM hierarchy rr_hierarchy
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
-				<text><![CDATA[Number of Related NAGPRA Inventory Record(s)]]></text>
+				<text><![CDATA[Number of Related NAGPRA Inventory Records]]></text>
 			</staticText>
 			<staticText>
 				<reportElement style="Column header" x="1205" y="0" width="100" height="60" uuid="9ba161bf-860a-4d46-9914-34ccd4072209">

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/repatriation_request_consultation.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/repatriation_request_consultation.jrxml
@@ -317,28 +317,28 @@ FROM hierarchy rr_hierarchy
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
-				<text><![CDATA[Ethnographic Belongings Repatriation Request]]></text>
+				<text><![CDATA[Ethnographic Count]]></text>
 			</staticText>
 			<staticText>
 				<reportElement style="Column header" x="840" y="0" width="100" height="60" uuid="a672b0d8-60c7-4ad6-a47e-abe724790fe8">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
-				<text><![CDATA[Culture(s) Related to Repatriation Request]]></text>
+				<text><![CDATA[Culture(s) Related to Requested Objects]]></text>
 			</staticText>
 			<staticText>
 				<reportElement style="Column header" x="945" y="0" width="100" height="60" uuid="4db40578-bd05-4689-935f-4c6c00dc6f2a">
 					<property name="com.jaspersoft.studio.unit.width" value="px"/>
 				</reportElement>
 				<textElement markup="styled"/>
-				<text><![CDATA[Site(s) Related to Repatriation Request]]></text>
+				<text><![CDATA[Site(s) Related to Requested Objects]]></text>
 			</staticText>
 			<staticText>
 				<reportElement style="Column header" x="1050" y="0" width="150" height="60" uuid="8d8d804b-e4f2-4cb7-84a1-0fc343babd25">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
-				<text><![CDATA[Number of Associated NAGPRA Inventory Record(s)]]></text>
+				<text><![CDATA[Number of Related NAGPRA Inventory Record(s)]]></text>
 			</staticText>
 			<staticText>
 				<reportElement style="Column header" x="1205" y="0" width="100" height="60" uuid="9ba161bf-860a-4d46-9914-34ccd4072209">
@@ -352,7 +352,7 @@ FROM hierarchy rr_hierarchy
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
-				<text><![CDATA[Number of Associated Summary Documentation Records]]></text>
+				<text><![CDATA[Number of Related Summary Documentation Records]]></text>
 			</staticText>
 			<staticText>
 				<reportElement style="Column header" x="1465" y="0" width="100" height="60" uuid="711eac26-05f5-4868-bbab-9a77bfb223d0">
@@ -366,7 +366,7 @@ FROM hierarchy rr_hierarchy
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
-				<text><![CDATA[Number of Associated Consultation Log Entries]]></text>
+				<text><![CDATA[Number of Consultation Log Entries]]></text>
 			</staticText>
 		</band>
 	</columnHeader>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/repatriation_request_consultation.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/repatriation_request_consultation.jrxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 6.20.1.final using JasperReports Library version 6.20.1-7584acb244139816654f64e2fd57a00d3e31921e  -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="repatriation_request_consultation" language="javascript" pageWidth="1700" pageHeight="800" orientation="Landscape" columnWidth="100" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isIgnorePagination="true" uuid="6a52b090-4ec9-4176-a09a-8af53b7323f0">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="repatriation_request_consultation" language="javascript" pageWidth="1750" pageHeight="800" orientation="Landscape" columnWidth="100" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isIgnorePagination="true" uuid="6a52b090-4ec9-4176-a09a-8af53b7323f0">
 	<property name="com.jaspersoft.studio.data.sql.tables" value="" />
 	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="nuxeo" />
 	<property name="com.jaspersoft.studio.data.sql.SQLQueryDesigner.sash.w1" value="193" />
@@ -270,98 +270,98 @@ FROM hierarchy rr_hierarchy
 				<text><![CDATA[Organization(s)]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="100" y="0" width="100" height="60" uuid="888a4b38-9b27-457e-91e1-ffa1882b659a">
+				<reportElement style="Column header" x="105" y="0" width="100" height="60" uuid="888a4b38-9b27-457e-91e1-ffa1882b659a">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
 				<text><![CDATA[Repatriation Request Origination Date]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="200" y="0" width="100" height="60" uuid="fef83b09-5b96-45cc-8a9a-2e59fc3baf60">
+				<reportElement style="Column header" x="210" y="0" width="100" height="60" uuid="fef83b09-5b96-45cc-8a9a-2e59fc3baf60">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
 				<text><![CDATA[Repatriation Request Number]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="300" y="0" width="100" height="60" uuid="f3636866-52a2-49ac-b609-2a58bcc53047">
+				<reportElement style="Column header" x="315" y="0" width="100" height="60" uuid="f3636866-52a2-49ac-b609-2a58bcc53047">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
 				<text><![CDATA[Repatriation Request Name]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="400" y="0" width="100" height="60" uuid="0efc36d1-4e40-46e9-b650-71afe6d73692">
+				<reportElement style="Column header" x="420" y="0" width="100" height="60" uuid="0efc36d1-4e40-46e9-b650-71afe6d73692">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
 				<text><![CDATA[MNI Count]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="500" y="0" width="100" height="60" uuid="edfbd25f-31aa-49c9-aa15-3834efc57ac1">
+				<reportElement style="Column header" x="525" y="0" width="100" height="60" uuid="edfbd25f-31aa-49c9-aa15-3834efc57ac1">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
 				<text><![CDATA[AFO Count]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="600" y="0" width="100" height="60" uuid="906e84f6-068d-4e6b-bb09-99c6aae85fbc">
+				<reportElement style="Column header" x="630" y="0" width="100" height="60" uuid="906e84f6-068d-4e6b-bb09-99c6aae85fbc">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
 				<text><![CDATA[UFO Count]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="700" y="0" width="100" height="60" uuid="2daa4c02-9105-4701-ad08-c28a0830725a">
+				<reportElement style="Column header" x="735" y="0" width="100" height="60" uuid="2daa4c02-9105-4701-ad08-c28a0830725a">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
 				<text><![CDATA[Ethnographic Belongings Repatriation Request]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="800" y="0" width="100" height="60" uuid="a672b0d8-60c7-4ad6-a47e-abe724790fe8">
+				<reportElement style="Column header" x="840" y="0" width="100" height="60" uuid="a672b0d8-60c7-4ad6-a47e-abe724790fe8">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
 				<text><![CDATA[Culture(s) Related to Repatriation Request]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="900" y="0" width="100" height="60" uuid="4db40578-bd05-4689-935f-4c6c00dc6f2a">
+				<reportElement style="Column header" x="945" y="0" width="100" height="60" uuid="4db40578-bd05-4689-935f-4c6c00dc6f2a">
 					<property name="com.jaspersoft.studio.unit.width" value="px"/>
 				</reportElement>
 				<textElement markup="styled"/>
 				<text><![CDATA[Site(s) Related to Repatriation Request]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="1000" y="0" width="150" height="60" uuid="8d8d804b-e4f2-4cb7-84a1-0fc343babd25">
+				<reportElement style="Column header" x="1050" y="0" width="150" height="60" uuid="8d8d804b-e4f2-4cb7-84a1-0fc343babd25">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
 				<text><![CDATA[Number of Associated NAGPRA Inventory Record(s)]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="1150" y="0" width="100" height="60" uuid="9ba161bf-860a-4d46-9914-34ccd4072209">
+				<reportElement style="Column header" x="1205" y="0" width="100" height="60" uuid="9ba161bf-860a-4d46-9914-34ccd4072209">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
 				<text><![CDATA[Title of NAGPRA Inventory Records]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="1250" y="0" width="150" height="60" uuid="dd4ef24d-c3fd-4f1c-ac95-bbe21171030a">
+				<reportElement style="Column header" x="1310" y="0" width="150" height="60" uuid="dd4ef24d-c3fd-4f1c-ac95-bbe21171030a">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
 				<text><![CDATA[Number of Associated Summary Documentation Records]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="1400" y="0" width="100" height="60" uuid="711eac26-05f5-4868-bbab-9a77bfb223d0">
+				<reportElement style="Column header" x="1465" y="0" width="100" height="60" uuid="711eac26-05f5-4868-bbab-9a77bfb223d0">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
 				<text><![CDATA[Summary Documentation Title]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="1500" y="0" width="150" height="60" uuid="3806b552-a19e-4535-b2f5-cee59f3410b4">
+				<reportElement style="Column header" x="1570" y="0" width="150" height="60" uuid="3806b552-a19e-4535-b2f5-cee59f3410b4">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
@@ -379,85 +379,85 @@ FROM hierarchy rr_hierarchy
 				<textFieldExpression><![CDATA[$F{onbehalfof}.getArray().filter((val) => !!val).join('; ')]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" x="100" y="0" width="100" height="30" uuid="89b571d2-50e1-47bf-bf2d-f8a24b944ec8">
+				<reportElement style="Detail" x="105" y="0" width="100" height="30" uuid="89b571d2-50e1-47bf-bf2d-f8a24b944ec8">
 					<property name="com.jaspersoft.studio.unit.y" value="px" />
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{requestdate} !== null ? $F{requestdate}.toLocalDateTime().toLocalDate() : '']]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" x="200" y="0" width="100" height="30" uuid="f7d5770e-a729-457b-a39f-9b1f05c980d3">
+				<reportElement style="Detail" x="210" y="0" width="100" height="30" uuid="f7d5770e-a729-457b-a39f-9b1f05c980d3">
 					<property name="com.jaspersoft.studio.unit.y" value="px" />
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{requestnumber}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" x="300" y="0" width="100" height="30" uuid="4f536bed-b62a-4a53-97ce-81f1fafc0c94">
+				<reportElement style="Detail" x="315" y="0" width="100" height="30" uuid="4f536bed-b62a-4a53-97ce-81f1fafc0c94">
 					<property name="com.jaspersoft.studio.unit.y" value="px" />
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{title}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" x="400" y="0" width="100" height="30" uuid="460dc3a8-b239-4472-b2a3-1bb8be0980e9">
+				<reportElement style="Detail" x="420" y="0" width="100" height="30" uuid="460dc3a8-b239-4472-b2a3-1bb8be0980e9">
 					<property name="com.jaspersoft.studio.unit.y" value="px" />
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{mni_count}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" x="500" y="0" width="100" height="30" uuid="43c1f876-745f-4f14-9c08-8cee4b02575a">
+				<reportElement style="Detail" x="525" y="0" width="100" height="30" uuid="43c1f876-745f-4f14-9c08-8cee4b02575a">
 					<property name="com.jaspersoft.studio.unit.y" value="px" />
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{afo_count}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" x="600" y="0" width="100" height="30" uuid="9f75ab33-ec3b-42fd-a1be-16caa9254291">
+				<reportElement style="Detail" x="630" y="0" width="100" height="30" uuid="9f75ab33-ec3b-42fd-a1be-16caa9254291">
 					<property name="com.jaspersoft.studio.unit.y" value="px" />
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{ufo_count}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" x="700" y="0" width="100" height="30" uuid="91f7ab7a-d0c4-4d79-af7c-372fb8222baa">
+				<reportElement style="Detail" x="735" y="0" width="100" height="30" uuid="91f7ab7a-d0c4-4d79-af7c-372fb8222baa">
 					<property name="com.jaspersoft.studio.unit.y" value="px" />
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{ethnographic_count}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" x="800" y="0" width="100" height="30" uuid="68f1bf63-5f1a-497e-a132-af81b2634348">
+				<reportElement style="Detail" x="840" y="0" width="100" height="30" uuid="68f1bf63-5f1a-497e-a132-af81b2634348">
 					<property name="com.jaspersoft.studio.unit.y" value="px" />
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{cultures}.getArray().filter((val) => !!val).join('; ')]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" x="900" y="0" width="100" height="30" uuid="af734fab-e383-4813-b108-1d1e70e7989e">
+				<reportElement style="Detail" x="945" y="0" width="100" height="30" uuid="af734fab-e383-4813-b108-1d1e70e7989e">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{sites}.getArray().filter((site) => !!site).join('; ')]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" x="1000" y="0" width="100" height="30" uuid="7d87ad02-5a25-4e8c-88ae-537ecd7a1fe1">
+				<reportElement style="Detail" x="1050" y="0" width="100" height="30" uuid="7d87ad02-5a25-4e8c-88ae-537ecd7a1fe1">
 					<property name="com.jaspersoft.studio.unit.y" value="px" />
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{inventory_count}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" x="1150" y="0" width="100" height="30" uuid="a8f2a24f-31fc-46e8-a52d-175e372223a8">
+				<reportElement style="Detail" x="1205" y="0" width="100" height="30" uuid="a8f2a24f-31fc-46e8-a52d-175e372223a8">
 					<property name="com.jaspersoft.studio.unit.y" value="px" />
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{inventory_titles}.getArray().filter(val => !!val).join('; ')]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" x="1250" y="0" width="100" height="30" uuid="a84fbf28-7959-412f-b391-d7a1a222c9d0">
+				<reportElement style="Detail" x="1310" y="0" width="100" height="30" uuid="a84fbf28-7959-412f-b391-d7a1a222c9d0">
 					<property name="com.jaspersoft.studio.unit.y" value="px" />
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{summary_count}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" x="1400" y="0" width="100" height="30" uuid="38c63f53-35bf-4b7b-8e17-11287df5e98c">
+				<reportElement style="Detail" x="1465" y="0" width="100" height="30" uuid="38c63f53-35bf-4b7b-8e17-11287df5e98c">
 					<property name="com.jaspersoft.studio.unit.y" value="px" />
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{summary_titles}.getArray().filter((val) => !!val).join('; ')]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement style="Detail" x="1500" y="0" width="100" height="30" uuid="c39e0311-64b2-425e-a63d-31279c0eeb07">
+				<reportElement style="Detail" x="1570" y="0" width="100" height="30" uuid="c39e0311-64b2-425e-a63d-31279c0eeb07">
 					<property name="com.jaspersoft.studio.unit.y" value="px" />
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{log_total}]]></textFieldExpression>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/repatriation_request_consultation.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/repatriation_request_consultation.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Repatriation Request Consultation</name>
-    <notes>Placeholder</notes>
+    <notes>This report provides an overview of consultations associated with NAGPRA summary documentation workflows.</notes>
     <forDocTypes>
       <forDocType>RepatriationRequest</forDocType>
     </forDocTypes>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/summary_documentation_consultation.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/summary_documentation_consultation.jrxml
@@ -94,6 +94,7 @@ FROM hierarchy summary_hierarchy
 		GROUP BY hierarchy.parentid
 	) partiesinvolved ON partiesinvolved.parentid = summary_hierarchy.id
 	LEFT JOIN (
+		-- Production People is overridden on anthro to use ethculture and archculture
 		SELECT related_objects.summary_csid,
 			array_agg(people.objectproductionpeople) AS cultures
 		FROM hierarchy

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/summary_documentation_consultation.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/summary_documentation_consultation.jrxml
@@ -336,28 +336,28 @@ FROM hierarchy summary_hierarchy
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
-				<text><![CDATA[Site(s) Related to Summary]]></text>
+				<text><![CDATA[Site(s) Related to Related Objects]]></text>
 			</staticText>
 			<staticText>
 				<reportElement style="Column header" x="1100" y="0" width="100" height="44" uuid="c361bc9c-e677-4a74-a59e-695ba9eddbaa">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
-				<text><![CDATA[Culture(s) Related to Summary]]></text>
+				<text><![CDATA[Culture(s) Related to Related Objects]]></text>
 			</staticText>
 			<staticText>
 				<reportElement style="Column header" x="1200" y="0" width="100" height="44" uuid="f6441c8d-82a9-4908-94c0-b57be2d22746">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
-				<text><![CDATA[Number of Associated Consultation Log Entries]]></text>
+				<text><![CDATA[Number of Related Consultation Log Entries]]></text>
 			</staticText>
 			<staticText>
 				<reportElement style="Column header" x="1300" y="0" width="100" height="44" uuid="17fc9356-5a96-4aa4-915a-cf18a83bc614">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
-				<text><![CDATA[Exit Record Current Owner with Exit Date]]></text>
+				<text><![CDATA[Exit Owner with Date]]></text>
 			</staticText>
 		</band>
 	</columnHeader>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/summary_documentation_consultation.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/summary_documentation_consultation.jrxml
@@ -102,7 +102,7 @@ FROM hierarchy summary_hierarchy
 			INNER JOIN objectproductionpeoplegroup people ON people.id = hierarchy.id
 		WHERE hierarchy.name = 'collectionobjects_common:objectProductionPeopleGroupList'
 		GROUP BY related_objects.summary_csid
-	) culturalgroup ON culturalgroup.summary_csid = summary.name
+	) culturalgroup ON culturalgroup.summary_csid = summary_hierarchy.name
 	LEFT JOIN (
 		SELECT related_objects.summary_csid,
 			array_agg(fcs.item) as sites
@@ -260,102 +260,102 @@ FROM hierarchy summary_hierarchy
 		<band splitType="Stretch" />
 	</background>
 	<columnHeader>
-		<band height="44" splitType="Stretch">
+		<band height="60" splitType="Stretch">
 			<property name="com.jaspersoft.studio.layout" value="com.jaspersoft.studio.editor.layout.FreeLayout" />
 			<property name="com.jaspersoft.studio.unit.height" value="px" />
 			<staticText>
-				<reportElement style="Column header" x="0" y="0" width="100" height="44" uuid="b8cd41b4-34e5-455f-81fc-97800f4ae9b7">
+				<reportElement style="Column header" x="0" y="0" width="100" height="60" uuid="b8cd41b4-34e5-455f-81fc-97800f4ae9b7">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
 				<text><![CDATA[Organization(s)]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="100" y="0" width="100" height="44" uuid="539fd511-8c4c-4f20-ac0f-1b71fdc26939">
+				<reportElement style="Column header" x="100" y="0" width="100" height="60" uuid="539fd511-8c4c-4f20-ac0f-1b71fdc26939">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
 				<text><![CDATA[Summary Documentation Origination Date]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="200" y="0" width="100" height="44" uuid="9741cf97-9acc-45aa-bab2-90a03cf29e83">
+				<reportElement style="Column header" x="200" y="0" width="100" height="60" uuid="9741cf97-9acc-45aa-bab2-90a03cf29e83">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
 				<text><![CDATA[Summary Documentation Number]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="300" y="0" width="100" height="44" uuid="65b98683-6871-48ec-a4c4-553e41f1b26b">
+				<reportElement style="Column header" x="300" y="0" width="100" height="60" uuid="65b98683-6871-48ec-a4c4-553e41f1b26b">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
 				<text><![CDATA[Summary Documentation Title]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="400" y="0" width="100" height="44" uuid="02898623-0732-4b3d-abe6-948350332361">
+				<reportElement style="Column header" x="400" y="0" width="95" height="60" uuid="02898623-0732-4b3d-abe6-948350332361">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
 				<text><![CDATA[Summary Documentation - Summary Status]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="500" y="0" width="100" height="44" uuid="a0f54698-7f5f-4d08-8286-f86c412fa876">
+				<reportElement style="Column header" x="500" y="0" width="100" height="60" uuid="a0f54698-7f5f-4d08-8286-f86c412fa876">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
 				<text><![CDATA[UFO Count]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="600" y="0" width="100" height="44" uuid="9afbf556-a4f6-4041-97a9-ac9f106aa75e">
+				<reportElement style="Column header" x="600" y="0" width="95" height="60" uuid="9afbf556-a4f6-4041-97a9-ac9f106aa75e">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
 				<text><![CDATA[Objects of Cultural Patrimony Count]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="700" y="0" width="100" height="44" uuid="679eb6c6-e454-47d1-8320-1a723dabf0a1">
+				<reportElement style="Column header" x="700" y="0" width="100" height="60" uuid="679eb6c6-e454-47d1-8320-1a723dabf0a1">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
 				<text><![CDATA[Sacred Object Count]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="800" y="0" width="100" height="44" uuid="f9a1fb86-9c78-48ba-942e-e35417916eeb">
+				<reportElement style="Column header" x="800" y="0" width="100" height="60" uuid="f9a1fb86-9c78-48ba-942e-e35417916eeb">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
 				<text><![CDATA[Lineal Descendent Count]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="900" y="0" width="100" height="44" uuid="c2e6ccf4-0900-400d-a6f4-4ea0fc9bb95a">
+				<reportElement style="Column header" x="900" y="0" width="95" height="60" uuid="c2e6ccf4-0900-400d-a6f4-4ea0fc9bb95a">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
 				<text><![CDATA[NAGPRA Category Type(s)]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="1000" y="0" width="100" height="44" uuid="52cec6c0-596a-47f6-877a-fa0a4227e55d">
+				<reportElement style="Column header" x="1000" y="0" width="95" height="60" uuid="52cec6c0-596a-47f6-877a-fa0a4227e55d">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
 				<text><![CDATA[Site(s) Related to Related Objects]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="1100" y="0" width="100" height="44" uuid="c361bc9c-e677-4a74-a59e-695ba9eddbaa">
+				<reportElement style="Column header" x="1100" y="0" width="100" height="60" uuid="c361bc9c-e677-4a74-a59e-695ba9eddbaa">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
 				<text><![CDATA[Culture(s) Related to Related Objects]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="1200" y="0" width="100" height="44" uuid="f6441c8d-82a9-4908-94c0-b57be2d22746">
+				<reportElement style="Column header" x="1200" y="0" width="95" height="60" uuid="f6441c8d-82a9-4908-94c0-b57be2d22746">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />
 				<text><![CDATA[Number of Related Consultation Log Entries]]></text>
 			</staticText>
 			<staticText>
-				<reportElement style="Column header" x="1300" y="0" width="100" height="44" uuid="17fc9356-5a96-4aa4-915a-cf18a83bc614">
+				<reportElement style="Column header" x="1300" y="0" width="100" height="60" uuid="17fc9356-5a96-4aa4-915a-cf18a83bc614">
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>
 				<textElement markup="styled" />

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/summary_documentation_consultation.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/summary_documentation_consultation.jrxml
@@ -94,13 +94,14 @@ FROM hierarchy summary_hierarchy
 		GROUP BY hierarchy.parentid
 	) partiesinvolved ON partiesinvolved.parentid = summary_hierarchy.id
 	LEFT JOIN (
-		SELECT hierarchy.parentid,
-			array_agg(culturalgroup.culture) AS cultures
+		SELECT related_objects.summary_csid,
+			array_agg(people.objectproductionpeople) AS cultures
 		FROM hierarchy
-			INNER JOIN culturalgroup ON culturalgroup.id = hierarchy.id
-			AND hierarchy.name = 'summarydocumentations_common:culturalGroupList'
-		GROUP BY hierarchy.parentid
-	) culturalgroup ON culturalgroup.parentid = summary.id
+			INNER JOIN related_objects on related_objects.object_id = hierarchy.parentid
+			INNER JOIN objectproductionpeoplegroup people ON people.id = hierarchy.id
+		WHERE hierarchy.name = 'collectionobjects_common:objectProductionPeopleGroupList'
+		GROUP BY related_objects.summary_csid
+	) culturalgroup ON culturalgroup.summary_csid = summary.name
 	LEFT JOIN (
 		SELECT related_objects.summary_csid,
 			array_agg(fcs.item) as sites

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/summary_documentation_consultation.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/summary_documentation_consultation.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Summary Documentation Consultation</name>
-    <notes>Placeholder</notes>
+    <notes>This report provides an overview of consultations associated with NAGPRA summary documentation workflows.</notes>
     <forDocTypes>
       <forDocType>SummaryDocumentation</forDocType>
     </forDocTypes>


### PR DESCRIPTION
**What does this do?**
* Use objectproductionpeople for related culutres - summary; inventory
* Fix location for mni and afo counts - inventory
* Add collectors to description text - intent to repatriate
* Pull multiple involved parties - intent to repatriate
* Deurn objectproductionpeople - exhibition basic list
* Make header text more consistent for 8.1 reports
* Adjust header spacing and height for 8.1 reports
* Add 8.1 report descriptions

**Why are we doing this? (with JIRA link)**
* https://collectionspace.atlassian.net/browse/DRYD-1598
* https://collectionspace.atlassian.net/browse/DRYD-1603

This has a few things which were missed in the previous PRs with report updates and some more changes after looking at the reports as a whole in order to add some more consistency to them. In addition, we determined that some columns should be renamed to better reflect the data they're pulling back (e.g. cultures of related objects), which also needed to have query updates in order to pull back the correct data.

**How should this be tested? Do these changes have associated tests?**
* Redeploy the reports
* Inventory Consultation
  * Check that headers are updated
  * Check that afo and mni counts are in the correct location
* Repatriation Request Consultation
  * Check that the cultures column now uses object production people
  * Check that headers use updated names
* Summary Documentation Consultation
  * Check that the cultures column now uses object production people
  * Check that headers use updated names
* Notice of Intent to Repatriate
  * Involved party fields aggregate
  * Contact headers are updated
  * Description contains collector and donor names
* Notice of Inventory Completion
  * Headers for afo and mni include 'Count'


**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally