### PR TITLE
DRYD-1759: Null Error in Full Place Report

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/full_obj_place.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/full_obj_place.jrxml
@@ -36,7 +36,7 @@
 	material.material, -- deurn
 	bd.item AS briefdescription,
 	comment.item AS comment,
-	publicart_collections.collections,
+	coalesce(publicart_collections.collections, '{}') as collections,
 	owners.item AS owner,
 	dimension.dimension,
 	obj.computedcurrentlocation,


### PR DESCRIPTION
**What does this do?**
This protects against the `collection` field being null by coalescing with an empty array. 

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1759

Recently we made a change to aggregate the `collection` field in the full object with place details report. This was done without any guard around the value being null which could occur if no collections were added to an object. This caused a null error to be created when the string concatenation was being done (using `join`).

**How should this be tested? Do these changes have associated tests?**
* Deploy the test with the publicart profile enabled
* Create an object without anything in the `collection` field
* Run the `Full Object with Place Details` report
  * I'm not sure if more fields need to be filled out or not, it looks like a large report and it's hard to parse them after the fact

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
...no