### PR TITLE
Add aspectj dependencies back into deployment

### DIFF
--- a/common-lib/pom.xml
+++ b/common-lib/pom.xml
@@ -283,6 +283,18 @@
       version changes because they require the gateway to be deployed.
     -->
     <dependency>
+      <groupId>org.aspectj</groupId>
+      <artifactId>aspectjrt</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.aspectj</groupId>
+      <artifactId>aspectjtools</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.aspectj</groupId>
+      <artifactId>aspectjweaver</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml</groupId>
       <artifactId>classmate</artifactId>
       <version>1.5.1</version>


### PR DESCRIPTION
**What does this do?**
Re-adds the aspectj dependencies when deploying cspace

**Why are we doing this? (with JIRA link)**
Related to - Jira: https://collectionspace.atlassian.net/browse/DRYD-1742

When initially reworking the dependency copies, I opted to remove the aspectj dependencies thinking we could add them into the gateway. However when trying this I found that the classes were still not being loaded because some of the other dependencies in the `${TOMCAT}/lib` directory. We'll have to update the two builds later on because it's there are some other issues starting to appear from the current build.

**How should this be tested? Do these changes have associated tests?**
Redeploy collectionspace as well as the cspace-public-gateway to the same Tomcat

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No, we still need to write the build docs :)

**Did someone actually run this code to verify it works?**
@mikejritter tested locally