### PR TITLE
Add description to full object with place report

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/full_obj_place.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/full_obj_place.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Full Object with Place Details</name>
-    <notes>Full Object with Place Details</notes>
+    <notes>This object report exclusive to the Public Art profile includes descriptive object record fields combined with current place details.</notes>
     <forDocTypes>
       <forDocType>CollectionObject</forDocType>
     </forDocTypes>


### PR DESCRIPTION
**What does this do?**
* Add description to xml payload

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1431

The Full Object with Place Details report was missing a description.

**How should this be tested? Do these changes have associated tests?**
* Build a clean collectionspace install with the public art profile enabled
* See that the Full Object with Place Details has the updated description

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter will test locally