### PR TITLE
DRYD-2053: Update JAXB Imports

### DIFF
--- a/services/IntegrationTests/src/test/java/org/collectionspace/services/IntegrationTests/test/CollectionSpaceIntegrationTest.java
+++ b/services/IntegrationTests/src/test/java/org/collectionspace/services/IntegrationTests/test/CollectionSpaceIntegrationTest.java
@@ -31,8 +31,8 @@ import java.util.List;
 
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.Marshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Marshaller;
 
 import org.collectionspace.services.client.PayloadInputPart;
 import org.collectionspace.services.client.PoxPayloadIn;

--- a/services/IntegrationTests/src/test/java/org/collectionspace/services/IntegrationTests/test/RelationIntegrationTest.java
+++ b/services/IntegrationTests/src/test/java/org/collectionspace/services/IntegrationTests/test/RelationIntegrationTest.java
@@ -29,8 +29,8 @@ import java.util.List;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.Marshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Marshaller;
 
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;

--- a/services/PerformanceTests/src/test/java/org/collectionspace/services/PerformanceTests/test/CollectionSpacePerformanceTest.java
+++ b/services/PerformanceTests/src/test/java/org/collectionspace/services/PerformanceTests/test/CollectionSpacePerformanceTest.java
@@ -32,8 +32,8 @@ import java.util.Random;
 
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.Marshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Marshaller;
 
 import org.collectionspace.services.collectionobject.CollectionobjectsCommon;
 import org.collectionspace.services.collectionobject.TitleGroup;

--- a/services/account/service/src/main/java/org/collectionspace/services/account/AccountResource.java
+++ b/services/account/service/src/main/java/org/collectionspace/services/account/AccountResource.java
@@ -106,7 +106,7 @@ import javax.ws.rs.core.PathSegment;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 
 
 /** AccountResource provides RESTful interface to the account service  */

--- a/services/advancedsearch/service/src/main/java/org/collectionspace/services/advancedsearch/AdvancedSearch.java
+++ b/services/advancedsearch/service/src/main/java/org/collectionspace/services/advancedsearch/AdvancedSearch.java
@@ -12,8 +12,8 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.UriInfo;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 
 import org.collectionspace.services.MediaJAXBSchema;
 import org.collectionspace.services.advancedsearch.AdvancedsearchCommonList.AdvancedsearchListItem;

--- a/services/advancedsearch/service/src/main/java/org/collectionspace/services/advancedsearch/AdvancedSearchJAXBContext.java
+++ b/services/advancedsearch/service/src/main/java/org/collectionspace/services/advancedsearch/AdvancedSearchJAXBContext.java
@@ -1,7 +1,7 @@
 package org.collectionspace.services.advancedsearch;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
 
 import org.collectionspace.collectionspace_core.CollectionSpaceCore;
 import org.collectionspace.services.collectionobject.CollectionobjectsCommon;

--- a/services/advancedsearch/service/src/main/java/org/collectionspace/services/advancedsearch/mapper/CollectionObjectMapper.java
+++ b/services/advancedsearch/service/src/main/java/org/collectionspace/services/advancedsearch/mapper/CollectionObjectMapper.java
@@ -7,8 +7,8 @@ import static org.collectionspace.services.client.CollectionSpaceClient.PART_COM
 import static org.collectionspace.services.client.CollectionSpaceClient.PART_LABEL_SEPARATOR;
 
 import java.util.Map;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 import org.collectionspace.collectionspace_core.CollectionSpaceCore;
 import org.collectionspace.services.MediaJAXBSchema;
 import org.collectionspace.services.advancedsearch.AdvancedsearchCommonList.AdvancedsearchListItem;

--- a/services/authorization-mgt/import/src/main/java/org/collectionspace/services/authorization/importer/AuthorizationGen.java
+++ b/services/authorization-mgt/import/src/main/java/org/collectionspace/services/authorization/importer/AuthorizationGen.java
@@ -30,8 +30,8 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.List;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.Marshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Marshaller;
 
 import org.collectionspace.services.client.TenantClient;
 import org.collectionspace.authentication.AuthN;

--- a/services/authorization-mgt/import/src/main/java/org/collectionspace/services/authorization/importer/AuthorizationSeed.java
+++ b/services/authorization-mgt/import/src/main/java/org/collectionspace/services/authorization/importer/AuthorizationSeed.java
@@ -28,8 +28,8 @@ import java.io.InputStream;
 
 import java.util.List;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Unmarshaller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/services/authorization-mgt/service/src/main/java/org/collectionspace/services/authorization/RoleResource.java
+++ b/services/authorization-mgt/service/src/main/java/org/collectionspace/services/authorization/RoleResource.java
@@ -101,7 +101,7 @@ public class RoleResource extends SecurityResourceBase<Role, Role> {
                     //
                     // Replace the generic error message with a Role-specific error message
                     //
-                    String msg = String.format("There is already a role with the name '%s'.  Please choose a different name.", input.displayName);
+                    String msg = String.format("There is already a role with the name '%s'.  Please choose a different name.", input.getDisplayName());
                     throw bigReThrow(new DocumentException(msg, de, de.getErrorCode()), msg);
                 }
             }

--- a/services/authorization-mgt/service/src/main/java/org/collectionspace/services/authorization/storage/PermissionValidatorHandler.java
+++ b/services/authorization-mgt/service/src/main/java/org/collectionspace/services/authorization/storage/PermissionValidatorHandler.java
@@ -26,7 +26,7 @@ package org.collectionspace.services.authorization.storage;
 
 import java.util.List;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 
 import org.collectionspace.services.authorization.perms.Permission;
 import org.collectionspace.services.authorization.perms.PermissionAction;

--- a/services/client/src/main/java/org/collectionspace/services/client/AbstractServiceClientImpl.java
+++ b/services/client/src/main/java/org/collectionspace/services/client/AbstractServiceClientImpl.java
@@ -33,7 +33,7 @@ import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.UsernamePasswordCredentials;

--- a/services/client/src/main/java/org/collectionspace/services/client/CollectionSpaceClientUtils.java
+++ b/services/client/src/main/java/org/collectionspace/services/client/CollectionSpaceClientUtils.java
@@ -31,10 +31,10 @@ import java.util.List;
 
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.apache.commons.io.FileUtils;

--- a/services/client/src/main/java/org/collectionspace/services/client/PoxPayload.java
+++ b/services/client/src/main/java/org/collectionspace/services/client/PoxPayload.java
@@ -11,10 +11,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
 import javax.xml.transform.stream.StreamSource;
 
 import com.sun.xml.bind.api.impl.NameConverter;

--- a/services/client/src/main/java/org/collectionspace/services/client/PoxPayload.java
+++ b/services/client/src/main/java/org/collectionspace/services/client/PoxPayload.java
@@ -17,8 +17,6 @@ import jakarta.xml.bind.Marshaller;
 import jakarta.xml.bind.Unmarshaller;
 import javax.xml.transform.stream.StreamSource;
 
-import com.sun.xml.bind.api.impl.NameConverter;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.dom4j.Document;
@@ -27,10 +25,10 @@ import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
 import org.dom4j.Namespace;
 import org.dom4j.io.SAXReader;
+import org.glassfish.jaxb.core.api.impl.NameConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// TODO: Auto-generated Javadoc
 /**
  * The Class PoxPayload.
  *

--- a/services/client/src/main/java/org/collectionspace/services/client/test/BaseServiceTest.java
+++ b/services/client/src/main/java/org/collectionspace/services/client/test/BaseServiceTest.java
@@ -36,12 +36,12 @@ import java.util.Random;
 import javax.activation.MimetypesFileTypeMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.MarshalException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.MarshalException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilderFactory;
 

--- a/services/common/src/main/java/org/collectionspace/services/common/document/JaxbUtils.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/document/JaxbUtils.java
@@ -31,11 +31,11 @@ import java.io.InputStream;
 import java.io.StringWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
 import javax.xml.namespace.QName;
 
 import org.slf4j.Logger;
@@ -63,7 +63,7 @@ public class JaxbUtils {
             Marshaller m = jc.createMarshaller();
             m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
             m.marshal(o, sw);
-        } catch (javax.xml.bind.MarshalException e) {
+        } catch (jakarta.xml.bind.MarshalException e) {
         	//
         	// If the JAX-B object we're trying to marshal doesn't have an @XmlRootElement, then we need another
         	// approach.

--- a/services/common/src/main/java/org/collectionspace/services/nuxeo/client/handler/CSDocumentModelList.java
+++ b/services/common/src/main/java/org/collectionspace/services/nuxeo/client/handler/CSDocumentModelList.java
@@ -3,9 +3,9 @@ package org.collectionspace.services.nuxeo.client.handler;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import org.collectionspace.services.client.PoxPayloadOut;
 import org.collectionspace.services.jaxb.AbstractCommonList;

--- a/services/common/src/main/java/org/collectionspace/services/nuxeo/client/java/RemoteDocumentModelHandlerImpl.java
+++ b/services/common/src/main/java/org/collectionspace/services/nuxeo/client/java/RemoteDocumentModelHandlerImpl.java
@@ -37,7 +37,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 
 import org.collectionspace.authentication.AuthN;
 import org.collectionspace.services.authorization.AccountPermission;

--- a/services/common/src/test/java/org/collectionspace/services/common/test/AbstractSecurityTestBase.java
+++ b/services/common/src/test/java/org/collectionspace/services/common/test/AbstractSecurityTestBase.java
@@ -2,7 +2,7 @@ package org.collectionspace.services.common.test;
 
 import java.io.ByteArrayInputStream;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 import javax.xml.namespace.QName;
 
 import org.collectionspace.services.common.config.ServicesConfigReaderImpl;

--- a/services/common/src/test/java/org/collectionspace/services/common/test/SecurityUtilsTest.java
+++ b/services/common/src/test/java/org/collectionspace/services/common/test/SecurityUtilsTest.java
@@ -2,7 +2,7 @@ package org.collectionspace.services.common.test;
 
 import java.util.Set;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 
 import org.collectionspace.services.common.security.SecurityUtils;
 import org.collectionspace.services.config.AssertionProbesType;

--- a/services/config/src/main/java/org/collectionspace/services/common/config/AbstractConfigReaderImpl.java
+++ b/services/config/src/main/java/org/collectionspace/services/common/config/AbstractConfigReaderImpl.java
@@ -31,9 +31,9 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 
 import org.collectionspace.services.common.api.JEEServerDeployment;
 import org.slf4j.Logger;

--- a/services/config/src/test/java/org/collectionspace/services/common/config/ServicesConfigReaderImplTest.java
+++ b/services/config/src/test/java/org/collectionspace/services/common/config/ServicesConfigReaderImplTest.java
@@ -4,7 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 
 import org.collectionspace.services.config.AssertionAttributeProbeType;
 import org.collectionspace.services.config.SAMLRelyingPartyType;

--- a/services/vocabulary/service/src/main/java/org/collectionspace/services/vocabulary/VocabularyResource.java
+++ b/services/vocabulary/service/src/main/java/org/collectionspace/services/vocabulary/VocabularyResource.java
@@ -76,7 +76,7 @@ import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 
 @Path("/" + VocabularyClient.SERVICE_PATH_COMPONENT)
 public class VocabularyResource extends

--- a/services/vocabulary/service/src/main/java/org/collectionspace/services/vocabulary/VocabularyResource.java
+++ b/services/vocabulary/service/src/main/java/org/collectionspace/services/vocabulary/VocabularyResource.java
@@ -23,6 +23,21 @@
  */
 package org.collectionspace.services.vocabulary;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+
 import org.collectionspace.services.client.IClientQueryParams;
 import org.collectionspace.services.client.PayloadInputPart;
 import org.collectionspace.services.client.PoxPayload;
@@ -60,24 +75,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
 
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.HashSet;
-import java.util.Set;
-
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Request;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
-import javax.ws.rs.core.UriInfo;
-import jakarta.xml.bind.DatatypeConverter;
-
 @Path("/" + VocabularyClient.SERVICE_PATH_COMPONENT)
 public class VocabularyResource extends
 	AuthorityResource<VocabulariesCommon, VocabularyItemDocumentModelHandler> {
@@ -86,12 +83,12 @@ public class VocabularyResource extends
         POST, PUT;
     }
 
-    private final static String vocabularyServiceName = VocabularyClient.SERVICE_PATH_COMPONENT;
+    private static final String vocabularyServiceName = VocabularyClient.SERVICE_PATH_COMPONENT;
 
-	private final static String VOCABULARIES_COMMON = "vocabularies_common";
+	private static final String VOCABULARIES_COMMON = "vocabularies_common";
 
-    private final static String vocabularyItemServiceName = "vocabularyitems";
-	private final static String VOCABULARYITEMS_COMMON = "vocabularyitems_common";
+    private static final String vocabularyItemServiceName = "vocabularyitems";
+	private static final String VOCABULARYITEMS_COMMON = "vocabularyitems_common";
 
     final Logger logger = LoggerFactory.getLogger(VocabularyResource.class);
 


### PR DESCRIPTION
**What does this do?**
* Replace JAXB imports with their Jakarta equivalents
* Update NameConverter importer
* Fix field access regression in RoleResource

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-2053

This replaces the javax.xml.bind imports with their jakarta versions now that we have replaced the old jaxb-api dependency and updated the maven plugin to generate with jakarta.

**How should this be tested? Do these changes have associated tests?**
* Pull the repository
* Compile :) `mvn clean package -DskipTests` 

**Dependencies for merging? Releasing to production?**
Next steps for this are to update our build, then get our build deployments to work which involves updating Hibernate and potentially Nuxeo.

**Has the application documentation been updated for these changes?**
Nyet

**Did someone actually run this code to verify it works?**
@mikejritter compiled locally

**Have any new security vulnerabilities been handled?**
n/a
