### PR TITLE
Pull cultural determination from nagpra extension

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/repatriation_request_consultation.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/repatriation_request_consultation.jrxml
@@ -89,13 +89,13 @@ FROM hierarchy rr_hierarchy
 		GROUP BY hierarchy.parentid
 	) partiesinvolved ON partiesinvolved.parentid = rr_hierarchy.id
 	LEFT JOIN (
-		-- Production People is overridden on anthro to use ethculture and archculture
+		-- Pull from the NAGPRA extension to get the cultural determination
 		SELECT related_objects.repatriation_csid,
-			array_agg(people.objectproductionpeople) AS cultures
+			array_agg(ndg.nagpradetermculture) AS cultures
 		FROM hierarchy
 			INNER JOIN related_objects on related_objects.object_id = hierarchy.parentid
-			INNER JOIN objectproductionpeoplegroup people ON people.id = hierarchy.id
-		WHERE hierarchy.name = 'collectionobjects_common:objectProductionPeopleGroupList'
+			INNER JOIN nagpradetermgroup ndg ON ndg.id = hierarchy.id
+		WHERE hierarchy.name = 'collectionobjects_nagpra:nagpraDetermGroupList'
 		GROUP BY related_objects.repatriation_csid
 	) culturalgroup ON culturalgroup.repatriation_csid = rr_hierarchy.name
 	LEFT JOIN LATERAL (


### PR DESCRIPTION
**What does this do?**
* Use nagpraDetermGroup for cultures output 

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1512

There was confusion about which field should be used to populate the output of the cultures related to requsted objects. After some discussion we reached the conclusion that it should be from the NAGPRA extension, which is in the `nagpradetermgroup` table.

**How should this be tested? Do these changes have associated tests?**
* Rebuild and deploy collectionspace with anthro enabled
* Create a Repatriation Request
* Create a related CollecionObject
* In the CollectionObject, populate the `Cultural determination` field under the `Repatriation and NAGPRA Compliance Information` section
* Search for Repatriation Requests and run the `Repatriation Request Consultation` report

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally