### PR TITLE
DRYD-1795: Fix 500 Error for Ethnographic Object Reports

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/coreIntake.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/coreIntake.jrxml
@@ -24,7 +24,7 @@ inc.entryDate entryDate,
 inc.returnDate returnDate,
 h1.name AS "csid",
 co.objectnumber AS "objectnumber",
-co.fieldcollectionplace AS site,
+fieldcollectionplace.item AS site,
 ong.objectName AS "objectname",
 bd.item AS description,
 oppp.objectproductionpeople AS productionpeople
@@ -36,6 +36,7 @@ LEFT OUTER JOIN collectionobjects_common co ON (h2.id=co.id)
 LEFT OUTER JOIN hierarchy h3 ON (co.id = h3.parentid AND h3.primarytype='objectNameGroup' AND h3.pos=0)
 LEFT OUTER JOIN objectnamegroup ong ON (ong.id=h3.id)
 LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id=co.id and bd.pos=0)
+LEFT OUTER JOIN collectionobjects_common_fieldcollectionplaces fieldcollectionplace ON (fieldcollectionplace.id = co.id AND fieldcollectionplace.pos = 0)
 left outer join hierarchy h4 on (co.id=h4.parentid and h4.pos=0 and h4.name='collectionobjects_common:objectProductionPeopleGroupList')
 left outer join objectproductionpeoplegroup oppp on (oppp.id=h4.id)
 LEFT OUTER JOIN misc m ON (m.id = co.id)

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/coreLoanIn.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/coreLoanIn.jrxml
@@ -28,7 +28,7 @@ lic.loanReturnDate as loanReturnDate,
 lic.loanInNote as loanInNote,
 h1.name AS "csid",
 co.objectnumber AS "objectnumber",
-co.fieldcollectionplace AS site,
+fieldcollectionplace.item AS site,
 ong.objectName AS "objectname",
 bd.item AS description,
 oppp.objectproductionpeople AS productionpeople
@@ -40,6 +40,7 @@ LEFT OUTER JOIN collectionobjects_common co ON (h2.id=co.id)
 LEFT OUTER JOIN hierarchy h3 ON (co.id = h3.parentid AND h3.primarytype='objectNameGroup' AND h3.pos=0)
 LEFT OUTER JOIN objectnamegroup ong ON (ong.id=h3.id)
 LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id=co.id and bd.pos=0)
+LEFT OUTER JOIN collectionobjects_common_fieldcollectionplaces fieldcollectionplace ON (fieldcollectionplace.id = co.id AND fieldcollectionplace.pos = 0)
 left outer join hierarchy h4 on (co.id=h4.parentid and h4.pos=0 and h4.name='collectionobjects_common:objectProductionPeopleGroupList')
 left outer join objectproductionpeoplegroup oppp on (oppp.id=h4.id)
 left outer join hierarchy hlgl on (lic.id=hlgl.parentid and hlgl.pos=0 and hlgl.name='loansin_common:lenderGroupList')

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/coreLoanOut.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/coreLoanOut.jrxml
@@ -28,7 +28,7 @@ loc.loanReturnDate loanReturnDate,
 loc.loanOutNote loanOutNote,
 h1.name AS "csid",
 co.objectnumber AS "objectnumber",
-co.fieldcollectionplace AS site,
+fieldcollectionplace.item AS site,
 ong.objectName AS "objectname",
 bd.item AS description,
 oppp.objectproductionpeople as productionpeople
@@ -40,6 +40,7 @@ LEFT OUTER JOIN collectionobjects_common co ON (h2.id=co.id)
 LEFT OUTER JOIN hierarchy h3 ON (co.id = h3.parentid AND h3.primarytype='objectNameGroup' AND h3.pos=0)
 LEFT OUTER JOIN objectnamegroup ong ON (ong.id=h3.id)
 LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id=co.id and bd.pos=0)
+LEFT OUTER JOIN collectionobjects_common_fieldcollectionplaces fieldcollectionplace ON (fieldcollectionplace.id = co.id AND fieldcollectionplace.pos = 0)
 left outer join hierarchy h4 on (co.id=h4.parentid and h4.pos=0 and h4.name='collectionobjects_common:objectProductionPeopleGroupList')
 left outer join objectproductionpeoplegroup oppp on (oppp.id=h4.id)
 LEFT OUTER JOIN misc m ON (m.id = co.id)

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/coreObjectExit.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/coreObjectExit.jrxml
@@ -27,7 +27,7 @@ case when (oec.currentOwner is not null and oec.currentOwner <> '') then
 end AS owner,
 h1.name AS "csid",
 co.objectnumber AS "objectnumber",
-co.fieldcollectionplace AS site,
+fieldcollectionplace.item AS site,
 -- co.fieldcollectionnote fieldcollectionnote,
 ong.objectName AS "objectname",
 bd.item AS description,
@@ -40,6 +40,7 @@ LEFT OUTER JOIN collectionobjects_common co ON (h2.id=co.id)
 LEFT OUTER JOIN hierarchy h3 ON (co.id = h3.parentid AND h3.primarytype='objectNameGroup' AND h3.pos=0)
 LEFT OUTER JOIN objectnamegroup ong ON (ong.id=h3.id)
 LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id=co.id and bd.pos=0)
+LEFT OUTER JOIN collectionobjects_common_fieldcollectionplaces fieldcollectionplace ON (fieldcollectionplace.id = co.id AND fieldcollectionplace.pos = 0)
 left outer join hierarchy h4 on (co.id=h4.parentid and h4.pos=0 and h4.name='collectionobjects_common:objectProductionPeopleGroupList')
 left outer join objectproductionpeoplegroup oppp on (oppp.id=h4.id)
 left outer join hierarchy h5 on (oec.id=h5.parentid and h5.name='objectexit_common:exitDateGroup')


### PR DESCRIPTION
**What does this do?**
This updates the `co.fieldcollectionplace` column to be a join on `collectionobjects_common_fieldcollectionplaces` as the field was changed to be repeating 

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1795

When this field was migrated to be repeating, we neglected to update reports which used it. This caused the reports to fail when the sql would fail to run in the database.

**How should this be tested? Do these changes have associated tests?**
* Rebuild and deploy CollectionSpace
* Create a CollectionObject with a `Field collection place` (underneath the `Object Collection Information` panel)
* For Intake:
  * Create an Intake with an entry date, return date, and entry note
  * Run the `Intake Ethnographic Object List` report and see that an empty report is generated
  * Relate the Intake to the created CollectionObject
  * Run the `Intake Ethnographic Object List` report and see the field collection place in the output
* For Loan In:
  * Create a Loan In with a loan in date, loan return date, and note
  * Run the `Loan In Ethnographic Object List` report and see that an empty report is generated
  * Relate the Loan In to the created CollectionObject
  * Run the `Loan in Ethnographic Object List` report and see the field collection place in the output
* For Loan Out:
  * Create n Loan Out with an loan out date, loan return date, and note
  * Run the `Loan Out Ethnographic Object List` report and see that an empty report is generated
  * Relate the Loan Out to the created CollectionObject
  * Run the `Loan Out Ethnographic Object List` report and see the field collection place in the output
* For Object Exit (Legacy):
  * Create an Object Exit (Legacy) with an exit date and exit note
  * Run the `Object Exit Ethnographic Object List` report and see that an empty report is generated
  * Relate the Object Exit to the created CollectionObject
  * Run the `Object Exit Ethnographic Object List` report and see the field collection place in the output

**Dependencies for merging? Releasing to production?**
If the report has already been compiled, the jrxml will need to be removed in order for the server to recompile. This normally happens during the `ant undeploy` phase.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally