### PR TITLE
DRYD-1716: set the antrun plugin that runs check-env-vars to <inherited>false</inherited>

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -385,6 +385,7 @@
 			<plugin>
 				<artifactId>maven-antrun-plugin</artifactId>
 				<version>1.8</version> <!-- Most recent version is 3.0.0 -->
+				<inherited>false</inherited>
 				<executions>
 					<execution>
 						<id>check-environment-vars</id>


### PR DESCRIPTION
**What does this do?**
The `maven-antrun-plugin` was running a goal `check-env-vars` once for every child project within the `services` multi-module project. Besides being a redundant check--the env cannot change while maven is executing--and besides being a deploy-only necessity, it also added many seconds to compile times. This PR changes the build process to only run `check-env-vars` once per compile cycle, saving ~5 seconds of compile time.

**Why are we doing this? (with JIRA link)**
Addresses JIRA ticket [DRYD-1716](https://collectionspace.atlassian.net/browse/DRYD-1716)

**How should this be tested? Do these changes have associated tests?**
This is a build-level change so there are no unit tests. It can be tested by running commonly-used maven commands and verifying they are behaving as expected.

**Dependencies for merging? Releasing to production?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@axb21 ran this code locally. `mvn compile`, `mvn test`, and `mvn clean install` all work as expected.
