### PR TITLE
SAML SSO unit tests etc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ bin
 *.diff
 logged_schemas
 logs
+.mvn

--- a/services/common/src/main/java/org/collectionspace/services/common/security/CSpaceSaml2ResponseAuthenticationConverter.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/security/CSpaceSaml2ResponseAuthenticationConverter.java
@@ -22,124 +22,139 @@ import org.springframework.security.saml2.provider.service.authentication.OpenSa
 import org.springframework.security.saml2.provider.service.authentication.Saml2Authentication;
 
 public class CSpaceSaml2ResponseAuthenticationConverter implements Converter<ResponseToken, CSpaceSaml2Authentication> {
-  private final Logger logger = LoggerFactory.getLogger(CSpaceSaml2ResponseAuthenticationConverter.class);
+	private final Logger logger = LoggerFactory.getLogger(CSpaceSaml2ResponseAuthenticationConverter.class);
 
-  private CSpaceUserDetailsService userDetailsService;
+	private CSpaceUserDetailsService userDetailsService;
 
-  public CSpaceSaml2ResponseAuthenticationConverter(CSpaceUserDetailsService userDetailsService) {
-    this.userDetailsService = userDetailsService;
-  }
+	public CSpaceSaml2ResponseAuthenticationConverter(CSpaceUserDetailsService userDetailsService) {
+		this.userDetailsService = userDetailsService;
+	}
 
-  @Override
-  public CSpaceSaml2Authentication convert(ResponseToken responseToken) {
-    Saml2Authentication authentication = OpenSamlAuthenticationProvider
-      .createDefaultResponseAuthenticationConverter()
-      .convert(responseToken);
+	@Override
+	public CSpaceSaml2Authentication convert(ResponseToken responseToken) {
+		Saml2Authentication authentication = OpenSamlAuthenticationProvider
+				.createDefaultResponseAuthenticationConverter().convert(responseToken);
 
-    String registrationId = responseToken.getToken().getRelyingPartyRegistration().getRegistrationId();
-    ServiceConfig serviceConfig = ServiceMain.getInstance().getServiceConfig();
-    SAMLRelyingPartyType relyingPartyRegistration = ConfigUtils.getSAMLRelyingPartyRegistration(serviceConfig, registrationId);
-    CSpaceUser user = findUser(relyingPartyRegistration, responseToken);
+		String registrationId = responseToken.getToken().getRelyingPartyRegistration().getRegistrationId();
+		ServiceConfig serviceConfig = ServiceMain.getInstance().getServiceConfig();
+		SAMLRelyingPartyType relyingPartyRegistration = ConfigUtils.getSAMLRelyingPartyRegistration(serviceConfig,
+				registrationId);
+		CSpaceUser user = findUser(relyingPartyRegistration, responseToken);
 
-    if (user != null) {
-      return new CSpaceSaml2Authentication(user, authentication);
-    }
+		if (user != null) {
+			return new CSpaceSaml2Authentication(user, authentication);
+		}
 
-    return null;
-  }
+		return null;
+	}
 
-  /**
-   * Attempt to find a CSpace user for a SAML response.
-   *
-   * @param relyingPartyRegistration
-   * @param responseToken
-   * @return
-   */
-  private CSpaceUser findUser(SAMLRelyingPartyType relyingPartyRegistration, ResponseToken responseToken) {
-    AssertionProbesType assertionSsoIdProbes = (
-      relyingPartyRegistration != null
-        ? relyingPartyRegistration.getAssertionSsoIdProbes()
-        : null
-    );
+	/**
+	 * Attempt to find a CSpace user for from a list of relying parties
+	 * (from the services configuration) and a list of assertions (from the SAML response)
+	 * 
+	 * @param relyingPartyRegistration object representing relying parties from the
+	 *                                 service config
+	 * @param assertions               list of SAML assertions to test
+	 * @return                         the found CSpace user, if any
+	 */
+	private CSpaceUser findUser(SAMLRelyingPartyType relyingPartyRegistration, List<Assertion> assertions) {
+		AssertionProbesType assertionSsoIdProbes = (relyingPartyRegistration != null
+				? relyingPartyRegistration.getAssertionSsoIdProbes()
+				: null);
 
-    AssertionProbesType assertionUsernameProbes = (
-      relyingPartyRegistration != null
-        ? relyingPartyRegistration.getAssertionUsernameProbes()
-        : null
-    );
+		AssertionProbesType assertionUsernameProbes = (relyingPartyRegistration != null
+				? relyingPartyRegistration.getAssertionUsernameProbes()
+				: null);
 
-    List<String> attemptedUsernames = new ArrayList<>();
-    List<Assertion> assertions = responseToken.getResponse().getAssertions();
+		List<String> attemptedUsernames = new ArrayList<>();
 
-    SecurityUtils.logSamlAssertions(assertions);
+		SecurityUtils.logSamlAssertions(assertions);
 
-    for (Assertion assertion : assertions) {
-      CSpaceUser user = null;
-      String ssoId = SecurityUtils.getSamlAssertionSsoId(assertion, assertionSsoIdProbes);
+		for (Assertion assertion : assertions) {
+			CSpaceUser user = null;
+			String ssoId = SecurityUtils.getSamlAssertionSsoId(assertion, assertionSsoIdProbes);
 
-      // First, look for a CSpace user whose SSO ID is the ID in the assertion.
+			// First, look for a CSpace user whose SSO ID is the ID in the assertion.
 
-      if (ssoId != null) {
-        try {
-          user = (CSpaceUser) userDetailsService.loadUserBySsoId(ssoId);
-        }
-        catch (UsernameNotFoundException e) {
-        }
-      }
+			if (ssoId != null) {
+				try {
+					user = (CSpaceUser) userDetailsService.loadUserBySsoId(ssoId);
+				} catch (UsernameNotFoundException e) {
+				}
+			}
 
-      if (user != null) {
-        return user;
-      }
+			if (user != null) {
+				return user;
+			}
 
-      // Next, look for a CSpace user whose username is the email address in the assertion.
+			// Next, look for a CSpace user whose username is the email address in the
+			// assertion.
 
-      Set<String> candidateUsernames = SecurityUtils.findSamlAssertionCandidateUsernames(assertion, assertionUsernameProbes);
+			Set<String> candidateUsernames = SecurityUtils.findSamlAssertionCandidateUsernames(assertion,
+					assertionUsernameProbes);
 
-      for (String candidateUsername : candidateUsernames) {
-        try {
-          user = (CSpaceUser) userDetailsService.loadUserByUsername(candidateUsername);
+			for (String candidateUsername : candidateUsernames) {
+				try {
+					user = (CSpaceUser) userDetailsService.loadUserByUsername(candidateUsername);
 
-          if (user != null) {
-            String expectedSsoId = user.getSsoId();
+					if (user != null) {
+						String expectedSsoId = user.getSsoId();
 
-            if (expectedSsoId == null) {
-              // Store the ID from the IdP to use in future log ins. Note that this does not save
-              // the SSO ID to the database. That happens in CSpaceAuthenticationSuccessEvent.
+						if (expectedSsoId == null) {
+							// Store the ID from the IdP to use in future log ins. Note that this does not
+							// save
+							// the SSO ID to the database. That happens in CSpaceAuthenticationSuccessEvent.
 
-              user.setSsoId(ssoId);
+							user.setSsoId(ssoId);
 
-              // TODO: If the email address in the assertion differs from the CSpace user's email,
-              // update the CSpace user.
-            } else if (!StringUtils.equals(expectedSsoId, ssoId)) {
-              // If the user previously logged in via SSO, but they had a different ID from the
-              // IdP, something's wrong. (Did an account on the IdP get assigned an email that
-              // previously belonged to a different account on the IdP?)
+							// TODO: If the email address in the assertion differs from the CSpace user's
+							// email,
+							// update the CSpace user.
+						} else if (!StringUtils.equals(expectedSsoId, ssoId)) {
+							// If the user previously logged in via SSO, but they had a different ID from
+							// the
+							// IdP, something's wrong. (Did an account on the IdP get assigned an email that
+							// previously belonged to a different account on the IdP?)
 
-              logger.warn("User with username {} has expected SSO ID {}, but received {} in SAML assertion",
-                candidateUsername, expectedSsoId, ssoId);
+							logger.warn(
+									"User with username {} has expected SSO ID {}, but received {} in SAML assertion",
+									candidateUsername, expectedSsoId, ssoId);
 
-              user = null;
-            }
+							user = null;
+						}
 
-            if (user != null) {
-              return user;
-            }
-          }
-        }
-        catch(UsernameNotFoundException e) {
-        }
-      }
+						if (user != null) {
+							return user;
+						}
+					}
+				} catch (UsernameNotFoundException e) {
+				}
+			}
 
-      attemptedUsernames.addAll(candidateUsernames);
-    }
+			attemptedUsernames.addAll(candidateUsernames);
+		}
 
-    // No CSpace user was found for this SAML response.
-    // TODO: Auto-create a CSpace user, using the display name, email address, and ID in the response.
+		// No CSpace user was found for this SAML response.
+		// TODO: Auto-create a CSpace user, using the display name, email address, and
+		// ID in the response.
 
-    String errorMessage = attemptedUsernames.size() == 0
-      ? "The SAML response did not contain a CollectionSpace username."
-      : "No CollectionSpace account found for " + StringUtils.join(attemptedUsernames, " / ") + ".";
+		String errorMessage = attemptedUsernames.size() == 0
+				? "The SAML response did not contain a CollectionSpace username."
+				: "No CollectionSpace account found for " + StringUtils.join(attemptedUsernames, " / ") + ".";
 
-    throw(new UsernameNotFoundException(errorMessage));
-  }
+		throw (new UsernameNotFoundException(errorMessage));
+	}
+
+	/**
+	 * Attempt to find a CSpace user for a SAML response.
+	 *
+	 * @deprecated
+	 * @param relyingPartyRegistration
+	 * @param responseToken
+	 * @return a CSpace user
+	 */
+	private CSpaceUser findUser(SAMLRelyingPartyType relyingPartyRegistration, ResponseToken responseToken) {
+		List<Assertion> assertions = responseToken.getResponse().getAssertions();
+		return findUser(relyingPartyRegistration,assertions);
+	}
 }

--- a/services/common/src/test/java/org/collectionspace/services/common/test/AbstractSecurityTestBase.java
+++ b/services/common/src/test/java/org/collectionspace/services/common/test/AbstractSecurityTestBase.java
@@ -71,11 +71,15 @@ public class AbstractSecurityTestBase {
 		
     	return testAssertion;
     }
-	protected Attribute createAttribute(boolean hasTypedAttributeValues) throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
+	protected Attribute createAttribute(
+			boolean hasTypedAttributeValues,
+			String attributeName,
+			String attributeNameFormat
+		) throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
 		Attribute attr = createNewSAMLObject(Attribute.class);
 		attr.setFriendlyName(FRIENDLY_ATTR_NAME);
-		attr.setName(ATTR_NAME);
-		attr.setNameFormat(ATTR_NAME_FORMAT);
+		attr.setName(attributeName);
+		attr.setNameFormat(attributeNameFormat);
 		if(hasTypedAttributeValues) {
 			XSString attrValue = createNewXSString(EMAIL_ADDRESS);
 			attr.getAttributeValues().add(attrValue);
@@ -86,32 +90,28 @@ public class AbstractSecurityTestBase {
 		}
 		
 		return attr;
+	}
+	protected Attribute createDefaultAttribute(boolean hasTypedAttributeValues) throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
+		return createAttribute(hasTypedAttributeValues, ATTR_NAME, ATTR_NAME_FORMAT);
     }
-	protected Assertion createTestAssertionTypedAttributeValues() throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
+	protected Assertion createTestAssertion(Attribute attribute) throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
 		Assertion testAssertion = createTestAssertionNoAttributes();
-
-		Attribute attr = createAttribute(true);
 		
 		AttributeStatement attrStmt = createNewSAMLObject(AttributeStatement.class);
-		attrStmt.getAttributes().add(attr);
+		attrStmt.getAttributes().add(attribute);
 		testAssertion.getAttributeStatements().add(attrStmt);
     	
 		return testAssertion;
+	}
+	protected Assertion createTestAssertionTypedAttributeValues() throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
+		return createTestAssertion(createDefaultAttribute(true));
     }
 	protected Assertion createTestAssertionUntypedAttributeValues() throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
-		Assertion testAssertion = createTestAssertionNoAttributes();
-
-		Attribute attr = createAttribute(false);
-		
-		AttributeStatement attrStmt = createNewSAMLObject(AttributeStatement.class);
-		attrStmt.getAttributes().add(attr);
-		testAssertion.getAttributeStatements().add(attrStmt);
-    	
-		return testAssertion;
+		return createTestAssertion(createDefaultAttribute(false));
     }
+	
     protected Assertion testAssertionTypedAttributeValues = null;
     protected Assertion testAssertionUntypedAttributeValues = null;
-	
     @BeforeSuite
     private void setup() throws InitializationException,NoSuchFieldException,IllegalAccessException {
     	// try to set up openSAML

--- a/services/common/src/test/java/org/collectionspace/services/common/test/AbstractSecurityTestBase.java
+++ b/services/common/src/test/java/org/collectionspace/services/common/test/AbstractSecurityTestBase.java
@@ -39,41 +39,34 @@ public class AbstractSecurityTestBase {
 	protected static final String USERNAME_ATTRIBUTE = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress";
 	protected static final String SSOID_ATTRIBUTE = "http://schemas.auth0.com/identifier";
 	protected static final String SSO_CONFIG_STRING = createDefaultTestConfig();
+
 	protected static String createDefaultTestConfig() {
 		return createTestConfig(USERNAME_ATTRIBUTE, SSOID_ATTRIBUTE);
 	}
+
 	protected static String createTestConfig(String usernameAttribute, String ssoAttribute) {
-		return new StringBuilder()
-				.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
+		return new StringBuilder().append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
 				.append("<svc:service-config xmlns:svc='http://collectionspace.org/services/config'>")
-				.append("<security>")
-				.append("<sso>")
-				.append("<saml>")
-				.append("<single-logout />")
-				.append("<relying-party-registrations>")
-				.append("<relying-party id=\"auth0\">")
+				.append("<security>").append("<sso>").append("<saml>").append("<single-logout />")
+				.append("<relying-party-registrations>").append("<relying-party id=\"auth0\">")
 				.append("<name>Auth0 - Scenario 11</name>")
 				.append("<icon location=\"https://cdn.auth0.com/manhattan/versions/1.4478.0/assets/badge.png\" />")
 				.append("<metadata location=\"https://dev-cf0ltyyfory6gtqm.us.auth0.com/samlp/metadata/ZXtZfEN0mj96GP8LCmEUWcpuDO0OtqKY\" />")
-				.append("<assertion-username-probes>")
-				.append("<attribute name=\"" + usernameAttribute + "\" />")
-				.append("</assertion-username-probes>")
-				.append("<assertion-sso-id-probes>")
-				.append("<attribute name=\"" + ssoAttribute + "\" />")
-				.append("</assertion-sso-id-probes>")
-				.append("</relying-party>")
-				.append("</relying-party-registrations>")
-				.append("</saml>")
-				.append("</sso>\n")
-				.append("</security>")
-				.append("</svc:service-config>")
-				.toString();
+				.append("<assertion-username-probes>").append("<attribute name=\"" + usernameAttribute + "\" />")
+				.append("</assertion-username-probes>").append("<assertion-sso-id-probes>")
+				.append("<attribute name=\"" + ssoAttribute + "\" />").append("</assertion-sso-id-probes>")
+				.append("</relying-party>").append("</relying-party-registrations>").append("</saml>")
+				.append("</sso>\n").append("</security>").append("</svc:service-config>").toString();
 	}
+
 	protected static final String MOCK_ROOT_DIR = "./";
-    protected ServiceConfig parseServiceConfigString() throws JAXBException {
-    	return parseServiceConfigString(MOCK_ROOT_DIR, SSO_CONFIG_STRING);
-    }
-	protected ServiceConfig parseServiceConfigString(String mockRootDir, String seviceConfigString) throws JAXBException {
+
+	protected ServiceConfig parseServiceConfigString() throws JAXBException {
+		return parseServiceConfigString(MOCK_ROOT_DIR, SSO_CONFIG_STRING);
+	}
+
+	protected ServiceConfig parseServiceConfigString(String mockRootDir, String seviceConfigString)
+			throws JAXBException {
 		ServicesConfigReaderImpl rdr = new ServicesConfigReaderImpl(mockRootDir);
 		ByteArrayInputStream in = new ByteArrayInputStream(seviceConfigString.getBytes());
 		try {
@@ -84,35 +77,42 @@ public class AbstractSecurityTestBase {
 		}
 		return serviceConfig;
 	}
-	
+
 	/* for mocking useful SAML objects */
-	protected <T extends SAMLObject> T createNewSAMLObject(Class<T> clazz) throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
-    	XMLObjectBuilderFactory builderFactory = XMLObjectProviderRegistrySupport.getBuilderFactory();
-    	QName defaultElementName = (QName) clazz.getDeclaredField("DEFAULT_ELEMENT_NAME").get(null);
-    	
-    	@SuppressWarnings("unchecked") // NOTE: the T extends SAMLObject ought to guarantee this works
+	protected <T extends SAMLObject> T createNewSAMLObject(Class<T> clazz)
+			throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
+		XMLObjectBuilderFactory builderFactory = XMLObjectProviderRegistrySupport.getBuilderFactory();
+		QName defaultElementName = (QName) clazz.getDeclaredField("DEFAULT_ELEMENT_NAME").get(null);
+
+		@SuppressWarnings("unchecked") // NOTE: the T extends SAMLObject ought to guarantee this works
 		T theObject = (T) builderFactory.getBuilder(defaultElementName).buildObject(defaultElementName);
-    	return theObject;
-    }
+		return theObject;
+	}
+
 	protected XSString createNewXSString(String value) {
-    	XMLObjectBuilderFactory builderFactory = XMLObjectProviderRegistrySupport.getBuilderFactory();
-    	@SuppressWarnings("unchecked")
-		XMLObjectBuilder<XSString> stringBuilder = (XMLObjectBuilder<XSString>) builderFactory.getBuilder(XSString.TYPE_NAME);
-    	XSString theString = stringBuilder.buildObject(AttributeValue.DEFAULT_ELEMENT_NAME, XSString.TYPE_NAME);
-    	theString.setValue(value);
-    	return theString;
-    }
-    // NOTE: making the assumption that OpenSAML parses an untyped attribute value into XSAny with value in the text content 
+		XMLObjectBuilderFactory builderFactory = XMLObjectProviderRegistrySupport.getBuilderFactory();
+		@SuppressWarnings("unchecked")
+		XMLObjectBuilder<XSString> stringBuilder = (XMLObjectBuilder<XSString>) builderFactory
+				.getBuilder(XSString.TYPE_NAME);
+		XSString theString = stringBuilder.buildObject(AttributeValue.DEFAULT_ELEMENT_NAME, XSString.TYPE_NAME);
+		theString.setValue(value);
+		return theString;
+	}
+
+	// NOTE: making the assumption that OpenSAML parses an untyped attribute value
+	// into XSAny with value in the text content
 	protected XSAny createNewXSAny(String value) {
-    	XMLObjectBuilderFactory builderFactory = XMLObjectProviderRegistrySupport.getBuilderFactory();
-    	@SuppressWarnings("unchecked")
+		XMLObjectBuilderFactory builderFactory = XMLObjectProviderRegistrySupport.getBuilderFactory();
+		@SuppressWarnings("unchecked")
 		XMLObjectBuilder<XSAny> stringBuilder = (XMLObjectBuilder<XSAny>) builderFactory.getBuilder(XSAny.TYPE_NAME);
-    	XSAny theAny = stringBuilder.buildObject(AttributeValue.DEFAULT_ELEMENT_NAME,XSAny.TYPE_NAME);
-    	theAny.setTextContent(value);
-    	return theAny;
-    }
-	protected Assertion createTestAssertionNoAttributes() throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
-    	Assertion testAssertion = createNewSAMLObject(Assertion.class);
+		XSAny theAny = stringBuilder.buildObject(AttributeValue.DEFAULT_ELEMENT_NAME, XSAny.TYPE_NAME);
+		theAny.setTextContent(value);
+		return theAny;
+	}
+
+	protected Assertion createTestAssertionNoAttributes()
+			throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
+		Assertion testAssertion = createNewSAMLObject(Assertion.class);
 		testAssertion.setVersion(SAMLVersion.VERSION_20);
 		testAssertion.setIssueInstant(new DateTime());
 
@@ -121,55 +121,62 @@ public class AbstractSecurityTestBase {
 		testNameId.setValue("test subject nameid");
 		testSubject.setNameID(testNameId);
 		testAssertion.setSubject(testSubject);
-		
-    	return testAssertion;
-    }
-	protected Attribute createTestAttribute(
-			boolean hasTypedAttributeValues,
-			String attributeName,
-			String attributeNameFormat
-		) throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
+
+		return testAssertion;
+	}
+
+	protected Attribute createTestAttribute(boolean hasTypedAttributeValues, String attributeName,
+			String attributeNameFormat)
+			throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
 		Attribute attr = createNewSAMLObject(Attribute.class);
 		attr.setFriendlyName(FRIENDLY_ATTR_NAME);
 		attr.setName(attributeName);
 		attr.setNameFormat(attributeNameFormat);
-		if(hasTypedAttributeValues) {
+		if (hasTypedAttributeValues) {
 			XSString attrValue = createNewXSString(EMAIL_ADDRESS);
 			attr.getAttributeValues().add(attrValue);
-		}
-		else {
+		} else {
 			XSAny attrValue = createNewXSAny(EMAIL_ADDRESS);
 			attr.getAttributeValues().add(attrValue);
 		}
-		
+
 		return attr;
 	}
-	protected Attribute createDefaultTestAttribute(boolean hasTypedAttributeValues) throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
+
+	protected Attribute createDefaultTestAttribute(boolean hasTypedAttributeValues)
+			throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
 		return createTestAttribute(hasTypedAttributeValues, ATTR_NAME, ATTR_NAME_FORMAT);
-    }
-	protected Assertion createTestAssertion(Attribute attribute) throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
+	}
+
+	protected Assertion createTestAssertion(Attribute attribute)
+			throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
 		Assertion testAssertion = createTestAssertionNoAttributes();
-		
+
 		AttributeStatement attrStmt = createNewSAMLObject(AttributeStatement.class);
 		attrStmt.getAttributes().add(attribute);
 		testAssertion.getAttributeStatements().add(attrStmt);
-    	
+
 		return testAssertion;
 	}
-	protected Assertion createTestAssertionTypedAttributeValues() throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
+
+	protected Assertion createTestAssertionTypedAttributeValues()
+			throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
 		return createTestAssertion(createDefaultTestAttribute(true));
-    }
-	protected Assertion createTestAssertionUntypedAttributeValues() throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
+	}
+
+	protected Assertion createTestAssertionUntypedAttributeValues()
+			throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
 		return createTestAssertion(createDefaultTestAttribute(false));
-    }
-	
+	}
+
 	/* test suite setup below */
-    protected Assertion testAssertionTypedAttributeValues = null;
-    protected Assertion testAssertionUntypedAttributeValues = null;
-    protected ServiceConfig serviceConfig = null;
-    @BeforeSuite
-    protected void setup() throws InitializationException,NoSuchFieldException,IllegalAccessException, JAXBException {
-    	/* try to set up openSAML */
+	protected Assertion testAssertionTypedAttributeValues = null;
+	protected Assertion testAssertionUntypedAttributeValues = null;
+	protected ServiceConfig serviceConfig = null;
+
+	@BeforeSuite
+	protected void setup() throws InitializationException, NoSuchFieldException, IllegalAccessException, JAXBException {
+		/* try to set up openSAML */
 		XMLObjectProviderRegistry registry = new XMLObjectProviderRegistry();
 		ConfigurationService.register(XMLObjectProviderRegistry.class, registry);
 		try {
@@ -177,23 +184,26 @@ public class AbstractSecurityTestBase {
 		} catch (InitializationException e) {
 			logger.error("Could not initialize openSAML: " + e.getLocalizedMessage(), e);
 			throw e;
-		}	
-		// try to create a test assertion with typed attribute values; fail the test if this doesn't work
+		}
+		// try to create a test assertion with typed attribute values; fail the test if
+		// this doesn't work
 		try {
 			testAssertionTypedAttributeValues = createTestAssertionTypedAttributeValues();
 		} catch (IllegalArgumentException | IllegalAccessException | NoSuchFieldException | SecurityException e) {
 			logger.error("Could not create test assertion with typed attribute values: " + e.getLocalizedMessage(), e);
 			throw e;
 		}
-		// try to create a test assertion with untyped attribute values; fail the test if this doesn't work
+		// try to create a test assertion with untyped attribute values; fail the test
+		// if this doesn't work
 		try {
 			testAssertionUntypedAttributeValues = createTestAssertionUntypedAttributeValues();
 		} catch (IllegalArgumentException | IllegalAccessException | NoSuchFieldException | SecurityException e) {
-			logger.error("Could not create test assertion with untyped attribute values: " + e.getLocalizedMessage(), e);
+			logger.error("Could not create test assertion with untyped attribute values: " + e.getLocalizedMessage(),
+					e);
 			throw e;
 		}
-		
+
 		/* try to set up mock config */
 		serviceConfig = parseServiceConfigString();
-    }
+	}
 }

--- a/services/common/src/test/java/org/collectionspace/services/common/test/AbstractSecurityTestBase.java
+++ b/services/common/src/test/java/org/collectionspace/services/common/test/AbstractSecurityTestBase.java
@@ -1,0 +1,141 @@
+package org.collectionspace.services.common.test;
+
+import javax.xml.namespace.QName;
+
+import org.joda.time.DateTime;
+import org.opensaml.core.config.ConfigurationService;
+import org.opensaml.core.config.InitializationException;
+import org.opensaml.core.config.InitializationService;
+import org.opensaml.core.xml.XMLObjectBuilder;
+import org.opensaml.core.xml.XMLObjectBuilderFactory;
+import org.opensaml.core.xml.config.XMLObjectProviderRegistry;
+import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
+import org.opensaml.core.xml.schema.XSAny;
+import org.opensaml.core.xml.schema.XSString;
+import org.opensaml.saml.common.SAMLObject;
+import org.opensaml.saml.common.SAMLVersion;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AttributeStatement;
+import org.opensaml.saml.saml2.core.AttributeValue;
+import org.opensaml.saml.saml2.core.NameID;
+import org.opensaml.saml.saml2.core.Subject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.BeforeSuite;
+
+public class AbstractSecurityTestBase {
+	private static final Logger logger = LoggerFactory.getLogger(SecurityUtilsTest.class);
+	protected static String BANNER = "-------------------------------------------------------";
+	protected static String FRIENDLY_ATTR_NAME = "mail";
+	protected static String ATTR_NAME = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress";
+	protected static String ATTR_NAME_FORMAT = "urn:oasis:names:tc:SAML:2.0:attrname-format:uri";
+	protected static String EMAIL_ADDRESS = "example@example.org";
+
+	/* for mocking useful SAML objects */
+	protected <T extends SAMLObject> T createNewSAMLObject(Class<T> clazz) throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
+    	XMLObjectBuilderFactory builderFactory = XMLObjectProviderRegistrySupport.getBuilderFactory();
+    	QName defaultElementName = (QName) clazz.getDeclaredField("DEFAULT_ELEMENT_NAME").get(null);
+    	
+    	@SuppressWarnings("unchecked") // NOTE: the T extends SAMLObject ought to guarantee this works
+		T theObject = (T) builderFactory.getBuilder(defaultElementName).buildObject(defaultElementName);
+    	return theObject;
+    }
+	protected XSString createNewXSString(String value) {
+    	XMLObjectBuilderFactory builderFactory = XMLObjectProviderRegistrySupport.getBuilderFactory();
+    	@SuppressWarnings("unchecked")
+		XMLObjectBuilder<XSString> stringBuilder = (XMLObjectBuilder<XSString>) builderFactory.getBuilder(XSString.TYPE_NAME);
+    	XSString theString = stringBuilder.buildObject(AttributeValue.DEFAULT_ELEMENT_NAME, XSString.TYPE_NAME);
+    	theString.setValue(value);
+    	return theString;
+    }
+    // NOTE: making the assumption that OpenSAML parses an untyped attribute value into XSAny with value in the text content 
+	protected XSAny createNewXSAny(String value) {
+    	XMLObjectBuilderFactory builderFactory = XMLObjectProviderRegistrySupport.getBuilderFactory();
+    	@SuppressWarnings("unchecked")
+		XMLObjectBuilder<XSAny> stringBuilder = (XMLObjectBuilder<XSAny>) builderFactory.getBuilder(XSAny.TYPE_NAME);
+    	XSAny theAny = stringBuilder.buildObject(AttributeValue.DEFAULT_ELEMENT_NAME,XSAny.TYPE_NAME);
+    	theAny.setTextContent(value);
+    	return theAny;
+    }
+	protected Assertion createTestAssertionNoAttributes() throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
+    	Assertion testAssertion = createNewSAMLObject(Assertion.class);
+		testAssertion.setVersion(SAMLVersion.VERSION_20);
+		testAssertion.setIssueInstant(new DateTime());
+
+		Subject testSubject = createNewSAMLObject(Subject.class);
+		NameID testNameId = createNewSAMLObject(NameID.class);
+		testNameId.setValue("test subject nameid");
+		testSubject.setNameID(testNameId);
+		testAssertion.setSubject(testSubject);
+		
+    	return testAssertion;
+    }
+	protected Attribute createAttribute(boolean hasTypedAttributeValues) throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
+		Attribute attr = createNewSAMLObject(Attribute.class);
+		attr.setFriendlyName(FRIENDLY_ATTR_NAME);
+		attr.setName(ATTR_NAME);
+		attr.setNameFormat(ATTR_NAME_FORMAT);
+		if(hasTypedAttributeValues) {
+			XSString attrValue = createNewXSString(EMAIL_ADDRESS);
+			attr.getAttributeValues().add(attrValue);
+		}
+		else {
+			XSAny attrValue = createNewXSAny(EMAIL_ADDRESS);
+			attr.getAttributeValues().add(attrValue);
+		}
+		
+		return attr;
+    }
+	protected Assertion createTestAssertionTypedAttributeValues() throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
+		Assertion testAssertion = createTestAssertionNoAttributes();
+
+		Attribute attr = createAttribute(true);
+		
+		AttributeStatement attrStmt = createNewSAMLObject(AttributeStatement.class);
+		attrStmt.getAttributes().add(attr);
+		testAssertion.getAttributeStatements().add(attrStmt);
+    	
+		return testAssertion;
+    }
+	protected Assertion createTestAssertionUntypedAttributeValues() throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
+		Assertion testAssertion = createTestAssertionNoAttributes();
+
+		Attribute attr = createAttribute(false);
+		
+		AttributeStatement attrStmt = createNewSAMLObject(AttributeStatement.class);
+		attrStmt.getAttributes().add(attr);
+		testAssertion.getAttributeStatements().add(attrStmt);
+    	
+		return testAssertion;
+    }
+    protected Assertion testAssertionTypedAttributeValues = null;
+    protected Assertion testAssertionUntypedAttributeValues = null;
+	
+    @BeforeSuite
+    private void setup() throws InitializationException,NoSuchFieldException,IllegalAccessException {
+    	// try to set up openSAML
+		XMLObjectProviderRegistry registry = new XMLObjectProviderRegistry();
+		ConfigurationService.register(XMLObjectProviderRegistry.class, registry);
+		try {
+			InitializationService.initialize();
+		} catch (InitializationException e) {
+			logger.error("Could not initialize openSAML: " + e.getLocalizedMessage(), e);
+			throw e;
+		}	
+		// try to create a test assertion with typed attribute values; fail the test if this doesn't work
+		try {
+			testAssertionTypedAttributeValues = createTestAssertionTypedAttributeValues();
+		} catch (IllegalArgumentException | IllegalAccessException | NoSuchFieldException | SecurityException e) {
+			logger.error("Could not create test assertion with typed attribute values: " + e.getLocalizedMessage(), e);
+			throw e;
+		}
+		// try to create a test assertion with untyped attribute values; fail the test if this doesn't work
+		try {
+			testAssertionUntypedAttributeValues = createTestAssertionUntypedAttributeValues();
+		} catch (IllegalArgumentException | IllegalAccessException | NoSuchFieldException | SecurityException e) {
+			logger.error("Could not create test assertion with untyped attribute values: " + e.getLocalizedMessage(), e);
+			throw e;
+		}
+    }
+}

--- a/services/common/src/test/java/org/collectionspace/services/common/test/SecurityUtilsTest.java
+++ b/services/common/src/test/java/org/collectionspace/services/common/test/SecurityUtilsTest.java
@@ -26,124 +26,12 @@ import org.opensaml.saml.saml2.core.Subject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
-import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
 
-public class SecurityUtilsTest {
+public class SecurityUtilsTest extends AbstractSecurityTestBase {
 	private static final Logger logger = LoggerFactory.getLogger(SecurityUtilsTest.class);
-	private static String BANNER = "-------------------------------------------------------";
-	private static String FRIENDLY_ATTR_NAME = "mail";
-	private static String ATTR_NAME = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress";
-	private static String ATTR_NAME_FORMAT = "urn:oasis:names:tc:SAML:2.0:attrname-format:uri";
-	private static String EMAIL_ADDRESS = "example@example.org";
 	private void testBanner(String msg) {      
         logger.info("\r" + BANNER + "\r\n" + this.getClass().getName() + "\r\n" + msg + "\r\n" + BANNER);
-    }
-	private <T extends SAMLObject> T createNewSAMLObject(Class<T> clazz) throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
-    	XMLObjectBuilderFactory builderFactory = XMLObjectProviderRegistrySupport.getBuilderFactory();
-    	QName defaultElementName = (QName) clazz.getDeclaredField("DEFAULT_ELEMENT_NAME").get(null);
-    	
-    	@SuppressWarnings("unchecked") // NOTE: the T extends SAMLObject ought to guarantee this works
-		T theObject = (T) builderFactory.getBuilder(defaultElementName).buildObject(defaultElementName);
-    	return theObject;
-    }
-    private XSString createNewXSString(String value) {
-    	XMLObjectBuilderFactory builderFactory = XMLObjectProviderRegistrySupport.getBuilderFactory();
-    	@SuppressWarnings("unchecked")
-		XMLObjectBuilder<XSString> stringBuilder = (XMLObjectBuilder<XSString>) builderFactory.getBuilder(XSString.TYPE_NAME);
-    	XSString theString = stringBuilder.buildObject(AttributeValue.DEFAULT_ELEMENT_NAME, XSString.TYPE_NAME);
-    	theString.setValue(value);
-    	return theString;
-    }
-    // NOTE: making the assumption that OpenSAML parses an untyped attribute value into XSAny with value in the text content 
-    private XSAny createNewXSAny(String value) {
-    	XMLObjectBuilderFactory builderFactory = XMLObjectProviderRegistrySupport.getBuilderFactory();
-    	@SuppressWarnings("unchecked")
-		XMLObjectBuilder<XSAny> stringBuilder = (XMLObjectBuilder<XSAny>) builderFactory.getBuilder(XSAny.TYPE_NAME);
-    	XSAny theAny = stringBuilder.buildObject(AttributeValue.DEFAULT_ELEMENT_NAME,XSAny.TYPE_NAME);
-    	theAny.setTextContent(value);
-    	return theAny;
-    }
-    private Assertion createTestAssertionNoAttributes() throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
-    	Assertion testAssertion = createNewSAMLObject(Assertion.class);
-		testAssertion.setVersion(SAMLVersion.VERSION_20);
-		testAssertion.setIssueInstant(new DateTime());
-
-		Subject testSubject = createNewSAMLObject(Subject.class);
-		NameID testNameId = createNewSAMLObject(NameID.class);
-		testNameId.setValue("test subject nameid");
-		testSubject.setNameID(testNameId);
-		testAssertion.setSubject(testSubject);
-		
-    	return testAssertion;
-    }
-    private Attribute createAttribute(boolean hasTypedAttributeValues) throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
-		Attribute attr = createNewSAMLObject(Attribute.class);
-		attr.setFriendlyName(FRIENDLY_ATTR_NAME);
-		attr.setName(ATTR_NAME);
-		attr.setNameFormat(ATTR_NAME_FORMAT);
-		if(hasTypedAttributeValues) {
-			XSString attrValue = createNewXSString(EMAIL_ADDRESS);
-			attr.getAttributeValues().add(attrValue);
-		}
-		else {
-			XSAny attrValue = createNewXSAny(EMAIL_ADDRESS);
-			attr.getAttributeValues().add(attrValue);
-		}
-		
-		return attr;
-    }
-    private Assertion createTestAssertionTypedAttributeValues() throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
-		Assertion testAssertion = createTestAssertionNoAttributes();
-
-		Attribute attr = createAttribute(true);
-		
-		AttributeStatement attrStmt = createNewSAMLObject(AttributeStatement.class);
-		attrStmt.getAttributes().add(attr);
-		testAssertion.getAttributeStatements().add(attrStmt);
-    	
-		return testAssertion;
-    }
-    private Assertion createTestAssertionUntypedAttributeValues() throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
-		Assertion testAssertion = createTestAssertionNoAttributes();
-
-		Attribute attr = createAttribute(false);
-		
-		AttributeStatement attrStmt = createNewSAMLObject(AttributeStatement.class);
-		attrStmt.getAttributes().add(attr);
-		testAssertion.getAttributeStatements().add(attrStmt);
-    	
-		return testAssertion;
-    }
-
-    // the tests are below
-    private Assertion testAssertionTypedAttributeValues = null;
-    private Assertion testAssertionUntypedAttributeValues = null;
-	@BeforeSuite
-    private void setup() throws InitializationException,NoSuchFieldException,IllegalAccessException {
-    	// try to set up openSAML
-		XMLObjectProviderRegistry registry = new XMLObjectProviderRegistry();
-		ConfigurationService.register(XMLObjectProviderRegistry.class, registry);
-		try {
-			InitializationService.initialize();
-		} catch (InitializationException e) {
-			logger.error("Could not initialize openSAML: " + e.getLocalizedMessage(), e);
-			throw e;
-		}	
-		// try to create a test assertion with typed attribute values; fail the test if this doesn't work
-		try {
-			testAssertionTypedAttributeValues = createTestAssertionTypedAttributeValues();
-		} catch (IllegalArgumentException | IllegalAccessException | NoSuchFieldException | SecurityException e) {
-			logger.error("Could not create test assertion with typed attribute values: " + e.getLocalizedMessage(), e);
-			throw e;
-		}
-		// try to create a test assertion with untyped attribute values; fail the test if this doesn't work
-		try {
-			testAssertionUntypedAttributeValues = createTestAssertionUntypedAttributeValues();
-		} catch (IllegalArgumentException | IllegalAccessException | NoSuchFieldException | SecurityException e) {
-			logger.error("Could not create test assertion with untyped attribute values: " + e.getLocalizedMessage(), e);
-			throw e;
-		}
     }
     
     @Test

--- a/services/common/src/test/java/org/collectionspace/services/common/test/SecurityUtilsTest.java
+++ b/services/common/src/test/java/org/collectionspace/services/common/test/SecurityUtilsTest.java
@@ -1,13 +1,5 @@
 package org.collectionspace.services.common.test;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testng.Assert;
-import org.testng.annotations.BeforeSuite;
-import org.testng.annotations.Test;
-import org.w3c.dom.Element;
-
-import java.util.ArrayList;
 import java.util.Set;
 
 import javax.xml.namespace.QName;
@@ -20,8 +12,6 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
 import org.collectionspace.services.common.security.SecurityUtils;
-import org.collectionspace.services.config.AssertionAttributeProbeType;
-import org.collectionspace.services.config.AssertionProbesType;
 import org.joda.time.DateTime;
 import org.opensaml.core.config.ConfigurationService;
 import org.opensaml.core.config.InitializationException;
@@ -37,12 +27,18 @@ import org.opensaml.core.xml.schema.XSAny;
 import org.opensaml.core.xml.schema.XSString;
 import org.opensaml.saml.common.SAMLObject;
 import org.opensaml.saml.common.SAMLVersion;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
 import org.opensaml.saml.saml2.core.AttributeStatement;
 import org.opensaml.saml.saml2.core.AttributeValue;
 import org.opensaml.saml.saml2.core.NameID;
 import org.opensaml.saml.saml2.core.Subject;
-import org.opensaml.saml.saml2.core.Assertion;
-import org.opensaml.saml.saml2.core.Attribute;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+import org.w3c.dom.Element;
 
 public class SecurityUtilsTest {
 	private static final Logger logger = LoggerFactory.getLogger(SecurityUtilsTest.class);

--- a/services/common/src/test/java/org/collectionspace/services/common/test/SecurityUtilsTest.java
+++ b/services/common/src/test/java/org/collectionspace/services/common/test/SecurityUtilsTest.java
@@ -18,61 +18,73 @@ import org.testng.annotations.Test;
 
 public class SecurityUtilsTest extends AbstractSecurityTestBase {
 	private static final Logger logger = LoggerFactory.getLogger(SecurityUtilsTest.class);
-	private void testBanner(String msg) {      
-        logger.info("\r" + BANNER + "\r\n" + this.getClass().getName() + "\r\n" + msg + "\r\n" + BANNER);
-    }
-    
-    @Test
-    public void assertionWithTypedAttributeValuesIsNotNull() {
-    	testBanner("the mock assertion with typed attribute values is not null");
-    	Assert.assertNotNull(testAssertionTypedAttributeValues);
-    }
-    @Test
-    public void assertionWithUntypedAttributeValuesIsNotNull() {
-    	testBanner("the mock assertion with untyped attribute values is not null");
-    	Assert.assertNotNull(testAssertionUntypedAttributeValues);
-    }
-    @Test(dependsOnMethods = {"assertionWithTypedAttributeValuesIsNotNull"})
-    public void candidateUsernamesTypedNotNullOrEmpty() {
-    	testBanner("findSamlAssertionCandidateUsernames finds candidate usernames when they are typed as string");
-    	Set<String> candidateUsernames = SecurityUtils.findSamlAssertionCandidateUsernames(testAssertionTypedAttributeValues, null);
-		Assert.assertNotNull(candidateUsernames);
-		if(null != candidateUsernames)
-			Assert.assertFalse(candidateUsernames.isEmpty());
-    }
-    @Test(dependsOnMethods = {"assertionWithUntypedAttributeValuesIsNotNull"})
-    public void candidateUsernamesUntypedNotNullOrEmpty() {
-    	testBanner("findSamlAssertionCandidateUsernames finds candidate usernames when they are not typed");
-    	Set<String> candidateUsernames = SecurityUtils.findSamlAssertionCandidateUsernames(testAssertionUntypedAttributeValues, null);
-		Assert.assertNotNull(candidateUsernames);
-		if(null != candidateUsernames)
-			Assert.assertFalse(candidateUsernames.isEmpty());
-    }
-    @Test(dependsOnMethods = {"assertionWithUntypedAttributeValuesIsNotNull"})
-    public void candidateUsernamesUntypedIsCorrect() {
-    	testBanner("findSamlAssertionCandidateUsernames finds candidate usernames when they are not typed");
-    	Set<String> candidateUsernames = SecurityUtils.findSamlAssertionCandidateUsernames(testAssertionUntypedAttributeValues, null);
-		Assert.assertNotNull(candidateUsernames);
-		if(null != candidateUsernames)
-			Assert.assertEquals(candidateUsernames.iterator().next(),EMAIL_ADDRESS);
-    }
-    @Test(dependsOnMethods = {"assertionWithTypedAttributeValuesIsNotNull"})
-    public void candidateUsernamesTypedIsCorrect() {
-    	testBanner("findSamlAssertionCandidateUsernames finds candidate usernames when they are typed as string");
-    	Set<String> candidateUsernames = SecurityUtils.findSamlAssertionCandidateUsernames(testAssertionTypedAttributeValues, null);
-		Assert.assertNotNull(candidateUsernames);
-		if(null != candidateUsernames)
-			Assert.assertEquals(candidateUsernames.iterator().next(),EMAIL_ADDRESS);
-    }
+
+	private void testBanner(String msg) {
+		logger.info("\r" + BANNER + "\r\n" + this.getClass().getName() + "\r\n" + msg + "\r\n" + BANNER);
+	}
+
 	@Test
-	public void idenfitiferProbeFindsSsoId() throws JAXBException,IllegalArgumentException,IllegalAccessException,NoSuchFieldException,SecurityException
-	{
+	public void assertionWithTypedAttributeValuesIsNotNull() {
+		testBanner("the mock assertion with typed attribute values is not null");
+		Assert.assertNotNull(testAssertionTypedAttributeValues);
+	}
+
+	@Test
+	public void assertionWithUntypedAttributeValuesIsNotNull() {
+		testBanner("the mock assertion with untyped attribute values is not null");
+		Assert.assertNotNull(testAssertionUntypedAttributeValues);
+	}
+
+	@Test(dependsOnMethods = { "assertionWithTypedAttributeValuesIsNotNull" })
+	public void candidateUsernamesTypedNotNullOrEmpty() {
+		testBanner("findSamlAssertionCandidateUsernames finds candidate usernames when they are typed as string");
+		Set<String> candidateUsernames = SecurityUtils
+				.findSamlAssertionCandidateUsernames(testAssertionTypedAttributeValues, null);
+		Assert.assertNotNull(candidateUsernames);
+		if (null != candidateUsernames)
+			Assert.assertFalse(candidateUsernames.isEmpty());
+	}
+
+	@Test(dependsOnMethods = { "assertionWithUntypedAttributeValuesIsNotNull" })
+	public void candidateUsernamesUntypedNotNullOrEmpty() {
+		testBanner("findSamlAssertionCandidateUsernames finds candidate usernames when they are not typed");
+		Set<String> candidateUsernames = SecurityUtils
+				.findSamlAssertionCandidateUsernames(testAssertionUntypedAttributeValues, null);
+		Assert.assertNotNull(candidateUsernames);
+		if (null != candidateUsernames)
+			Assert.assertFalse(candidateUsernames.isEmpty());
+	}
+
+	@Test(dependsOnMethods = { "assertionWithUntypedAttributeValuesIsNotNull" })
+	public void candidateUsernamesUntypedIsCorrect() {
+		testBanner("findSamlAssertionCandidateUsernames finds candidate usernames when they are not typed");
+		Set<String> candidateUsernames = SecurityUtils
+				.findSamlAssertionCandidateUsernames(testAssertionUntypedAttributeValues, null);
+		Assert.assertNotNull(candidateUsernames);
+		if (null != candidateUsernames)
+			Assert.assertEquals(candidateUsernames.iterator().next(), EMAIL_ADDRESS);
+	}
+
+	@Test(dependsOnMethods = { "assertionWithTypedAttributeValuesIsNotNull" })
+	public void candidateUsernamesTypedIsCorrect() {
+		testBanner("findSamlAssertionCandidateUsernames finds candidate usernames when they are typed as string");
+		Set<String> candidateUsernames = SecurityUtils
+				.findSamlAssertionCandidateUsernames(testAssertionTypedAttributeValues, null);
+		Assert.assertNotNull(candidateUsernames);
+		if (null != candidateUsernames)
+			Assert.assertEquals(candidateUsernames.iterator().next(), EMAIL_ADDRESS);
+	}
+
+	@Test
+	public void idenfitiferProbeFindsSsoId() throws JAXBException, IllegalArgumentException, IllegalAccessException,
+			NoSuchFieldException, SecurityException {
 		testBanner("identifier probe finds sso id");
-		
+
 		String nameFormat = "urn:oasis:names:tc:SAML:2.0:attrname-format:uri";
 		String identifierName = "http://schemas.auth0.com/identifier";
-		
-		// set up a minimal mock configuration string with the SSO ID probe we wish to test
+
+		// set up a minimal mock configuration string with the SSO ID probe we wish to
+		// test
 		String theConfigString = createTestConfig(USERNAME_ATTRIBUTE, identifierName);
 		ServiceConfig theServiceConfig = null;
 		try {
@@ -81,12 +93,13 @@ public class SecurityUtilsTest extends AbstractSecurityTestBase {
 			logger.warn("Could not create mock service config: " + e.getLocalizedMessage());
 			throw e;
 		}
-		SAMLRelyingPartyRegistrationsType relyingPartyRegistrations = theServiceConfig.getSecurity().getSso().getSaml().getRelyingPartyRegistrations();
+		SAMLRelyingPartyRegistrationsType relyingPartyRegistrations = theServiceConfig.getSecurity().getSso().getSaml()
+				.getRelyingPartyRegistrations();
 		SAMLRelyingPartyType relyingPartyRegistration = relyingPartyRegistrations.getRelyingParty().get(0);
 		AssertionProbesType assertionSsoIdProbes = (relyingPartyRegistration != null
 				? relyingPartyRegistration.getAssertionSsoIdProbes()
 				: null);
-		
+
 		// create an attribute with the same name identifier as the test probe
 		Attribute attribute = null;
 		try {
@@ -103,11 +116,12 @@ public class SecurityUtilsTest extends AbstractSecurityTestBase {
 			logger.warn("Could not create SAML assertion" + e.getLocalizedMessage());
 			throw e;
 		}
-		
-		// check whether getSamlAssertionSsoId finds the SSO ID we put in the assertion using the test probe
+
+		// check whether getSamlAssertionSsoId finds the SSO ID we put in the assertion
+		// using the test probe
 		String ssoId = SecurityUtils.getSamlAssertionSsoId(assertion, assertionSsoIdProbes);
 		Assert.assertNotNull(ssoId);
 		Assert.assertFalse(ssoId.isEmpty());
-		Assert.assertEquals(ssoId,EMAIL_ADDRESS);
+		Assert.assertEquals(ssoId, EMAIL_ADDRESS);
 	}
 }

--- a/services/common/src/test/java/org/collectionspace/services/common/test/SecurityUtilsTest.java
+++ b/services/common/src/test/java/org/collectionspace/services/common/test/SecurityUtilsTest.java
@@ -3,26 +3,16 @@ package org.collectionspace.services.common.test;
 import java.util.Set;
 
 import javax.xml.namespace.QName;
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerConfigurationException;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
 
 import org.collectionspace.services.common.security.SecurityUtils;
 import org.joda.time.DateTime;
 import org.opensaml.core.config.ConfigurationService;
 import org.opensaml.core.config.InitializationException;
 import org.opensaml.core.config.InitializationService;
-import org.opensaml.core.xml.XMLObject;
 import org.opensaml.core.xml.XMLObjectBuilder;
 import org.opensaml.core.xml.XMLObjectBuilderFactory;
 import org.opensaml.core.xml.config.XMLObjectProviderRegistry;
 import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
-import org.opensaml.core.xml.io.Marshaller;
-import org.opensaml.core.xml.io.MarshallingException;
 import org.opensaml.core.xml.schema.XSAny;
 import org.opensaml.core.xml.schema.XSString;
 import org.opensaml.saml.common.SAMLObject;
@@ -38,7 +28,6 @@ import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
-import org.w3c.dom.Element;
 
 public class SecurityUtilsTest {
 	private static final Logger logger = LoggerFactory.getLogger(SecurityUtilsTest.class);

--- a/services/common/src/test/java/org/collectionspace/services/common/test/SecurityUtilsTest.java
+++ b/services/common/src/test/java/org/collectionspace/services/common/test/SecurityUtilsTest.java
@@ -50,38 +50,6 @@ public class SecurityUtilsTest {
 	private void testBanner(String msg) {      
         logger.info("\r" + BANNER + "\r\n" + this.getClass().getName() + "\r\n" + msg + "\r\n" + BANNER);
     }
-	
-	private String xml2String(XMLObject xmlObject) {
-		Element element = null;
-		String xmlString = "<uninitialized>";
-        try {
-            Marshaller out = XMLObjectProviderRegistrySupport.getMarshallerFactory().getMarshaller(xmlObject);
-            out.marshall(xmlObject);
-            element = xmlObject.getDOM();
-
-        } catch (MarshallingException e) {
-            logger.error(e.getMessage(), e);
-            e.printStackTrace();
-        }
-
-        try {
-            Transformer transformer = TransformerFactory.newInstance().newTransformer();
-            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-            StreamResult result = new StreamResult(new java.io.StringWriter());
-            
-            transformer.transform(new DOMSource(element), result);
-            xmlString = result.getWriter().toString();
-        } catch (TransformerConfigurationException e) {
-        	logger.error("Transformer configuration exception: " + e.getLocalizedMessage());
-            e.printStackTrace();
-        } catch (TransformerException e) {
-        	logger.error("Exception in transformer: " + e.getLocalizedMessage());
-            e.printStackTrace();
-        }
-        
-        return xmlString;
-	}
-	
 	private <T extends SAMLObject> T createNewSAMLObject(Class<T> clazz) throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
     	XMLObjectBuilderFactory builderFactory = XMLObjectProviderRegistrySupport.getBuilderFactory();
     	QName defaultElementName = (QName) clazz.getDeclaredField("DEFAULT_ELEMENT_NAME").get(null);
@@ -187,8 +155,6 @@ public class SecurityUtilsTest {
 			logger.error("Could not create test assertion with untyped attribute values: " + e.getLocalizedMessage(), e);
 			throw e;
 		}
-		System.out.println(xml2String(testAssertionTypedAttributeValues));
-		System.out.println(xml2String(testAssertionUntypedAttributeValues));
     }
     
     @Test

--- a/services/common/src/test/java/org/collectionspace/services/common/test/SecurityUtilsTest.java
+++ b/services/common/src/test/java/org/collectionspace/services/common/test/SecurityUtilsTest.java
@@ -48,13 +48,13 @@ public class SecurityUtilsTest {
 	private static final Logger logger = LoggerFactory.getLogger(SecurityUtilsTest.class);
 	private static String BANNER = "-------------------------------------------------------";
 	private static String FRIENDLY_ATTR_NAME = "mail";
-	private static String ATTR_NAME = "urn:oid:0.9.2342.19200300.100.1.3";
+	private static String ATTR_NAME = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress";
 	private static String ATTR_NAME_FORMAT = "urn:oasis:names:tc:SAML:2.0:attrname-format:uri";
 	private static String EMAIL_ADDRESS = "example@example.org";
 	private void testBanner(String msg) {      
         logger.info("\r" + BANNER + "\r\n" + this.getClass().getName() + "\r\n" + msg + "\r\n" + BANNER);
     }
-	/*
+	
 	private String xml2String(XMLObject xmlObject) {
 		Element element = null;
 		String xmlString = "<uninitialized>";
@@ -85,7 +85,7 @@ public class SecurityUtilsTest {
         
         return xmlString;
 	}
-	*/
+	
 	private <T extends SAMLObject> T createNewSAMLObject(Class<T> clazz) throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
     	XMLObjectBuilderFactory builderFactory = XMLObjectProviderRegistrySupport.getBuilderFactory();
     	QName defaultElementName = (QName) clazz.getDeclaredField("DEFAULT_ELEMENT_NAME").get(null);
@@ -191,6 +191,8 @@ public class SecurityUtilsTest {
 			logger.error("Could not create test assertion with untyped attribute values: " + e.getLocalizedMessage(), e);
 			throw e;
 		}
+		System.out.println(xml2String(testAssertionTypedAttributeValues));
+		System.out.println(xml2String(testAssertionUntypedAttributeValues));
     }
     
     @Test
@@ -218,5 +220,21 @@ public class SecurityUtilsTest {
 		Assert.assertNotNull(candidateUsernames);
 		if(null != candidateUsernames)
 			Assert.assertFalse(candidateUsernames.isEmpty());
+    }
+    @Test(dependsOnMethods = {"assertionWithUntypedAttributeValuesIsNotNull"})
+    public void candidateUsernamesUntypedIsCorrect() {
+    	testBanner("findSamlAssertionCandidateUsernames finds candidate usernames when they are not typed");
+    	Set<String> candidateUsernames = SecurityUtils.findSamlAssertionCandidateUsernames(testAssertionUntypedAttributeValues, null);
+		Assert.assertNotNull(candidateUsernames);
+		if(null != candidateUsernames)
+			Assert.assertEquals(candidateUsernames.iterator().next(),EMAIL_ADDRESS);
+    }
+    @Test(dependsOnMethods = {"assertionWithTypedAttributeValuesIsNotNull"})
+    public void candidateUsernamesTypedIsCorrect() {
+    	testBanner("findSamlAssertionCandidateUsernames finds candidate usernames when they are typed as string");
+    	Set<String> candidateUsernames = SecurityUtils.findSamlAssertionCandidateUsernames(testAssertionTypedAttributeValues, null);
+		Assert.assertNotNull(candidateUsernames);
+		if(null != candidateUsernames)
+			Assert.assertEquals(candidateUsernames.iterator().next(),EMAIL_ADDRESS);
     }
 }

--- a/services/config/pom.xml
+++ b/services/config/pom.xml
@@ -30,6 +30,17 @@
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
         </dependency>
+        <dependency>
+    		<groupId>com.sun.xml.bind</groupId>
+    		<artifactId>jaxb-core</artifactId>
+    		<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>xerces</groupId>
+			<artifactId>xercesImpl</artifactId>
+			<version>2.12.2</version>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.jvnet.jaxb2_commons</groupId>
 			<artifactId>jaxb2-basics</artifactId>

--- a/services/config/src/main/java/org/collectionspace/services/common/config/AbstractConfigReaderImpl.java
+++ b/services/config/src/main/java/org/collectionspace/services/common/config/AbstractConfigReaderImpl.java
@@ -121,7 +121,7 @@ public abstract class AbstractConfigReaderImpl<T> implements ConfigReader<T> {
 		return getFileChildren(rootDir, true);
 	}
 
-	protected Object parse(File configFile, Class<?> clazz)
+	public Object parse(File configFile, Class<?> clazz)
 			throws FileNotFoundException, JAXBException {
 		Object result = null;
 
@@ -144,7 +144,7 @@ public abstract class AbstractConfigReaderImpl<T> implements ConfigReader<T> {
 	 * @throws JAXBException
 	 * @throws Exception
 	 */
-	protected Object parse(InputStream configFileStream, Class<?> clazz)
+	public Object parse(InputStream configFileStream, Class<?> clazz)
 			throws JAXBException {
 		Object result = null;
 

--- a/services/config/src/test/java/org/collectionspace/services/common/config/ServicesConfigReaderImplTest.java
+++ b/services/config/src/test/java/org/collectionspace/services/common/config/ServicesConfigReaderImplTest.java
@@ -51,20 +51,6 @@ public class ServicesConfigReaderImplTest {
 	private void testBanner(String msg) {      
         logger.info("\r" + BANNER + "\r\n" + this.getClass().getName() + "\r\n" + msg + "\r\n" + BANNER);
     }
-	
-	// the tests are below
-	private ServiceConfig serviceConfig = null;
-	@BeforeSuite
-	public void setup() throws JAXBException {
-		ServicesConfigReaderImpl rdr = new ServicesConfigReaderImpl(MOCK_ROOT_DIR);
-		ByteArrayInputStream in = new ByteArrayInputStream(SSO_CONFIG_STRING.getBytes());
-		try {
-			serviceConfig = (ServiceConfig) rdr.parse(in, ServiceConfig.class);
-		} catch (JAXBException e) {
-			logger.warn("Could not create test service config: " + e.getLocalizedMessage());
-			throw e;
-		}
-	}
 	private List<AssertionAttributeProbeType> getUserNameProbesFromConfig() {
 		return getUserNameProbesFromConfig(serviceConfig);
 	}
@@ -98,6 +84,19 @@ public class ServicesConfigReaderImplTest {
 		}
 		
 		return up;
+	}
+	// the tests are below
+	private ServiceConfig serviceConfig = null;
+	@BeforeSuite
+	public void setup() throws JAXBException {
+		ServicesConfigReaderImpl rdr = new ServicesConfigReaderImpl(MOCK_ROOT_DIR);
+		ByteArrayInputStream in = new ByteArrayInputStream(SSO_CONFIG_STRING.getBytes());
+		try {
+			serviceConfig = (ServiceConfig) rdr.parse(in, ServiceConfig.class);
+		} catch (JAXBException e) {
+			logger.warn("Could not create test service config: " + e.getLocalizedMessage());
+			throw e;
+		}
 	}
 	@Test
 	public void usernameProbesNotNullOrEmpty() {

--- a/services/config/src/test/java/org/collectionspace/services/common/config/ServicesConfigReaderImplTest.java
+++ b/services/config/src/test/java/org/collectionspace/services/common/config/ServicesConfigReaderImplTest.java
@@ -1,0 +1,140 @@
+package org.collectionspace.services.common.config;
+
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.JAXBException;
+
+import org.collectionspace.services.config.AssertionAttributeProbeType;
+import org.collectionspace.services.config.SAMLRelyingPartyType;
+import org.collectionspace.services.config.SAMLType;
+import org.collectionspace.services.config.ServiceConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+
+public class ServicesConfigReaderImplTest {
+	private static final Logger logger = LoggerFactory.getLogger(ServicesConfigReaderImplTest.class);
+	private static String BANNER = "-------------------------------------------------------";
+	// NOTE: adapted from https://collectionspace.atlassian.net/browse/DRYD-1702?focusedCommentId=60649
+	private static final String USERNAME_ATTRIBUTE = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress";
+	private static final String SSOID_ATTRIBUTE = "http://schemas.auth0.com/identifier";
+	private static final String SSO_CONFIG_STRING = new StringBuilder()
+			.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
+			.append("<svc:service-config xmlns:svc='http://collectionspace.org/services/config'>")
+			.append("<security>")
+			.append("<sso>")
+			.append("<saml>")
+			.append("<single-logout />")
+			.append("<relying-party-registrations>")
+			.append("<relying-party id=\"auth0\">")
+			.append("<name>Auth0 - Scenario 11</name>")
+			.append("<icon location=\"https://cdn.auth0.com/manhattan/versions/1.4478.0/assets/badge.png\" />")
+			.append("<metadata location=\"https://dev-cf0ltyyfory6gtqm.us.auth0.com/samlp/metadata/ZXtZfEN0mj96GP8LCmEUWcpuDO0OtqKY\" />")
+			.append("<assertion-username-probes>")
+			.append("<attribute name=\"" + USERNAME_ATTRIBUTE + "\" />")
+			.append("</assertion-username-probes>")
+			.append("<assertion-sso-id-probes>")
+			.append("<attribute name=\"" + SSOID_ATTRIBUTE + "\" />")
+			.append("</assertion-sso-id-probes>")
+			.append("</relying-party>")
+			.append("</relying-party-registrations>")
+			.append("</saml>")
+			.append("</sso>\n")
+			.append("</security>")
+			.append("</svc:service-config>")
+			.toString();
+	private static final String MOCK_ROOT_DIR = "./";
+	private void testBanner(String msg) {      
+        logger.info("\r" + BANNER + "\r\n" + this.getClass().getName() + "\r\n" + msg + "\r\n" + BANNER);
+    }
+	
+	// the tests are below
+	private ServiceConfig serviceConfig = null;
+	@BeforeSuite
+	public void setup() throws JAXBException {
+		ServicesConfigReaderImpl rdr = new ServicesConfigReaderImpl(MOCK_ROOT_DIR);
+		ByteArrayInputStream in = new ByteArrayInputStream(SSO_CONFIG_STRING.getBytes());
+		try {
+			serviceConfig = (ServiceConfig) rdr.parse(in, ServiceConfig.class);
+		} catch (JAXBException e) {
+			logger.warn("Could not create test service config: " + e.getLocalizedMessage());
+			throw e;
+		}
+	}
+	private List<AssertionAttributeProbeType> getUserNameProbesFromConfig() {
+		return getUserNameProbesFromConfig(serviceConfig);
+	}
+	private List<AssertionAttributeProbeType> getUserNameProbesFromConfig(ServiceConfig serviceConfig) {
+		SAMLType samlConfig = serviceConfig.getSecurity().getSso().getSaml();
+		List<SAMLRelyingPartyType> relyingParties = samlConfig.getRelyingPartyRegistrations().getRelyingParty();
+		SAMLRelyingPartyType relyingParty = relyingParties.get(0);
+		
+		List<Object> usernameProbes = relyingParty.getAssertionUsernameProbes().getNameIdOrAttribute();
+		ArrayList<AssertionAttributeProbeType> up = new ArrayList<AssertionAttributeProbeType>();
+		for (Object obj : usernameProbes) {
+			AssertionAttributeProbeType a = (AssertionAttributeProbeType) obj;
+			up.add(a);
+		}
+		
+		return up;
+	}
+	private List<AssertionAttributeProbeType> getSsoIdProbesFromConfig() {
+		return getSsoIdProbesFromConfig(serviceConfig);
+	}
+	private List<AssertionAttributeProbeType> getSsoIdProbesFromConfig(ServiceConfig serviceConfig) {
+		SAMLType samlConfig = serviceConfig.getSecurity().getSso().getSaml();
+		List<SAMLRelyingPartyType> relyingParties = samlConfig.getRelyingPartyRegistrations().getRelyingParty();
+		SAMLRelyingPartyType relyingParty = relyingParties.get(0);
+		
+		List<Object> ssoIdProbes = relyingParty.getAssertionSsoIdProbes().getNameIdOrAttribute();
+		ArrayList<AssertionAttributeProbeType> up = new ArrayList<AssertionAttributeProbeType>();
+		for (Object obj : ssoIdProbes) {
+			AssertionAttributeProbeType a = (AssertionAttributeProbeType) obj;
+			up.add(a);
+		}
+		
+		return up;
+	}
+	@Test
+	public void usernameProbesNotNullOrEmpty() {
+		testBanner("the username probes list is not null or empty");
+		
+		List<AssertionAttributeProbeType> usernameProbes = getUserNameProbesFromConfig();
+		Assert.assertNotNull(usernameProbes);
+		if(null != usernameProbes) {
+			Assert.assertFalse(usernameProbes.isEmpty());
+		}
+	}
+	@Test(dependsOnMethods = {"usernameProbesNotNullOrEmpty"})
+	public void usernameProbesCorrectlyParsedFromConfig() {
+		testBanner("the username probes list has expected contents");
+		
+		List<AssertionAttributeProbeType> usernameProbes = getUserNameProbesFromConfig();
+		Assert.assertEquals(usernameProbes.size(), 1);
+		AssertionAttributeProbeType probe = usernameProbes.get(0);
+		Assert.assertEquals(probe.getName(), USERNAME_ATTRIBUTE);
+	}
+	@Test
+	public void ssoIdProbesNotNullOrEmpty() {
+		testBanner("the SSO ID probes list is not null or empty");
+		
+		List<AssertionAttributeProbeType> ssoIdProbes = getSsoIdProbesFromConfig();
+		Assert.assertNotNull(ssoIdProbes);
+		if(null != ssoIdProbes) {
+			Assert.assertFalse(ssoIdProbes.isEmpty());
+		}
+	}
+	@Test(dependsOnMethods = {"ssoIdProbesNotNullOrEmpty"})
+	public void ssoIdProbesCorrectlyParsedFromConfig() {
+		testBanner("the SSO ID probes list has expected contents");
+		
+		List<AssertionAttributeProbeType> ssoIdProbes = getSsoIdProbesFromConfig();
+		Assert.assertEquals(ssoIdProbes.size(), 1);
+		AssertionAttributeProbeType probe = ssoIdProbes.get(0);
+		Assert.assertEquals(probe.getName(), SSOID_ATTRIBUTE);
+	}
+}


### PR DESCRIPTION
**What does this do?**
While working on some of the SAML SSO JIRA tickets such as [DRYD-1702](https://collectionspace.atlassian.net/browse/DRYD-1702), I wrote a number of unit tests for testing CollectionSpace's handling of incoming SAML assertions with configured assertion probes. I think these tests are of general value for avoiding regressions, so they are present in this pull request. I also made some relatively minor changes that are also useful; for instance, adding `.mvn` to `.gitignore` so that developers can store local maven configurations without accidentally sending them to the git repository.

**Why are we doing this? (with JIRA link)**
I did most of the work in this pull request while investigating a SAML SSO related issue ([DRYD-1702](https://collectionspace.atlassian.net/browse/DRYD-1702)) and while working on improving the build process ([DRYD-1716](https://collectionspace.atlassian.net/browse/DRYD-1716))

**How should this be tested? Do these changes have associated tests?**
This code does not need to be tested.

**Dependencies for merging? Releasing to production?**
There should be no merge dependencies; this code is additive.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@axb21 ran this code locally.