### PR TITLE
Update build branch for ui plugins

### DIFF
--- a/cspace-ui/anthro/build.properties
+++ b/cspace-ui/anthro/build.properties
@@ -4,7 +4,7 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-anthro
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileAnthro
 tenant.ui.profile.plugin.version=9.0.0
-tenant.ui.profile.plugin.build.branch=master
+tenant.ui.profile.plugin.build.branch=main
 
 # If not set, defaults to /gateway/${tenant.shortname} on the current host.
 # tenant.public.browser.gateway.url=https://core.dev.collectionspace.org/gateway/${tenant.shortname}

--- a/cspace-ui/bonsai/build.properties
+++ b/cspace-ui/bonsai/build.properties
@@ -4,7 +4,7 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-bonsai
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileBonsai
 tenant.ui.profile.plugin.version=7.0.0
-tenant.ui.profile.plugin.build.branch=master
+tenant.ui.profile.plugin.build.branch=main
 
 # If not set, defaults to /gateway/${tenant.shortname} on the current host.
 # tenant.public.browser.gateway.url=https://core.dev.collectionspace.org/gateway/${tenant.shortname}

--- a/cspace-ui/botgarden/build.properties
+++ b/cspace-ui/botgarden/build.properties
@@ -4,7 +4,7 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-botgarden
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileBotGarden
 tenant.ui.profile.plugin.version=4.0.0
-tenant.ui.profile.plugin.build.branch=master
+tenant.ui.profile.plugin.build.branch=main
 
 # If not set, defaults to /gateway/${tenant.shortname} on the current host.
 # tenant.public.browser.gateway.url=https://core.dev.collectionspace.org/gateway/${tenant.shortname}

--- a/cspace-ui/fcart/build.properties
+++ b/cspace-ui/fcart/build.properties
@@ -4,7 +4,7 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-fcart
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileFCart
 tenant.ui.profile.plugin.version=8.0.0
-tenant.ui.profile.plugin.build.branch=master
+tenant.ui.profile.plugin.build.branch=main
 
 # If not set, defaults to /gateway/${tenant.shortname} on the current host.
 # tenant.public.browser.gateway.url=https://core.dev.collectionspace.org/gateway/${tenant.shortname}

--- a/cspace-ui/herbarium/build.properties
+++ b/cspace-ui/herbarium/build.properties
@@ -4,7 +4,7 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-herbarium
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileHerbarium
 tenant.ui.profile.plugin.version=3.0.0
-tenant.ui.profile.plugin.build.branch=master
+tenant.ui.profile.plugin.build.branch=main
 
 # If not set, defaults to /gateway/${tenant.shortname} on the current host.
 # tenant.public.browser.gateway.url=https://core.dev.collectionspace.org/gateway/${tenant.shortname}

--- a/cspace-ui/lhmc/build.properties
+++ b/cspace-ui/lhmc/build.properties
@@ -4,7 +4,7 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-lhmc
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileLHMC
 tenant.ui.profile.plugin.version=8.0.0
-tenant.ui.profile.plugin.build.branch=master
+tenant.ui.profile.plugin.build.branch=main
 
 # If not set, defaults to /gateway/${tenant.shortname} on the current host.
 # tenant.public.browser.gateway.url=https://core.dev.collectionspace.org/gateway/${tenant.shortname}

--- a/cspace-ui/materials/build.properties
+++ b/cspace-ui/materials/build.properties
@@ -4,7 +4,7 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-materials
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileMaterials
 tenant.ui.profile.plugin.version=4.0.1
-tenant.ui.profile.plugin.build.branch=master
+tenant.ui.profile.plugin.build.branch=main
 
 # If not set, defaults to /gateway/${tenant.shortname} on the current host.
 # tenant.public.browser.gateway.url=https://core.dev.collectionspace.org/gateway/${tenant.shortname}

--- a/cspace-ui/publicart/build.properties
+++ b/cspace-ui/publicart/build.properties
@@ -4,7 +4,7 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-publicart
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfilePublicArt
 tenant.ui.profile.plugin.version=7.0.0
-tenant.ui.profile.plugin.build.branch=master
+tenant.ui.profile.plugin.build.branch=main
 
 # If not set, defaults to /gateway/${tenant.shortname} on the current host.
 # tenant.public.browser.gateway.url=https://core.dev.collectionspace.org/gateway/${tenant.shortname}


### PR DESCRIPTION
**What does this do?**
This updates the build property for `tenant.ui.profile.plugin.build.branch` to be `main`. 

**Why are we doing this? (with JIRA link)**
No jira.

This will allow our dev deployments to build the latest version of the cspace profile plugins. They are fairly low churn so they've mostly only had one branch workflows which is why they use `main` and not `develop`

**How should this be tested? Do these changes have associated tests?**
* Set the `CSPACE_UI_BUILD` env var to true
* Rebuild collection space
* Check the commit is the same as `main`

**Dependencies for merging? Releasing to production?**
All repositories will need to be updated. Only a few have been so far, but it's a fairly quick change to make.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
No