### PR TITLE
DRYD-1747: Add update_userid function to database

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -309,7 +309,7 @@
 	<target name="setup_initdb.sql" description="copy init_db scripts, replacing keywords">
 		<mkdir dir="${jee.server.cspace}/cspace/services/db/postgresql"/>
 		<copy todir="${jee.server.cspace}/cspace/services/db/postgresql">
-			<fileset dir="${jee.server.cspace}/cspace/services/db/postgresql" includes="drop_cspace_db.sql, init_cspace_db.sql, drop_nuxeo_db.sql">
+			<fileset dir="${jee.server.cspace}/cspace/services/db/postgresql" includes="drop_cspace_db.sql, init_cspace_db.sql, drop_nuxeo_db.sql, update_userid_function.sql">
 				<present targetdir="${src}/main/resources/db/postgresql" />
 			</fileset>
 			<globmapper from="*" to="*.bak" />

--- a/build.xml
+++ b/build.xml
@@ -216,10 +216,12 @@
 
 	<!--
 		This target sends the 'create_nuxeo_db' and 'create_nuxeo_db' targets to all the Ant sub-modules/directories
+		and creates some database utility functions
 	-->
 	<target name="-create_db" depends="-validate_create_db_unix, -validate_create_db_windows">
 		<antcall target="create_nuxeo_db" />
 		<antcall target="create_cspace_db" />
+		<antcall target="create_update_userid_db_function" />
 	</target>
 
 	<!--
@@ -271,6 +273,15 @@
 	<target name="drop_cspace_db" if="${create_db.recreate}" description="drop cspace database">
 		<echo>Dropping the cspace database with user ${db.csadmin.user}</echo>
 		<sql driver="${db.jdbc.driver.class}" url="${db.jdbc.csadmin.url}" userid="${db.csadmin.user}" password="${db.csadmin.user.password}" autocommit="true" src="${db.script.dir}/drop_cspace_db.sql">
+			<classpath>
+				<pathelement path="${db.driver.jar}" />
+			</classpath>
+		</sql>
+	</target>
+
+	<target name="create_update_userid_db_function" description="create the update_userid function in postgres">
+		<echo>Creating the update_userid function in postgres</echo>
+		<sql driver="${db.jdbc.driver.class}" url="${db.jdbc.csadmin.url}" userid="${db.csadmin.user}" password="${db.csadmin.user.password}" autocommit="true" src="${db.script.dir}/update_userid_function.sql">
 			<classpath>
 				<pathelement path="${db.driver.jar}" />
 			</classpath>

--- a/build.xml
+++ b/build.xml
@@ -281,7 +281,7 @@
 
 	<target name="create_update_userid_db_function" description="create the update_userid function in postgres">
 		<echo>Creating the update_userid function in postgres</echo>
-		<sql driver="${db.jdbc.driver.class}" url="${db.jdbc.csadmin.url}" userid="${db.csadmin.user}" password="${db.csadmin.user.password}" autocommit="true" src="${db.script.dir}/update_userid_function.sql">
+		<sql driver="${db.jdbc.driver.class}" url="${db.jdbc.cspace.url}" userid="${db.csadmin.user}" password="${db.csadmin.user.password}" autocommit="true" src="${db.script.dir}/update_userid_function.sql">
 			<classpath>
 				<pathelement path="${db.driver.jar}" />
 			</classpath>

--- a/src/main/resources/db/postgresql/update_userid_function.sql
+++ b/src/main/resources/db/postgresql/update_userid_function.sql
@@ -1,0 +1,1 @@
+CREATE OR REPLACE FUNCTION update_userid(old_userid VARCHAR, new_userid VARCHAR) RETURNS VOID AS $BODY$ BEGIN UPDATE accounts_common SET userid = new_userid WHERE userid = old_userid; UPDATE users SET username = new_userid WHERE username = old_userid; UPDATE accounts_roles SET user_id = new_userid WHERE user_id = old_userid; END $BODY$ LANGUAGE plpgsql;


### PR DESCRIPTION
**What does this do?**
This PR adds:
- A SQL script `services/src/main/resources/db/postgresql/update_userid_function.sql`
- A new `ant` target `create_update_userid_db_function` that calls this SQL script to create the `update_userid` function in the database

This PR updates:
- `ant deploy` to put `update_userid_function_sql` in  `$CSPACE_JEESERVER_HOME/cspace/services/db/postgresql` 
- `ant create_db` to run this script and create the `update_userid` function.

On initial `ant create_db`, the function will be added to the database. If one only wants to create the function and not call any other ant targets, `ant create_update_userid_db_function` will do that. One could also run the SQL script.

**Why are we doing this? (with JIRA link)**
Jira ticket: https://collectionspace.atlassian.net/browse/DRYD-1747 . This is a request from hosting.

**How should this be tested? Do these changes have associated tests?**
- Ensure there is no file `update_userid_function_sql` in `$CSPACE_JEESERVER_HOME/cspace/services/db/postgresql`. Run `ant deploy` in `services` and verify `update_userid_function_sql` is now present in `$CSPACE_JEESERVER_HOME/cspace/services/db/postgresql`
- Connect to the CollectionSpace postgress database In `psql`, run `\df`, and observe the `update_userid` function is not defined; run `DROP FUNCTION update_userid;` if it is. Issue `ant create_update_userid_db_function` in `services` and run `\df` again to verify `update_userid` is now defined 
- After a fresh `ant create_db`, connect to the CollectionSpace postgres database in `psql` and issue `\df`; observe the `update_userid` function is defined
- Run the `update_userid` function in `psql` (`SELECT update_userid('FOO','bar');` where `FOO` is a username) and verify the username is updated in the `accounts_common.userid`, `accounts_roles.user_id`, and `users.username` columns (CAUTION: this is a destructive and irreversible operation)

**Dependencies for merging? Releasing to production?**
The `ant` build targets will overwrite a function named `update_userid` if it already exists in the database.

**Has the application documentation been updated for these changes?**
No.

**Did someone actually run this code to verify it works?**
@axb21 tested this locally.