### PR TITLE
DRYD-1712/DRYD-1715: only run `git-commit-id-plugin` once

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -414,11 +414,6 @@
                     </files>
                 </configuration>
             </plugin>
-
-			<plugin>
-				<groupId>pl.project13.maven</groupId>
-				<artifactId>git-commit-id-plugin</artifactId>
-			</plugin>
 		</plugins>
 	</build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -227,29 +227,6 @@
 						</archive>
 					</configuration>
 				</plugin>
-
-				<plugin>
-					<groupId>pl.project13.maven</groupId>
-					<artifactId>git-commit-id-plugin</artifactId>
-					<version>4.9.10</version>
-					<executions>
-						<execution>
-							<goals>
-								<goal>revision</goal>
-							</goals>
-							<phase>initialize</phase>
-						</execution>
-					</executions>
-					<configuration>
-						<generateGitPropertiesFile>true</generateGitPropertiesFile>
-						<generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
-						<includeOnlyProperties>
-							<includeOnlyProperty>^git.commit.id.abbrev$</includeOnlyProperty>
-						</includeOnlyProperties>
-						<commitIdGenerationMode>full</commitIdGenerationMode>
-					</configuration>
-				</plugin>
-
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-dependency-plugin</artifactId>

--- a/services/JaxRsServiceProvider/pom.xml
+++ b/services/JaxRsServiceProvider/pom.xml
@@ -873,6 +873,27 @@
                     </execution>
                 </executions>
             </plugin>
+			<plugin>
+				<groupId>pl.project13.maven</groupId>
+				<artifactId>git-commit-id-plugin</artifactId>
+				<version>4.9.10</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>revision</goal>
+						</goals>
+						<phase>initialize</phase>
+					</execution>
+				</executions>
+				<configuration>
+					<generateGitPropertiesFile>true</generateGitPropertiesFile>
+					<generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+					<includeOnlyProperties>
+							<includeOnlyProperty>^git.commit.id.abbrev$</includeOnlyProperty>
+						</includeOnlyProperties>
+						<commitIdGenerationMode>full</commitIdGenerationMode>
+					</configuration>
+				</plugin>
             <plugin>
                 <groupId>org.codehaus.cargo</groupId>
                 <artifactId>cargo-maven2-plugin</artifactId>


### PR DESCRIPTION
**What does this do?**
Our build had `git-commit-id-plugin` in the topmost `pom.xml` file from which all other `pom.xml` files inherit. This plugin' reads the latest git commit and stores it in a file `git.properties` that is read by the `systeminfo` service. See for instance; 
![systeminfo-screenshot](https://github.com/user-attachments/assets/21543293-4cd3-4d8b-ab91-22cc73b227e5)

this shows the version of CSpace services running comes from commit `a7af564` (the<build> tag).

However, because of this inheritance structure the `git-commit-id-plugin` was being run 217 times during builds, even builds that don't need this number. This unnecessary extra work added tens of seconds to build times. 

This change removes the `git-commit-id-plugin` from the topmost `pom.xml` and places it instead in the `JaxRsServiceProvider` project. The latter is where the ultimate WAR file used to deploy Cspace services is built, and maven can find the generated `git.properties` file there.

**Why are we doing this? (with JIRA link)**
This PR fixes the bug described in [DRYD-1712](https://collectionspace.atlassian.net/browse/DRYD-1712). It also addreses the enhancement in [DRYD-1715](https://collectionspace.atlassian.net/browse/DRYD-1715), which is no longer needed since this plugin is not taking up significant time during the build now that this bug is fixed.

**How should this be tested? Do these changes have associated tests?**
N/A

**Dependencies for merging? Releasing to production?**
No merge dependencies. There should not be implications for production.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@axb21 ran this code locally. I packaged the WAR `cspace-services.war` file and verified `git.properties` was in it and had the intended contents. I also deployed CSpace services from this commit and verified that the `systeminfo` service runs correctly and reports the correct SHA (compare the value in the <build> tag reported by the `systeminfo` service with the 1st commit SHA in the console output of `git`): 
![systeminfo-screenshot](https://github.com/user-attachments/assets/21543293-4cd3-4d8b-ab91-22cc73b227e5)
![console-screenshot](https://github.com/user-attachments/assets/806727d6-254c-4f9c-b29e-e41b5cde4279)

