### PR TITLE
Contact Organization Fix

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/contact_org.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/contact_org.jrxml
@@ -22,8 +22,8 @@
 	</parameter>
 	<parameter name="whereclause" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA[$P{csid} != null ? "WHERE org_hier.name = '" + $P{csid} + "'"
-		: $P{csids} != "NOVALUE" ? ( "WHERE org_hier.name IN (" + $P{csids} + ")" )
-			: "WHERE org_hier.name = 'NOVALUE'"]]></defaultValueExpression>
+		: $P{csids} != "NOVALUE" ? ( "WHERE org_hier.name IN (" + $P{csids} + ")" ) : ""]]>
+		</defaultValueExpression>
 	</parameter>
 	<queryString language="SQL">
 		<![CDATA[WITH org_auths AS (

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/contact_org.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/contact_org.jrxml
@@ -15,9 +15,7 @@
 	<parameter name="tenantid" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA["1"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="csid" class="java.lang.String" isForPrompting="false">
-		<defaultValueExpression><![CDATA["4a236626-06cc-4ce6-8e11"]]></defaultValueExpression>
-	</parameter>
+	<parameter name="csid" class="java.lang.String" isForPrompting="false" />
 	<parameter name="csidlist" class="java.lang.String" isForPrompting="false" />
 	<parameter name="csids" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA[$P{csidlist} != null ? ("'" + $P{csidlist}.replaceAll(",", "','") + "'") : "NOVALUE"]]></defaultValueExpression>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/contact_org.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/contact_org.jrxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 6.20.1.final using JasperReports Library version 6.20.1-7584acb244139816654f64e2fd57a00d3e31921e  -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="contact_org" pageWidth="2200" pageHeight="800" orientation="Landscape" columnWidth="100" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isIgnorePagination="true" uuid="49b29b35-57c3-422f-8699-01975b0a33f9">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="contact_org" whenNoDataType="NoDataSection" pageWidth="2200" pageHeight="800" orientation="Landscape" columnWidth="100" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isIgnorePagination="true" uuid="49b29b35-57c3-422f-8699-01975b0a33f9">
 	<property name="com.jaspersoft.studio.data.sql.tables" value="" />
 	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="nuxeo" />
 	<property name="com.jaspersoft.studio.data.sql.SQLQueryDesigner.sash.w1" value="193" />
@@ -597,4 +597,15 @@ ORDER BY orgs.termdisplayname,
 			</textField>
 		</band>
 	</detail>
+	<noData>
+		<band height="50">
+			<staticText>
+				<reportElement style="Column header" x="0" y="10" width="375" height="28" uuid="f449dbd9-0782-4ffc-9296-1c09a978c94b" />
+				<textElement>
+					<font size="14"/>
+				</textElement>
+				<text><![CDATA[No contacts found for this Organization.]]></text>
+			</staticText>
+		</band>
+	</noData>
 </jasperReport>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/contact_org.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/contact_org.jrxml
@@ -9,9 +9,9 @@
 	<property name="com.jaspersoft.studio.property.dataset.dialog.DatasetDialog.sash.w2" value="361" />
 	<style name="Column header" fontName="SansSerif" fontSize="12" isBold="true" />
 	<style name="Detail" fontName="SansSerif" fontSize="12" />
-  <parameter name="deurnfields" class="java.lang.String" isForPrompting="false">
-    <defaultValueExpression><![CDATA["contact_name,contact_role,contact_status"]]></defaultValueExpression>
-  </parameter>
+	<parameter name="deurnfields" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA["contact_name,contact_role,contact_status"]]></defaultValueExpression>
+	</parameter>
 	<parameter name="tenantid" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA["1"]]></defaultValueExpression>
 	</parameter>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/contact_person.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/contact_person.jrxml
@@ -19,8 +19,8 @@
 	</parameter>
 	<parameter name="whereclause" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA[$P{csid} != null ? "WHERE phier.name = '" + $P{csid} + "'"
-		: $P{csids} != "NOVALUE" ? ( "WHERE phier.name IN (" + $P{csids} + ")" )
-			: "WHERE phier.name = 'NOVALUE'"]]></defaultValueExpression>
+		: $P{csids} != "NOVALUE" ? ( "WHERE phier.name IN (" + $P{csids} + ")" ) : ""]]>
+		</defaultValueExpression>
 	</parameter>
 	<queryString language="SQL">
 		<![CDATA[WITH personbase AS (


### PR DESCRIPTION
**What does this do?**
* Remove default value for csid
* Add no data section
* Allow queries with no where clauses

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1576

When testing the contact organization report we saw that it wasn't working properly when being run on search results. This was being caused by the default value for `csid` which was being used instead of the provided csid list. In addition, when no contact exists for an organization an empty report was being returned, which has been replaced by the `noData` section.

**How should this be tested? Do these changes have associated tests?**
* Redeploy the tests
* Search for organizations
* Run the report on selected organizations

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally