### PR TITLE
DRYD-1687: Load NAGPRA reports in only core and anthro

### DIFF
--- a/services/common/src/main/cspace/config/services/tenants/anthro/anthro-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/anthro/anthro-tenant-bindings.delta.xml
@@ -12,6 +12,18 @@
 			<service:properties xmlns:service="http://collectionspace.org/services/config/service" xmlns:types="http://collectionspace.org/services/config/types">
 				<types:item merge:matcher="skip" merge:action="insert">
 					<types:key>report</types:key>
+					<types:value>inventory_consultation</types:value>
+				</types:item>
+				<types:item merge:matcher="skip" merge:action="insert">
+					<types:key>report</types:key>
+					<types:value>repatriation_request_consultation</types:value>
+				</types:item>
+				<types:item merge:matcher="skip" merge:action="insert">
+					<types:key>report</types:key>
+					<types:value>summary_documentation_consultation</types:value>
+				</types:item>
+				<types:item merge:matcher="skip" merge:action="insert">
+					<types:key>report</types:key>
 					<types:value>notice_of_intent_to_repatriate</types:value>
 				</types:item>
 				<types:item merge:matcher="skip" merge:action="insert">

--- a/services/common/src/main/cspace/config/services/tenants/core/core-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/core/core-tenant-bindings.delta.xml
@@ -8,6 +8,22 @@
     <!-- value in cspace/config/services/tenants/core-tenant-bindings-proto.xml -->
 
     <tenant:tenantBinding id="1">
+        <tenant:serviceBindings merge:matcher="id" id="Reports">
+            <service:properties xmlns:service="http://collectionspace.org/services/config/service" xmlns:types="http://collectionspace.org/services/config/types">
+                <types:item merge:matcher="skip" merge:action="insert">
+                    <types:key>report</types:key>
+                    <types:value>inventory_consultation</types:value>
+                </types:item>
+                <types:item merge:matcher="skip" merge:action="insert">
+                    <types:key>report</types:key>
+                    <types:value>repatriation_request_consultation</types:value>
+                </types:item>
+                <types:item merge:matcher="skip" merge:action="insert">
+                    <types:key>report</types:key>
+                    <types:value>summary_documentation_consultation</types:value>
+                </types:item>
+            </service:properties>
+        </tenant:serviceBindings>
     </tenant:tenantBinding>
 
 </tenant:TenantBindingConfig>

--- a/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
+++ b/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
@@ -732,18 +732,7 @@
 					<types:key>report</types:key>
 					<types:value>exhibition_checklist</types:value>
 				</types:item>
-				<types:item>
-					<types:key>report</types:key>
-					<types:value>inventory_consultation</types:value>
-				</types:item>
-				<types:item>
-					<types:key>report</types:key>
-					<types:value>repatriation_request_consultation</types:value>
-				</types:item>
-				<types:item>
-					<types:key>report</types:key>
-					<types:value>summary_documentation_consultation</types:value>
-				</types:item>
+
 				<types:item>
 					<types:key>report</types:key>
 					<types:value>contact_person</types:value>


### PR DESCRIPTION
**What does this do?**
This moves the report config for the new NAGPRA reports into the core and anthro tenant bindings. By doing this we ensure that the reports are only available for those tenants, as they are the only tenants with the procedures enabled for those reports.

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1687

In tenants other than core/anthro, the NAGPRA reports can be selected from the Tools > Reports interface. This has a modal which allows a user to select records to run the report on with a record type that does not exist in the tenant, and as such causes an error in the ui. Ideally we need error handling in the ui as well, but for the time being we've decided to fix things here for now.

**How should this be tested? Do these changes have associated tests?**
* Build collectionspace without any changes
* Save the files in `${CSPACE_JEE_SERVER}/cspace/config/services/tenants/`
* Rebuild collectionspace with the changes
* Diff the merged tenant bindings, e.g.
```
git diff -w --no-index materials/tenant-bindings.merged.xml ~/tmt/saved-bindings/materials/tenant-bindings.merged.xml
```

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter ran the build and compared the tenant bindings