### PR TITLE
DRYD-2080: Support Ant scripts

### DIFF
--- a/3rdparty/ant/build.xml
+++ b/3rdparty/ant/build.xml
@@ -1,13 +1,13 @@
 <project name="ant-libs" default="prepare-ant" basedir=".">
   <description>Collectionspace Services - Ant Libs</description>
 
-  <target name="prepare-ant">
+  <target name="prepare-ant-libs">
     <exec executable="mvn" failonerror="true">
       <arg value="dependency:copy-dependencies"/>
     </exec>
   </target>
 
-  <target name="test-classpath" depends="prepare-ant">
+  <target name="test-classpath" depends="prepare-ant-libs">
     <path id="javax.classpath">
       <fileset dir="./target/dependency">
         <include name="*.jar" />

--- a/3rdparty/ant/build.xml
+++ b/3rdparty/ant/build.xml
@@ -1,0 +1,23 @@
+<project name="ant-libs" default="prepare-ant" basedir=".">
+  <description>Collectionspace Services - Ant Libs</description>
+
+  <target name="prepare-ant">
+    <exec executable="mvn" failonerror="true">
+      <arg value="dependency:copy-dependencies"/>
+    </exec>
+  </target>
+
+  <target name="test-classpath" depends="prepare-ant">
+    <path id="javax.classpath">
+      <fileset dir="./target/dependency">
+        <include name="*.jar" />
+      </fileset>
+    </path>
+
+    <scriptdef name="testscript" language="javascript" manager="javax" classpathref="javax.classpath">
+      <![CDATA[self.log('script ran successfully')]]>
+    </scriptdef>
+
+    <testscript/>
+  </target>
+</project>

--- a/3rdparty/ant/pom.xml
+++ b/3rdparty/ant/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <groupId>org.collectionspace.services</groupId>
+    <artifactId>org.collectionspace.services.3rdparty</artifactId>
+    <version>${revision}</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>org.collectionspace.services.3rdparty.ant-lib</artifactId>
+  <name>collectionspace.3rdparty.ant-lib</name>
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.openjdk.nashorn</groupId>
+      <artifactId>nashorn-core</artifactId>
+      <version>15.7</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/3rdparty/pom.xml
+++ b/3rdparty/pom.xml
@@ -12,29 +12,7 @@
     <packaging>pom</packaging>
 
     <modules>
+        <module>ant</module>
         <module>nuxeo</module>
     </modules>
-
-    <dependencyManagement>
-        <dependencies>
-         </dependencies>
-    </dependencyManagement>
-
-    <build>
-<!--
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <configuration>
-                        <source>1.5</source>
-                        <target>1.5</target>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
--->
-    </build>
-
 </project>

--- a/build.xml
+++ b/build.xml
@@ -15,11 +15,11 @@
 		<os family="windows" />
 	</condition>
 
-  <target name="prepare-ant">
-    <ant antfile="3rdparty/ant/build.xml" target="prepare-ant" inheritAll="false" />
+  <target name="prepare-ant-libs">
+    <ant antfile="3rdparty/ant/build.xml" target="prepare-ant-libs" inheritAll="false" />
   </target>
 
-  <target name="encode-jdbc-options" depends="prepare-ant">
+  <target name="encode-jdbc-options" depends="prepare-ant-libs">
     <path id="javax.classpath">
       <fileset dir="${services.trunk}/3rdparty/ant/target/dependency">
         <include name="*.jar" />

--- a/build.xml
+++ b/build.xml
@@ -3,6 +3,7 @@
 	<!-- environment should be declared before reading build.properties -->
 	<property environment="env" />
 	<!-- set global properties for this build -->
+	<property name="services.trunk" value="." />
 	<property file="build.properties" />
 	<property name="mvn.opts" value="-V" />
 	<property name="src" location="src" />
@@ -14,7 +15,13 @@
 		<os family="windows" />
 	</condition>
 
-  <scriptdef name="urlencode" language="javascript">
+  <path id="javax.classpath">
+    <fileset dir="${services.trunk}/3rdparty/ant/target/dependency">
+      <include name="*.jar" />
+    </fileset>
+  </path>
+
+  <scriptdef name="urlencode" language="javascript" manager="javax" classpathref="javax.classpath">
     <attribute name="property"/>
     <![CDATA[
       var value = self.project.getProperty(attributes.get("property"));

--- a/build.xml
+++ b/build.xml
@@ -327,8 +327,8 @@
 
 	<target name="import" depends="encode-jdbc-options" description="import default configuration">
 		<ant antfile="services/build.xml" target="import" inheritAll="false">
-      <property name="db.jdbc.urloptions.encoded" value="${db.jdbc.urloptions.encoded}" />
-    </ant>
+			<property name="db.jdbc.urloptions.encoded" value="${db.jdbc.urloptions.encoded}" />
+		</ant>
 	</target>
 
 	<target name="deploy" depends="install, setup_initdb.sql, encode-jdbc-options" description="deploy services in ${jee.server.cspace}">
@@ -338,9 +338,9 @@
 		</copy>
 		<ant antfile="3rdparty/build.xml" target="deploy" inheritAll="false" />
 		<ant antfile="common-lib/build.xml" target="deploy" inheritAll="false" />
-    <ant antfile="services/build.xml" target="deploy" inheritAll="false">
-      <property name="db.jdbc.urloptions.encoded" value="${db.jdbc.urloptions.encoded}" />
-    </ant>
+		<ant antfile="services/build.xml" target="deploy" inheritAll="false">
+			<property name="db.jdbc.urloptions.encoded" value="${db.jdbc.urloptions.encoded}" />
+		</ant>
 		<ant antfile="cspace-ui/build.xml" target="deploy" inheritAll="false" />
 	</target>
 

--- a/build.xml
+++ b/build.xml
@@ -15,20 +15,28 @@
 		<os family="windows" />
 	</condition>
 
-  <path id="javax.classpath">
-    <fileset dir="${services.trunk}/3rdparty/ant/target/dependency">
-      <include name="*.jar" />
-    </fileset>
-  </path>
+  <target name="prepare-ant">
+    <ant antfile="3rdparty/ant/build.xml" target="prepare-ant" inheritAll="false" />
+  </target>
 
-  <scriptdef name="urlencode" language="javascript" manager="javax" classpathref="javax.classpath">
-    <attribute name="property"/>
-    <![CDATA[
-      var value = self.project.getProperty(attributes.get("property"));
-      var encoded = encodeURIComponent(value);
-      self.project.setProperty(attributes.get("property") + ".encoded", encoded)
-    ]]>
-  </scriptdef>
+  <target name="encode-jdbc-options" depends="prepare-ant">
+    <path id="javax.classpath">
+      <fileset dir="${services.trunk}/3rdparty/ant/target/dependency">
+        <include name="*.jar" />
+      </fileset>
+    </path>
+
+    <scriptdef name="encode" language="javascript" manager="javax" classpathref="javax.classpath">
+      <attribute name="property"/>
+      <![CDATA[
+        var value = self.project.getProperty(attributes.get("property"));
+        var encoded = encodeURIComponent(value);
+        self.project.setProperty(attributes.get("property") + ".encoded", encoded)
+      ]]>
+    </scriptdef>
+
+    <encode property="db.jdbc.urloptions" />
+  </target>
 
 	<target name="init">
 		<!-- Create the time stamp -->
@@ -233,8 +241,7 @@
 	<!--
 		This target calls the 'create_nuxeo_db' and 'create_cspace_db' targets and creates some database utility functions
 	-->
-	<target name="-create_db" depends="-validate_create_db_unix, -validate_create_db_windows">
-		<urlencode property="db.jdbc.urloptions" />
+	<target name="-create_db" depends="-validate_create_db_unix, -validate_create_db_windows, encode-jdbc-options">
 		<antcall target="create_nuxeo_db" />
 		<antcall target="create_cspace_db" />
 		<antcall target="create_update_userid_db_function" />
@@ -318,19 +325,22 @@
 		<ant antfile="services/build.xml" target="create_cspace_db" inheritAll="false" />
 	</target>
 
-	<target name="import" description="import default configuration">
-		<urlencode property="db.jdbc.urloptions" />
-		<ant antfile="services/build.xml" target="import" inheritAll="false" />
+	<target name="import" depends="encode-jdbc-options" description="import default configuration">
+		<ant antfile="services/build.xml" target="import" inheritAll="false">
+      <property name="db.jdbc.urloptions.encoded" value="${db.jdbc.urloptions.encoded}" />
+    </ant>
 	</target>
 
-	<target name="deploy" depends="install, setup_initdb.sql" description="deploy services in ${jee.server.cspace}">
+	<target name="deploy" depends="install, setup_initdb.sql, encode-jdbc-options" description="deploy services in ${jee.server.cspace}">
 		<!-- copy db scripts, etc. -->
 		<copy todir="${jee.server.cspace}/cspace/services/scripts">
 			<fileset dir="${src}/main/resources/scripts/" />
 		</copy>
 		<ant antfile="3rdparty/build.xml" target="deploy" inheritAll="false" />
 		<ant antfile="common-lib/build.xml" target="deploy" inheritAll="false" />
-		<ant antfile="services/build.xml" target="deploy" inheritAll="false" />
+    <ant antfile="services/build.xml" target="deploy" inheritAll="false">
+      <property name="db.jdbc.urloptions.encoded" value="${db.jdbc.urloptions.encoded}" />
+    </ant>
 		<ant antfile="cspace-ui/build.xml" target="deploy" inheritAll="false" />
 	</target>
 

--- a/cspace-ui/build.xml
+++ b/cspace-ui/build.xml
@@ -65,7 +65,6 @@
 	</target>
 
 	<target name="deploy_cspace_ui_js" depends="build_cspace_ui_js,download_cspace_ui_js">
-    <echo message="${services.trunk}" />
 		<pathconvert property="cspace.ui.install.filename" targetos="unix">
 			<first>
 				<fileset dir="${staging.dir}" includes="${cspace.ui.library.name}@*.min.js" />
@@ -128,7 +127,6 @@
 	</target>
 
 	<target name="deploy_tenants" depends="deploy_cspace_ui_js,deploy_cspace_public_browser_js">
-    <echo message="${services.trunk}"/>
 		<subant target="deploy_tenant" genericantfile="${ant.file}" inheritall="true">
 			<dirset dir="." includes="*" excludes="${build.dir.name}" />
 		</subant>
@@ -136,20 +134,18 @@
 
 	<target name="deploy_tenant">
 		<basename property="tenant.shortname" file="${basedir}" />
-    <path id="javax.classpath">
-      <!-- The subant calls in this file make it so we're required to traverse based off the ${tenant} directory -->
-      <fileset dir="../../3rdparty/ant">
-        <include name="**/*.jar" />
-      </fileset>
-    </path>
+		<path id="javax.classpath">
+				<!-- The subant calls in this file make it so we're required to traverse based off the tenant directory -->
+				<fileset dir="../../3rdparty/ant">
+						<include name="**/*.jar" />
+				</fileset>
+		</path>
 
-    <scriptdef name="uppercase" language="javascript" manager="javax" classpathref="javax.classpath">
-      <attribute name="property" />
-      <attribute name="string" />
-
-      project.setProperty(attributes.get("property"), attributes.get("string").toUpperCase());
-    </scriptdef>
-
+		<scriptdef name="uppercase" language="javascript" manager="javax" classpathref="javax.classpath">
+				<attribute name="property" />
+				<attribute name="string" />
+				project.setProperty(attributes.get("property"), attributes.get("string").toUpperCase());
+		</scriptdef>
 
 		<uppercase property="tenant.shortname.upper" string="${tenant.shortname}" />
 		<propertycopy name="tenant.create.disabled" from="env.CSPACE_${tenant.shortname.upper}_CREATE_DISABLED_OPT" />

--- a/cspace-ui/build.xml
+++ b/cspace-ui/build.xml
@@ -11,22 +11,7 @@
 		</sequential>
 	</macrodef>
 
-  <path id="javax.classpath">
-    <!-- The subant calls in this file make it so we're required to traverse based off the ${tenant} directory -->
-    <fileset dir="../../3rdparty/ant/target/dependency">
-      <include name="*.jar" />
-    </fileset>
-  </path>
-
-	<scriptdef name="uppercase" language="javascript" manager="javax" classpathref="javax.classpath">
-		<attribute name="property" />
-		<attribute name="string" />
-
-		project.setProperty(attributes.get("property"), attributes.get("string").toUpperCase());
-	</scriptdef>
-
 	<!-- set global properties for this build -->
-	<property name="services.trunk" value=".." />
 	<property name="build.dir.name" value="build" />
 	<property name="build.dir" value="./${build.dir.name}" />
 	<property name="source.dir" value="${build.dir}/source" />
@@ -150,11 +135,23 @@
 	</target>
 
 	<target name="deploy_tenant">
-    <echo message="${services.trunk}"/>
 		<basename property="tenant.shortname" file="${basedir}" />
-    <echo message="hi"/>
+    <path id="javax.classpath">
+      <!-- The subant calls in this file make it so we're required to traverse based off the ${tenant} directory -->
+      <fileset dir="../../3rdparty/ant">
+        <include name="**/*.jar" />
+      </fileset>
+    </path>
+
+    <scriptdef name="uppercase" language="javascript" manager="javax" classpathref="javax.classpath">
+      <attribute name="property" />
+      <attribute name="string" />
+
+      project.setProperty(attributes.get("property"), attributes.get("string").toUpperCase());
+    </scriptdef>
+
+
 		<uppercase property="tenant.shortname.upper" string="${tenant.shortname}" />
-    <echo message="hii"/>
 		<propertycopy name="tenant.create.disabled" from="env.CSPACE_${tenant.shortname.upper}_CREATE_DISABLED_OPT" />
 
 		<property file="${basedir}/build.properties" />

--- a/cspace-ui/build.xml
+++ b/cspace-ui/build.xml
@@ -12,6 +12,7 @@
 	</macrodef>
 
 	<!-- set global properties for this build -->
+	<property name="services.trunk" value=".." />
 	<property name="build.dir.name" value="build" />
 	<property name="build.dir" value="./${build.dir.name}" />
 	<property name="source.dir" value="${build.dir}/source" />

--- a/cspace-ui/build.xml
+++ b/cspace-ui/build.xml
@@ -11,7 +11,14 @@
 		</sequential>
 	</macrodef>
 
-	<scriptdef name="uppercase" language="javascript">
+  <path id="javax.classpath">
+    <!-- The subant calls in this file make it so we're required to traverse based off the ${tenant} directory -->
+    <fileset dir="../../3rdparty/ant/target/dependency">
+      <include name="*.jar" />
+    </fileset>
+  </path>
+
+	<scriptdef name="uppercase" language="javascript" manager="javax" classpathref="javax.classpath">
 		<attribute name="property" />
 		<attribute name="string" />
 
@@ -73,6 +80,7 @@
 	</target>
 
 	<target name="deploy_cspace_ui_js" depends="build_cspace_ui_js,download_cspace_ui_js">
+    <echo message="${services.trunk}" />
 		<pathconvert property="cspace.ui.install.filename" targetos="unix">
 			<first>
 				<fileset dir="${staging.dir}" includes="${cspace.ui.library.name}@*.min.js" />
@@ -135,14 +143,18 @@
 	</target>
 
 	<target name="deploy_tenants" depends="deploy_cspace_ui_js,deploy_cspace_public_browser_js">
+    <echo message="${services.trunk}"/>
 		<subant target="deploy_tenant" genericantfile="${ant.file}" inheritall="true">
 			<dirset dir="." includes="*" excludes="${build.dir.name}" />
 		</subant>
 	</target>
 
 	<target name="deploy_tenant">
+    <echo message="${services.trunk}"/>
 		<basename property="tenant.shortname" file="${basedir}" />
+    <echo message="hi"/>
 		<uppercase property="tenant.shortname.upper" string="${tenant.shortname}" />
+    <echo message="hii"/>
 		<propertycopy name="tenant.create.disabled" from="env.CSPACE_${tenant.shortname.upper}_CREATE_DISABLED_OPT" />
 
 		<property file="${basedir}/build.properties" />

--- a/services/JaxRsServiceProvider/build.xml
+++ b/services/JaxRsServiceProvider/build.xml
@@ -53,7 +53,6 @@
 
     <target name="package" depends="package-unix,package-windows"
   description="Package CollectionSpace Services" />
-    <urlencode property="db.jdbc.urloptions" />
     <target name="package-unix" if="osfamily-unix">
         <exec executable="mvn" failonerror="true">
             <arg value="package" />
@@ -77,7 +76,6 @@
             <arg value="${mvn.opts}" />
         </exec>
     </target>
-
 
     <target name="clean" depends="clean-unix,clean-windows"
   description="Delete target directories" >

--- a/services/build.xml
+++ b/services/build.xml
@@ -145,9 +145,9 @@
 
     <target name="import"
             description="import default configuration">
-      <ant antfile="authorization-mgt/build.xml" target="import" inheritAll="false">
-        <property name="db.jdbc.urloptions.encoded" value="${db.jdbc.urloptions.encoded}" />
-      </ant>
+        <ant antfile="authorization-mgt/build.xml" target="import" inheritAll="false">
+            <property name="db.jdbc.urloptions.encoded" value="${db.jdbc.urloptions.encoded}" />
+        </ant>
     </target>
 
     <!-- this target is called in order based on the dependencies between the services -->
@@ -202,10 +202,10 @@
         <ant antfile="publicitem/build.xml" target="deploy" inheritAll="false"/>
         <ant antfile="uoc/build.xml" target="deploy" inheritAll="false"/>
         <ant antfile="transport/build.xml" target="deploy" inheritAll="false"/>
-    	<ant antfile="advancedsearch/build.xml" target="deploy" inheritAll="false"/>
-      <ant antfile="JaxRsServiceProvider/build.xml" target="deploy" inheritAll="false">
-        <property name="db.jdbc.urloptions.encoded" value="${db.jdbc.urloptions.encoded}" />
-      </ant>
+        <ant antfile="advancedsearch/build.xml" target="deploy" inheritAll="false"/>
+        <ant antfile="JaxRsServiceProvider/build.xml" target="deploy" inheritAll="false">
+          <property name="db.jdbc.urloptions.encoded" value="${db.jdbc.urloptions.encoded}" />
+        </ant>
     </target>
 
     <!-- this target is called in reverse order of deploy targets -->

--- a/services/build.xml
+++ b/services/build.xml
@@ -145,7 +145,9 @@
 
     <target name="import"
             description="import default configuration">
-        <ant antfile="authorization-mgt/build.xml" target="import" inheritAll="false"/>
+      <ant antfile="authorization-mgt/build.xml" target="import" inheritAll="false">
+        <property name="db.jdbc.urloptions.encoded" value="${db.jdbc.urloptions.encoded}" />
+      </ant>
     </target>
 
     <!-- this target is called in order based on the dependencies between the services -->
@@ -201,7 +203,9 @@
         <ant antfile="uoc/build.xml" target="deploy" inheritAll="false"/>
         <ant antfile="transport/build.xml" target="deploy" inheritAll="false"/>
     	<ant antfile="advancedsearch/build.xml" target="deploy" inheritAll="false"/>
-        <ant antfile="JaxRsServiceProvider/build.xml" target="deploy" inheritAll="false"/>
+      <ant antfile="JaxRsServiceProvider/build.xml" target="deploy" inheritAll="false">
+        <property name="db.jdbc.urloptions.encoded" value="${db.jdbc.urloptions.encoded}" />
+      </ant>
     </target>
 
     <!-- this target is called in reverse order of deploy targets -->


### PR DESCRIPTION
**What does this do?**
* Create a 3rdparty/ant module to download and store dependencies for the javascript engine
* Rework build targets which use scripts to depend on the ant module

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-2080

The nashorn engine is no longer bundled with the JDK, meaning that the ant scripts which relied on it no longer work. This allows us to control which engine we depend on through maven and retrieve it before running any targets which depend on it.

**How should this be tested? Do these changes have associated tests?**
* cd to the 3rdparty/ant module
* run `ant test-classpath`
* for fun you could try `ant import` from the project root but the changes aren't complete yet to allow it to run.

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No. It might be worth creating some more documentation around the deployment in general since I believe it's very sparse.

**Did someone actually run this code to verify it works?**
@mikejritter has been testing locally

**Have any new security vulnerabilities been handled?**
n/a
