### PR TITLE
DRYD-2092: Make SecurityInterceptor Implement ContainerRequestFilter

### DIFF
--- a/services/common/src/main/java/org/collectionspace/services/common/AbstractCollectionSpaceResourceImpl.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/AbstractCollectionSpaceResourceImpl.java
@@ -579,8 +579,7 @@ public abstract class AbstractCollectionSpaceResourceImpl<IT, OT>
     }
     
 	@Override
-	public boolean allowAnonymousAccess(HttpRequest request,
-			Class<?> resourceClass) {
+	public boolean allowAnonymousAccess() {
 		return false;
 	}
 	

--- a/services/common/src/main/java/org/collectionspace/services/common/CollectionSpaceResource.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/CollectionSpaceResource.java
@@ -97,7 +97,7 @@ public interface CollectionSpaceResource<IT, OT> {
      */
 //			<sec:filter-chain pattern="/publicitems/*/*/content"
 //                              filters="none"/>
-	public boolean allowAnonymousAccess(HttpRequest request, Class<?> resourceClass);
+	public boolean allowAnonymousAccess();
 	
     /**
      * Returns a UriRegistry entry: a map of tenant-qualified URI templates

--- a/services/common/src/main/java/org/collectionspace/services/common/publicitem/PublicItemResource.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/publicitem/PublicItemResource.java
@@ -77,11 +77,10 @@ public class PublicItemResource extends NuxeoBasedResource {
     }
 
 	@Override
-	public boolean allowAnonymousAccess(HttpRequest request,
-			Class<?> resourceClass) {
+	public boolean allowAnonymousAccess() {
 		return true;
 	}
-	
+
     @GET
     @Path("/{csid}/{tenantId}/" + PublicItemClient.PUBLICITEMS_CONTENT_SUFFIX) // "content"
     public Response getPublishedResource(

--- a/services/common/src/main/java/org/collectionspace/services/common/security/SecurityInterceptor.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/security/SecurityInterceptor.java
@@ -32,10 +32,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.security.Principal;
 import java.util.HashMap;
 import java.util.Set;
-
-import org.jboss.resteasy.spi.Failure;
-import org.nuxeo.runtime.api.Framework;
-
 import javax.security.auth.Subject;
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
@@ -43,6 +39,8 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
@@ -55,6 +53,7 @@ import org.collectionspace.services.authorization.URIResourceImpl;
 import org.collectionspace.services.client.index.IndexClient;
 import org.collectionspace.services.client.workflow.WorkflowClient;
 import org.collectionspace.services.common.CSWebApplicationException;
+import org.collectionspace.services.common.CollectionSpaceResource;
 import org.collectionspace.services.common.ServiceMain;
 import org.collectionspace.services.common.document.JaxbUtils;
 import org.collectionspace.services.common.storage.jpa.JpaStorageUtils;
@@ -62,6 +61,8 @@ import org.collectionspace.services.config.tenant.TenantBindingType;
 import org.collectionspace.services.login.LoginClient;
 import org.collectionspace.services.logout.LogoutClient;
 import org.collectionspace.services.systeminfo.SystemInfoClient;
+import org.jboss.resteasy.spi.Failure;
+import org.nuxeo.runtime.api.Framework;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -94,6 +95,9 @@ public class SecurityInterceptor implements ContainerRequestFilter, ContainerRes
     private static final String ERROR_NUXEO_LOGOUT = "Attempt to logout when Nuxeo login context was null.";
     private static final String ERROR_UNBALANCED_LOGINS = "The number of Logins vs Logouts to the Nuxeo framework was unbalanced.";
 
+	@Context
+	private ResourceInfo resourceInfo;
+
     private boolean isAnonymousRequest(ContainerRequestContext requestContext) {
     	boolean result = false;
 
@@ -107,18 +111,15 @@ public class SecurityInterceptor implements ContainerRequestFilter, ContainerRes
             return true;
         }
 
-		/*
-		 * Todo: Figure out the condition which this returns true (only publicItem overrides allowAnonymousAccess)
-		Class<?> resourceClass = resourceMethodInvoker.getResourceClass();
+		Class<?> resourceClass = resourceInfo.getResourceClass();
 		try {
 			CollectionSpaceResource resourceInstance = (CollectionSpaceResource)resourceClass.newInstance();
-			result = resourceInstance.allowAnonymousAccess(request, resourceClass);
+			result = resourceInstance.allowAnonymousAccess();
 		} catch (InstantiationException e) {
 			logger.error("isAnonymousRequest: ", e);
 		} catch (IllegalAccessException e) {
 			logger.error("isAnonymousRequest: ", e);
 		}
-		 */
 
     	return result;
     }

--- a/services/common/src/main/java/org/collectionspace/services/common/security/SecurityInterceptor.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/security/SecurityInterceptor.java
@@ -147,6 +147,21 @@ public class SecurityInterceptor implements ContainerRequestFilter, ContainerRes
         return result;
 	}
 
+	private void checkAccessAllowed(final AuthZ authZ,
+									final CSpaceResource resource,
+									final String resourceName,
+									final String uriPath,
+									final String httpMethod) throws CSWebApplicationException {
+		if (!authZ.isAccessAllowed(resource)) {
+			logger.error("Access to {}:{} is NOT allowed to  user={}", resourceName, resource.getId(),
+						 AuthN.get().getUserId());
+			final Response response = Response.status(Response.Status.FORBIDDEN)
+											  .entity(uriPath + " " + httpMethod)
+											  .type(MediaType.TEXT_PLAIN_TYPE).build();
+			throw new CSWebApplicationException(response);
+		}
+	}
+
 	@Override
 	public void filter(ContainerRequestContext containerRequestContext) throws IOException {
 		Request request = containerRequestContext.getRequest();
@@ -193,46 +208,26 @@ public class SecurityInterceptor implements ContainerRequestFilter, ContainerRes
 			//
 			checkActive();
 
-			if (requiresAuthorization(resName)) { //see comment immediately above
+			if (requiresAuthorization(resName)) {
 				AuthZ authZ = AuthZ.get();
 				CSpaceResource res = new URIResourceImpl(AuthN.get().getCurrentTenantId(), resName, httpMethod);
-				if (!authZ.isAccessAllowed(res)) {
-					logger.error("Access to {} is NOT allowed to  user={}", res.getId(), AuthN.get().getUserId());
-					Response response = Response.status(Response.Status.FORBIDDEN)
-												.entity(uriPath + " " + httpMethod)
-												.type("text/plain").build();
-					throw new CSWebApplicationException(response);
-				} else {
-					//
-					// They passed the first round of security checks, so now let's check to see if they're trying
-					// to perform a workflow state change or fulltext reindex and make sure they are allowed to this.
-					//
-					if (uriPath.contains(WorkflowClient.SERVICE_PATH)) {
-						String workflowProxyResource = SecurityUtils.getWorkflowResourceName(containerRequestContext);
-						res = new URIResourceImpl(AuthN.get().getCurrentTenantId(), workflowProxyResource, httpMethod);
-						if (!authZ.isAccessAllowed(res)) {
-							logger.error("Access to {}:{} is NOT allowed to  user={}", resName, res.getId(),
-										 AuthN.get().getUserId());
-							Response response = Response.status(Response.Status.FORBIDDEN)
-														.entity(uriPath + " " + httpMethod)
-														.type("text/plain").build();
-							throw new CSWebApplicationException(response);
-						}
-					} else if (uriPath.contains(IndexClient.SERVICE_PATH)) {
-						String indexProxyResource = SecurityUtils.getIndexResourceName();
-						res = new URIResourceImpl(AuthN.get().getCurrentTenantId(), indexProxyResource, httpMethod);
-						if (!authZ.isAccessAllowed(res)) {
-							logger.error("Access to {}:{} is NOT allowed to  user={}", resName, res.getId(),
-										 AuthN.get().getUserId());
-							Response response = Response.status(Response.Status.FORBIDDEN)
-														.entity(uriPath + " " + httpMethod)
-														.type("text/plain").build();
-							throw new CSWebApplicationException(response);
-						}
-					}
+				checkAccessAllowed(authZ, res, resName, uriPath, httpMethod);
 
-				}
-				//
+                //
+                // They passed the first round of security checks, so now let's check to see if they're trying
+                // to perform a workflow state change or fulltext reindex and make sure they are allowed to this.
+                //
+                if (uriPath.contains(WorkflowClient.SERVICE_PATH)) {
+                    String workflowProxyResource = SecurityUtils.getWorkflowResourceName(containerRequestContext);
+                    res = new URIResourceImpl(AuthN.get().getCurrentTenantId(), workflowProxyResource, httpMethod);
+					checkAccessAllowed(authZ, res, resName, uriPath, httpMethod);
+                } else if (uriPath.contains(IndexClient.SERVICE_PATH)) {
+                    String indexProxyResource = SecurityUtils.getIndexResourceName();
+                    res = new URIResourceImpl(AuthN.get().getCurrentTenantId(), indexProxyResource, httpMethod);
+					checkAccessAllowed(authZ, res, resName, uriPath, httpMethod);
+                }
+
+                //
 				// Login to Nuxeo
 				//
 				nuxeoPreProcess();

--- a/services/common/src/main/java/org/collectionspace/services/common/security/SecurityInterceptor.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/security/SecurityInterceptor.java
@@ -32,9 +32,11 @@ import java.lang.reflect.InvocationTargetException;
 import java.security.Principal;
 import java.util.HashMap;
 import java.util.Set;
+import javax.annotation.Priority;
 import javax.security.auth.Subject;
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
+import javax.ws.rs.Priorities;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseContext;
@@ -70,6 +72,7 @@ import org.slf4j.LoggerFactory;
  * RESTeasy interceptor for access control
  * @version $Revision: 1 $
  */
+@Priority(Priorities.AUTHENTICATION)
 @Provider
 public class SecurityInterceptor implements ContainerRequestFilter, ContainerResponseFilter {
 

--- a/services/common/src/main/java/org/collectionspace/services/common/security/SecurityInterceptor.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/security/SecurityInterceptor.java
@@ -161,7 +161,7 @@ public class SecurityInterceptor implements ContainerRequestFilter, ContainerRes
 			String tenantId = AuthN.get().getCurrentTenantId();
 			TenantBindingType tenantBindingType = ServiceMain.getInstance().getTenantBindingConfigReader().getTenantBinding(tenantId);
 			boolean tenantDisabled = tenantBindingType.isCreateDisabled();
-			if (tenantDisabled == true) {
+			if (tenantDisabled) {
 				String errMsg = String.format("The user %s's tenant '%s' is disabled.  Contact your CollectionSpace administrator.",
 						userId, tenantBindingType.getDisplayName());
 				Response response = Response.status(
@@ -236,29 +236,31 @@ public class SecurityInterceptor implements ContainerRequestFilter, ContainerRes
 	}
 
     private void logLoginContext(LoginContext loginContext) {
-    	if (!logger.isTraceEnabled()) return;
+    	if (!logger.isTraceEnabled()) {
+			return;
+		}
 
-		logger.trace("CollectionSpace services now logged in to Nuxeo with LoginContext: "
-				+ loginContext);
+        logger.trace("CollectionSpace services now logged in to Nuxeo with LoginContext: {}", loginContext);
 		Subject subject = loginContext.getSubject();
 		Set<Principal> principals = subject.getPrincipals();
 		logger.trace("Nuxeo login performed with principals: ");
 		for (Principal principal : principals) {
-			logger.trace("[" + principal.getName() + "]");
+            logger.trace("[{}]", principal.getName());
 		}
     }
 
     private void logLogoutContext(LoginContext loginContext) {
-    	if (!logger.isTraceEnabled()) return;
+    	if (!logger.isTraceEnabled()) {
+			return;
+		}
 
     	if (loginContext != null) {
-			logger.trace("CollectionSpace services now logging out of Nuxeo with LoginContext: "
-					+ loginContext);
+            logger.trace("CollectionSpace services now logging out of Nuxeo with LoginContext: {}", loginContext);
 			Subject subject = loginContext.getSubject();
 			Set<Principal> principals = subject.getPrincipals();
 			logger.trace("Nuxeo logout performed with principals: ");
 			for (Principal principal : principals) {
-				logger.trace("[" + principal.getName() + "]");
+                logger.trace("[{}]", principal.getName());
 			}
     	} else {
     		logger.trace("Logged out.");
@@ -275,11 +277,9 @@ public class SecurityInterceptor implements ContainerRequestFilter, ContainerRes
     	//
     	if (threadLocalLoginContext == null) {
     		threadLocalLoginContext = new ThreadLocal<LoginContext>();
-    		if (logger.isTraceEnabled() == true) {
-    			logger.trace(String.format("Thread ID %s: Created new ThreadLocal instance: %s)",
-    					Thread.currentThread(), threadLocalLoginContext));
-    		}
-    	}
+            logger.trace("Thread ID {}: Created new ThreadLocal instance: {})", Thread.currentThread(),
+                         threadLocalLoginContext);
+        }
 
     	LoginContext loginContext = threadLocalLoginContext.get();
 
@@ -287,11 +287,9 @@ public class SecurityInterceptor implements ContainerRequestFilter, ContainerRes
     		loginContext = Framework.loginAs(user);
     		frameworkLogins++;
     		threadLocalLoginContext.set(loginContext);
-    		if (logger.isTraceEnabled() == true) {
-	        	logger.trace(String.format("Thread ID %s: Logged in with ThreadLocal instance %s - %s ",
-	        			Thread.currentThread(), threadLocalLoginContext, threadLocalLoginContext.get()));
-    		}
-        	//
+            logger.trace("Thread ID {}: Logged in with ThreadLocal instance {} - {} ", Thread.currentThread(),
+                         threadLocalLoginContext, threadLocalLoginContext.get());
+            //
         	// Debug logging
         	//
    			logLoginContext(loginContext);
@@ -302,8 +300,8 @@ public class SecurityInterceptor implements ContainerRequestFilter, ContainerRes
     		// use the Nuxeo default "system admin" context for ever request, regardless of the CollectionSpace user making
     		// the request.  In short, there's no real security vulnerability here -just bad bookkeeping of logins.
     		//
-    		logger.warn(String.format(String.format("Thread ID %s: Alreadyed logged in with ThreadLocal instance %s - %s ",
-	        			Thread.currentThread(), threadLocalLoginContext, threadLocalLoginContext.get())));
+    		logger.warn("Thread ID {}: Already logged in with ThreadLocal instance {} - {} ", Thread.currentThread(),
+                        threadLocalLoginContext, threadLocalLoginContext.get());
     		frameworkLogins++;
     	}
     }
@@ -313,12 +311,10 @@ public class SecurityInterceptor implements ContainerRequestFilter, ContainerRes
         if (loginContext != null) {
    			logLogoutContext(loginContext);
             loginContext.logout();
-            threadLocalLoginContext.set(null); // We need to clear the login context from this thread, so the next request on this thread has to login again.
+            threadLocalLoginContext.remove(); // We need to clear the login context from this thread, so the next request on this thread has to login again.
             logLogoutContext(null);
             frameworkLogins--;
-            if (logger.isTraceEnabled()) {
-            	String.format("Framework logins: ", frameworkLogins);
-            }
+            logger.trace("Framework logins: {}", frameworkLogins);
         } else {
         	if (frameworkLogins > 0) {
         		logger.warn(ERROR_NUXEO_LOGOUT);  // If we get here, it means our login/logout bookkeeping has failed.
@@ -327,29 +323,16 @@ public class SecurityInterceptor implements ContainerRequestFilter, ContainerRes
 
         if (frameworkLogins == 0) {
         	if (threadLocalLoginContext != null) {
-	        	logger.trace(String.format("Thread ID %s: Clearing ThreadLocal instance %s - %s ",
-	        			Thread.currentThread(), threadLocalLoginContext, threadLocalLoginContext.get()));
+	        	logger.trace("Thread ID {}: Clearing ThreadLocal instance {} - {} ", Thread.currentThread(),
+                             threadLocalLoginContext, threadLocalLoginContext.get());
         	}
         	threadLocalLoginContext = null; //Clear the ThreadLocal to void Tomcat warnings associated with thread pools.
         }
     }
 
-	/* (non-Javadoc)
-	 * @see org.jboss.resteasy.spi.interception.PreProcessInterceptor#preProcess(org.jboss.resteasy.spi.HttpRequest, org.jboss.resteasy.core.ResourceMethod)
-	@Override
-	public ServerResponse preProcess(HttpRequest request, ResourceMethodInvoker resourceMethodInvoker)
-			throws Failure, CSWebApplicationException {
-	}
-
-	@Override
-	public void postProcess(ServerResponse arg0) {
-	}
-	*/
-
 	@Override
 	public void filter(ContainerRequestContext containerRequestContext) throws IOException {
 		Request request = containerRequestContext.getRequest();
-		// Method resourceMethod = resourceMethodInvoker.getMethod();
 
         try {
             if (isAnonymousRequest(containerRequestContext)) {

--- a/services/common/src/main/java/org/collectionspace/services/common/security/SecurityInterceptor.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/security/SecurityInterceptor.java
@@ -27,25 +27,24 @@
  */
 package org.collectionspace.services.common.security;
 
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.security.Principal;
 import java.util.HashMap;
 import java.util.Set;
 
-import org.jboss.resteasy.core.ResourceMethodInvoker;
-import org.jboss.resteasy.core.ServerResponse;
-import org.jboss.resteasy.spi.interception.PostProcessInterceptor;
-import org.jboss.resteasy.spi.interception.PreProcessInterceptor;
-import org.jboss.resteasy.annotations.interception.SecurityPrecedence;
-import org.jboss.resteasy.annotations.interception.ServerInterceptor;
 import org.jboss.resteasy.spi.Failure;
-import org.jboss.resteasy.spi.HttpRequest;
 import org.nuxeo.runtime.api.Framework;
 
 import javax.security.auth.Subject;
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
 
@@ -56,7 +55,6 @@ import org.collectionspace.services.authorization.URIResourceImpl;
 import org.collectionspace.services.client.index.IndexClient;
 import org.collectionspace.services.client.workflow.WorkflowClient;
 import org.collectionspace.services.common.CSWebApplicationException;
-import org.collectionspace.services.common.CollectionSpaceResource;
 import org.collectionspace.services.common.ServiceMain;
 import org.collectionspace.services.common.document.JaxbUtils;
 import org.collectionspace.services.common.storage.jpa.JpaStorageUtils;
@@ -71,10 +69,8 @@ import org.slf4j.LoggerFactory;
  * RESTeasy interceptor for access control
  * @version $Revision: 1 $
  */
-@SecurityPrecedence
-@ServerInterceptor
 @Provider
-public class SecurityInterceptor implements PreProcessInterceptor, PostProcessInterceptor {
+public class SecurityInterceptor implements ContainerRequestFilter, ContainerResponseFilter {
 
 	static {
 		System.err.println("Static initialization of: " + SecurityInterceptor.class.getCanonicalName());
@@ -98,20 +94,21 @@ public class SecurityInterceptor implements PreProcessInterceptor, PostProcessIn
     private static final String ERROR_NUXEO_LOGOUT = "Attempt to logout when Nuxeo login context was null.";
     private static final String ERROR_UNBALANCED_LOGINS = "The number of Logins vs Logouts to the Nuxeo framework was unbalanced.";
 
-    private boolean isAnonymousRequest(HttpRequest request, ResourceMethodInvoker resourceMethodInvoker) { // see C:\dev\src\cspace\services\services\JaxRsServiceProvider\src\main\webapp\WEB-INF\applicationContext-security.xml
+    private boolean isAnonymousRequest(ContainerRequestContext requestContext) {
     	boolean result = false;
 
-		String resName = SecurityUtils.getResourceName(request.getUri()).toLowerCase();
-		switch (resName) {
-			case AuthZ.PASSWORD_RESET:
-			case AuthZ.PROCESS_PASSWORD_RESET:
-			case LOGIN:
-			case LOGOUT:
-			case SYSTEM_INFO:
-			case "":
-				return true;
-		}
+		String resName = SecurityUtils.getResourceName(requestContext.getUriInfo()).toLowerCase();
+        if (resName.equals(AuthZ.PASSWORD_RESET)
+            || resName.equals(AuthZ.PROCESS_PASSWORD_RESET)
+            || resName.equals(LOGIN)
+            || resName.equals(LOGOUT)
+            || resName.equals(SYSTEM_INFO)
+            || resName.isEmpty()) {
+            return true;
+        }
 
+		/*
+		 * Todo: Figure out the condition which this returns true (only publicItem overrides allowAnonymousAccess)
 		Class<?> resourceClass = resourceMethodInvoker.getResourceClass();
 		try {
 			CollectionSpaceResource resourceInstance = (CollectionSpaceResource)resourceClass.newInstance();
@@ -121,162 +118,34 @@ public class SecurityInterceptor implements PreProcessInterceptor, PostProcessIn
 		} catch (IllegalAccessException e) {
 			logger.error("isAnonymousRequest: ", e);
 		}
+		 */
 
     	return result;
     }
 
-		/*
-			* Check to see if the resource required authorization to access
-			*
-			*/
-		private boolean requiresAuthorization(String resName) {
-			boolean result = true;
-			//
-			// ACCOUNT_PERMISSIONS, ACCOUNT_ROLES: All active users are allowed to see the *their*
-			// (we enforce this) current list of permissions and roles.  If this is not the request, then
-			// we'll do a full AuthZ check.
-			//
-			// STRUCTURED_DATE_REQUEST: All user can request the parsing of a structured date string.
-			//
-			switch (resName) {
-				case AuthZ.STRUCTURED_DATE_REQUEST:
-				case AuthZ.ACCOUNT_PERMISSIONS:
-				case AuthZ.ACCOUNT_ROLES:
-				case AuthZ.REPORTS_MIME_OUTPUTS:
-					result = false;
-					break;
-				default:
-					result = true;
-			}
-
-			return result;
-		}
-
-	/* (non-Javadoc)
-	 * @see org.jboss.resteasy.spi.interception.PreProcessInterceptor#preProcess(org.jboss.resteasy.spi.HttpRequest, org.jboss.resteasy.core.ResourceMethod)
+	/*
+	 * Check to see if the resource required authorization to access
+	 *
 	 */
-	@Override
-	public ServerResponse preProcess(HttpRequest request, ResourceMethodInvoker resourceMethodInvoker)
-			throws Failure, CSWebApplicationException {
+	private boolean requiresAuthorization(String resName) {
+		boolean result = true;
+		//
+		// ACCOUNT_PERMISSIONS, ACCOUNT_ROLES: All active users are allowed to see the *their*
+		// (we enforce this) current list of permissions and roles.  If this is not the request, then
+		// we'll do a full AuthZ check.
+		//
+		// STRUCTURED_DATE_REQUEST: All user can request the parsing of a structured date string.
+		//
+        if (resName.equals(AuthZ.STRUCTURED_DATE_REQUEST)
+			|| resName.equals(AuthZ.ACCOUNT_PERMISSIONS)
+			|| resName.equals(AuthZ.ACCOUNT_ROLES)
+			|| resName.equals(AuthZ.REPORTS_MIME_OUTPUTS)) {
+            result = false;
+        }
 
-		ServerResponse result = null; // A null value essentially means success for this method
-		Method resourceMethod = resourceMethodInvoker.getMethod();
-
-		try {
-			if (isAnonymousRequest(request, resourceMethodInvoker) == true) {
-				// We don't need to check credentials for anonymous requests.  Just login to Nuxeo and
-				// exit
-				nuxeoPreProcess(request, resourceMethodInvoker); // We login to Nuxeo only after we've checked authorization
-
-				return result;
-			}
-
-			final String servicesResource = "/cspace-services/"; // HACK - this is configured in war, get this from tomcat instead
-			final int servicesResourceLen = servicesResource.length();
-			String httpMethod = request.getHttpMethod();
-			String uriPath = request.getUri().getPath();
-
-			if (logger.isDebugEnabled()) {
-				String fullRequest = request.getUri().getRequestUri().toString();
-				int servicesResourceIdx = fullRequest.indexOf(servicesResource);
-				String relativeRequest = (servicesResourceIdx<=0)? fullRequest
-													: fullRequest.substring(servicesResourceIdx+servicesResourceLen);
-				logger.debug("received " + httpMethod + " on " + relativeRequest);
-			}
-
-			String resName = SecurityUtils.getResourceName(request.getUri());
-			String resEntity = SecurityUtils.getResourceEntity(resName);
-
-			//
-			// If the resource entity is acting as a proxy then all sub-resources will map to the resource itself.
-			// This essentially means sub-resources inherit all the authz permissions of the entity.
-			//
-			if (SecurityUtils.isResourceProxied(resName) == true) {
-				resName = resEntity;
-			} else {
-				//
-				// If our resName is not proxied, we may need to tweak it.
-				//
-				switch (resName) {
-					case AuthZ.REPORTS_INVOKE:
-					case AuthZ.BATCH_INVOKE: {
-						resName = resName.replace("/*/", "/");
-					}
-				}
-			}
-			//
-			// Make sure the account of the user making the request is current and active
-			//
-			checkActive();
-
-			if (requiresAuthorization(resName) == true) { //see comment immediately above
-				AuthZ authZ = AuthZ.get();
-				CSpaceResource res = new URIResourceImpl(AuthN.get().getCurrentTenantId(), resName, httpMethod);
-				if (authZ.isAccessAllowed(res) == false) {
-						logger.error("Access to " + res.getId() + " is NOT allowed to "
-								+ " user=" + AuthN.get().getUserId());
-						Response response = Response.status(
-								Response.Status.FORBIDDEN).entity(uriPath + " " + httpMethod).type("text/plain").build();
-						throw new CSWebApplicationException(response);
-				} else {
-					//
-					// They passed the first round of security checks, so now let's check to see if they're trying
-					// to perform a workflow state change or fulltext reindex and make sure they are allowed to to this.
-					//
-					if (uriPath.contains(WorkflowClient.SERVICE_PATH) == true) {
-						String workflowProxyResource = SecurityUtils.getWorkflowResourceName(request);
-						res = new URIResourceImpl(AuthN.get().getCurrentTenantId(), workflowProxyResource, httpMethod);
-						if (authZ.isAccessAllowed(res) == false) {
-							logger.error("Access to " + resName + ":" + res.getId() + " is NOT allowed to "
-									+ " user=" + AuthN.get().getUserId());
-							Response response = Response.status(
-									Response.Status.FORBIDDEN).entity(uriPath + " " + httpMethod).type("text/plain").build();
-							throw new CSWebApplicationException(response);
-						}
-					} else 	if (uriPath.contains(IndexClient.SERVICE_PATH) == true) {
-						String indexProxyResource = SecurityUtils.getIndexResourceName(request);
-						res = new URIResourceImpl(AuthN.get().getCurrentTenantId(), indexProxyResource, httpMethod);
-						if (authZ.isAccessAllowed(res) == false) {
-							logger.error("Access to " + resName + ":" + res.getId() + " is NOT allowed to "
-									+ " user=" + AuthN.get().getUserId());
-							Response response = Response.status(
-									Response.Status.FORBIDDEN).entity(uriPath + " " + httpMethod).type("text/plain").build();
-							throw new CSWebApplicationException(response);
-						}
-					}
-
-				}
-				//
-				// Login to Nuxeo
-				//
-				nuxeoPreProcess(request, resourceMethodInvoker); // We login to Nuxeo only after we've checked authorization
-
-				//
-				// We've passed all the checks.  Now just log the results
-				//
-				if (logger.isTraceEnabled()) {
-					logger.trace("Access to " + res.getId() + " is allowed to " +
-							" user=" + AuthN.get().getUserId() +
-							" for tenant id=" + AuthN.get().getCurrentTenantName());
-				}
-			}
-		} catch (Throwable t) {
-			if (logger.isTraceEnabled() == true) {
-				t.printStackTrace();
-			}
-			throw t;
-		}
-
-		return result;
+        return result;
 	}
 
-	@Override
-	public void postProcess(ServerResponse arg0) {
-		//
-		// Log out of the Nuxeo framework
-		//
-		nuxeoPostProcess(arg0);
-	}
 
 	/**
 	 * checkActive check if account is active
@@ -344,27 +213,24 @@ public class SecurityInterceptor implements PreProcessInterceptor, PostProcessIn
 	//
 	// Nuxeo login support
 	//
-	public ServerResponse nuxeoPreProcess(HttpRequest request, ResourceMethodInvoker resourceMethodInvoker)
-			throws Failure, CSWebApplicationException {
+	public void nuxeoPreProcess() throws Failure, CSWebApplicationException {
 		try {
 			nuxeoLogin(NUXEO_ADMIN);
 		} catch (LoginException e) {
 			String msg = "Unable to login to the Nuxeo framework";
 			logger.error(msg, e);
-			Response response = Response.status(
-					Response.Status.INTERNAL_SERVER_ERROR).entity(msg).type("text/plain").build();
+			Response response = Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+										.entity(msg)
+										.type(MediaType.TEXT_PLAIN).build();
 			throw new CSWebApplicationException(e, response);
 		}
-
-		return null;
 	}
 
-	public void nuxeoPostProcess(ServerResponse arg0) {
+	public void nuxeoPostProcess() {
 		try {
 			nuxeoLogout();
 		} catch (LoginException e) {
-			String msg = "Unable to logout of the Nuxeo framework.";
-			logger.error(msg, e);
+			logger.error("Unable to logout of the Nuxeo framework.", e);
 		}
 	}
 
@@ -466,4 +332,129 @@ public class SecurityInterceptor implements PreProcessInterceptor, PostProcessIn
         	threadLocalLoginContext = null; //Clear the ThreadLocal to void Tomcat warnings associated with thread pools.
         }
     }
+
+	/* (non-Javadoc)
+	 * @see org.jboss.resteasy.spi.interception.PreProcessInterceptor#preProcess(org.jboss.resteasy.spi.HttpRequest, org.jboss.resteasy.core.ResourceMethod)
+	@Override
+	public ServerResponse preProcess(HttpRequest request, ResourceMethodInvoker resourceMethodInvoker)
+			throws Failure, CSWebApplicationException {
+	}
+
+	@Override
+	public void postProcess(ServerResponse arg0) {
+	}
+	*/
+
+	@Override
+	public void filter(ContainerRequestContext containerRequestContext) throws IOException {
+		Request request = containerRequestContext.getRequest();
+		// Method resourceMethod = resourceMethodInvoker.getMethod();
+
+        try {
+            if (isAnonymousRequest(containerRequestContext)) {
+                // We don't need to check credentials for anonymous requests.  Just login to Nuxeo and exit
+                nuxeoPreProcess();
+				return;
+            }
+
+			// HACK - this is configured in war, get this from tomcat instead
+            final String servicesResource = "/cspace-services/";
+            final int servicesResourceLen = servicesResource.length();
+            String httpMethod = request.getMethod();
+            String uriPath = containerRequestContext.getUriInfo().getPath();
+
+            if (logger.isDebugEnabled()) {
+                int servicesResourceIdx = uriPath.indexOf(servicesResource);
+                String relativeRequest =
+					(servicesResourceIdx <= 0) ? uriPath : uriPath.substring(servicesResourceIdx + servicesResourceLen);
+                logger.debug("received {}s on {}", httpMethod, relativeRequest);
+            }
+
+            String resName = SecurityUtils.getResourceName(containerRequestContext.getUriInfo());
+            String resEntity = SecurityUtils.getResourceEntity(resName);
+
+            //
+            // If the resource entity is acting as a proxy then all sub-resources will map to the resource itself.
+            // This essentially means sub-resources inherit all the authz permissions of the entity.
+            //
+            if (SecurityUtils.isResourceProxied(resName)) {
+                resName = resEntity;
+            } else {
+                //
+                // If our resName is not proxied, we may need to tweak it.
+                //
+                if (resName.equals(AuthZ.REPORTS_INVOKE) || resName.equals(AuthZ.BATCH_INVOKE)) {
+                    resName = resName.replace("/*/", "/");
+                }
+            }
+            //
+            // Make sure the account of the user making the request is current and active
+            //
+            checkActive();
+
+            if (requiresAuthorization(resName)) { //see comment immediately above
+                AuthZ authZ = AuthZ.get();
+                CSpaceResource res = new URIResourceImpl(AuthN.get().getCurrentTenantId(), resName, httpMethod);
+                if (!authZ.isAccessAllowed(res)) {
+                    logger.error("Access to {} is NOT allowed to  user={}", res.getId(), AuthN.get().getUserId());
+                    Response response = Response.status(Response.Status.FORBIDDEN)
+                                                .entity(uriPath + " " + httpMethod)
+                                                .type("text/plain").build();
+                    throw new CSWebApplicationException(response);
+                } else {
+                    //
+                    // They passed the first round of security checks, so now let's check to see if they're trying
+                    // to perform a workflow state change or fulltext reindex and make sure they are allowed to this.
+                    //
+                    if (uriPath.contains(WorkflowClient.SERVICE_PATH)) {
+                        String workflowProxyResource = SecurityUtils.getWorkflowResourceName(containerRequestContext);
+                        res = new URIResourceImpl(AuthN.get().getCurrentTenantId(), workflowProxyResource, httpMethod);
+                        if (!authZ.isAccessAllowed(res)) {
+                            logger.error("Access to {}:{} is NOT allowed to  user={}", resName, res.getId(),
+                                         AuthN.get().getUserId());
+                            Response response = Response.status(Response.Status.FORBIDDEN)
+                                                        .entity(uriPath + " " + httpMethod)
+                                                        .type("text/plain").build();
+                            throw new CSWebApplicationException(response);
+                        }
+                    } else if (uriPath.contains(IndexClient.SERVICE_PATH)) {
+                        String indexProxyResource = SecurityUtils.getIndexResourceName();
+                        res = new URIResourceImpl(AuthN.get().getCurrentTenantId(), indexProxyResource, httpMethod);
+                        if (!authZ.isAccessAllowed(res)) {
+                            logger.error("Access to {}:{} is NOT allowed to  user={}", resName, res.getId(),
+                                         AuthN.get().getUserId());
+                            Response response = Response.status(Response.Status.FORBIDDEN)
+                                                        .entity(uriPath + " " + httpMethod)
+                                                        .type("text/plain").build();
+                            throw new CSWebApplicationException(response);
+                        }
+                    }
+
+                }
+                //
+                // Login to Nuxeo
+                //
+                nuxeoPreProcess();
+
+                //
+                // We've passed all the checks.  Now just log the results
+                //
+                logger.trace("Access to {} is allowed to  user={} for tenant id={}", res.getId(),
+                             AuthN.get().getUserId(),
+                             AuthN.get().getCurrentTenantName());
+            }
+        } catch (RuntimeException t) {
+            logger.error("Error in SecurityInterceptor", t);
+            throw t;
+        }
+	}
+
+	@Override
+	public void filter(ContainerRequestContext containerRequestContext,
+					   ContainerResponseContext containerResponseContext) throws IOException {
+		//
+		// Log out of the Nuxeo framework
+		//
+		nuxeoPostProcess();
+	}
 }

--- a/services/common/src/main/java/org/collectionspace/services/common/security/SecurityInterceptor.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/security/SecurityInterceptor.java
@@ -270,8 +270,9 @@ public class SecurityInterceptor implements ContainerRequestFilter, ContainerRes
 			if (tenantDisabled) {
 				String errMsg = String.format("The user %s's tenant '%s' is disabled.  Contact your CollectionSpace administrator.",
 						userId, tenantBindingType.getDisplayName());
-				Response response = Response.status(
-						Response.Status.CONFLICT).entity(errMsg).type("text/plain").build();
+				Response response = Response.status(Response.Status.CONFLICT)
+											.entity(errMsg)
+											.type(MediaType.TEXT_PLAIN_TYPE).build();
 				throw new CSWebApplicationException(response);
 			}
 		} catch (IllegalStateException ise) {
@@ -279,8 +280,9 @@ public class SecurityInterceptor implements ContainerRequestFilter, ContainerRes
 			// Note the RFC on return types:
 			// If the request already included Authorization credentials, then the 401 response
 			// indicates that authorization has been refused for those credentials.
-			Response response = Response.status(
-					Response.Status.UNAUTHORIZED).entity(errMsg).type("text/plain").build();
+			Response response = Response.status(Response.Status.UNAUTHORIZED)
+										.entity(errMsg)
+										.type(MediaType.TEXT_PLAIN_TYPE).build();
 			throw new CSWebApplicationException(ise, response);
 		}
 
@@ -295,8 +297,9 @@ public class SecurityInterceptor implements ContainerRequestFilter, ContainerRes
 					"org.collectionspace.services.account.AccountsCommon", whereClause, params);
 			if (account == null) {
 				String msg = "User's account not found, userId=" + userId;
-				Response response = Response.status(
-						Response.Status.FORBIDDEN).entity(msg).type("text/plain").build();
+				Response response = Response.status(Response.Status.FORBIDDEN)
+											.entity(msg)
+											.type(MediaType.TEXT_PLAIN_TYPE).build();
 				throw new CSWebApplicationException(response);
 			}
 			Object status = JaxbUtils.getValue(account, "getStatus");
@@ -304,16 +307,18 @@ public class SecurityInterceptor implements ContainerRequestFilter, ContainerRes
 				String value = (String) JaxbUtils.getValue(status, "value");
 				if ("INACTIVE".equalsIgnoreCase(value)) {
 					String msg = "User's account is inactive, userId=" + userId;
-					Response response = Response.status(
-							Response.Status.FORBIDDEN).entity(msg).type("text/plain").build();
+					Response response = Response.status(Response.Status.FORBIDDEN)
+												.entity(msg)
+												.type(MediaType.TEXT_PLAIN_TYPE).build();
 					throw new CSWebApplicationException(response);
 				}
 			}
 		}
 		catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
 			String msg = "User's account is in invalid state, userId=" + userId;
-			Response response = Response.status(
-					Response.Status.FORBIDDEN).entity(msg).type("text/plain").build();
+			Response response = Response.status(Response.Status.FORBIDDEN)
+										.entity(msg)
+										.type(MediaType.TEXT_PLAIN_TYPE).build();
 			throw new CSWebApplicationException(e, response);
 		}
 	}

--- a/services/common/src/main/java/org/collectionspace/services/common/security/SecurityInterceptor.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/security/SecurityInterceptor.java
@@ -147,6 +147,117 @@ public class SecurityInterceptor implements ContainerRequestFilter, ContainerRes
         return result;
 	}
 
+	@Override
+	public void filter(ContainerRequestContext containerRequestContext) throws IOException {
+		Request request = containerRequestContext.getRequest();
+
+		try {
+			if (isAnonymousRequest(containerRequestContext)) {
+				// We don't need to check credentials for anonymous requests.  Just login to Nuxeo and exit
+				nuxeoPreProcess();
+				return;
+			}
+
+			// HACK - this is configured in war, get this from tomcat instead
+			final String servicesResource = "/cspace-services/";
+			final int servicesResourceLen = servicesResource.length();
+			String httpMethod = request.getMethod();
+			String uriPath = containerRequestContext.getUriInfo().getPath();
+
+			if (logger.isDebugEnabled()) {
+				int servicesResourceIdx = uriPath.indexOf(servicesResource);
+				String relativeRequest =
+					(servicesResourceIdx <= 0) ? uriPath : uriPath.substring(servicesResourceIdx + servicesResourceLen);
+				logger.debug("received {}s on {}", httpMethod, relativeRequest);
+			}
+
+			String resName = SecurityUtils.getResourceName(containerRequestContext.getUriInfo());
+			String resEntity = SecurityUtils.getResourceEntity(resName);
+
+			//
+			// If the resource entity is acting as a proxy then all sub-resources will map to the resource itself.
+			// This essentially means sub-resources inherit all the authz permissions of the entity.
+			//
+			if (SecurityUtils.isResourceProxied(resName)) {
+				resName = resEntity;
+			} else {
+				//
+				// If our resName is not proxied, we may need to tweak it.
+				//
+				if (resName.equals(AuthZ.REPORTS_INVOKE) || resName.equals(AuthZ.BATCH_INVOKE)) {
+					resName = resName.replace("/*/", "/");
+				}
+			}
+			//
+			// Make sure the account of the user making the request is current and active
+			//
+			checkActive();
+
+			if (requiresAuthorization(resName)) { //see comment immediately above
+				AuthZ authZ = AuthZ.get();
+				CSpaceResource res = new URIResourceImpl(AuthN.get().getCurrentTenantId(), resName, httpMethod);
+				if (!authZ.isAccessAllowed(res)) {
+					logger.error("Access to {} is NOT allowed to  user={}", res.getId(), AuthN.get().getUserId());
+					Response response = Response.status(Response.Status.FORBIDDEN)
+												.entity(uriPath + " " + httpMethod)
+												.type("text/plain").build();
+					throw new CSWebApplicationException(response);
+				} else {
+					//
+					// They passed the first round of security checks, so now let's check to see if they're trying
+					// to perform a workflow state change or fulltext reindex and make sure they are allowed to this.
+					//
+					if (uriPath.contains(WorkflowClient.SERVICE_PATH)) {
+						String workflowProxyResource = SecurityUtils.getWorkflowResourceName(containerRequestContext);
+						res = new URIResourceImpl(AuthN.get().getCurrentTenantId(), workflowProxyResource, httpMethod);
+						if (!authZ.isAccessAllowed(res)) {
+							logger.error("Access to {}:{} is NOT allowed to  user={}", resName, res.getId(),
+										 AuthN.get().getUserId());
+							Response response = Response.status(Response.Status.FORBIDDEN)
+														.entity(uriPath + " " + httpMethod)
+														.type("text/plain").build();
+							throw new CSWebApplicationException(response);
+						}
+					} else if (uriPath.contains(IndexClient.SERVICE_PATH)) {
+						String indexProxyResource = SecurityUtils.getIndexResourceName();
+						res = new URIResourceImpl(AuthN.get().getCurrentTenantId(), indexProxyResource, httpMethod);
+						if (!authZ.isAccessAllowed(res)) {
+							logger.error("Access to {}:{} is NOT allowed to  user={}", resName, res.getId(),
+										 AuthN.get().getUserId());
+							Response response = Response.status(Response.Status.FORBIDDEN)
+														.entity(uriPath + " " + httpMethod)
+														.type("text/plain").build();
+							throw new CSWebApplicationException(response);
+						}
+					}
+
+				}
+				//
+				// Login to Nuxeo
+				//
+				nuxeoPreProcess();
+
+				//
+				// We've passed all the checks.  Now just log the results
+				//
+				logger.trace("Access to {} is allowed to  user={} for tenant id={}", res.getId(),
+							 AuthN.get().getUserId(),
+							 AuthN.get().getCurrentTenantName());
+			}
+		} catch (RuntimeException t) {
+			logger.error("Error in SecurityInterceptor", t);
+			throw t;
+		}
+	}
+
+	@Override
+	public void filter(ContainerRequestContext containerRequestContext,
+					   ContainerResponseContext containerResponseContext) throws IOException {
+		//
+		// Log out of the Nuxeo framework
+		//
+		nuxeoPostProcess();
+	}
 
 	/**
 	 * checkActive check if account is active
@@ -330,115 +441,4 @@ public class SecurityInterceptor implements ContainerRequestFilter, ContainerRes
         }
     }
 
-	@Override
-	public void filter(ContainerRequestContext containerRequestContext) throws IOException {
-		Request request = containerRequestContext.getRequest();
-
-        try {
-            if (isAnonymousRequest(containerRequestContext)) {
-                // We don't need to check credentials for anonymous requests.  Just login to Nuxeo and exit
-                nuxeoPreProcess();
-				return;
-            }
-
-			// HACK - this is configured in war, get this from tomcat instead
-            final String servicesResource = "/cspace-services/";
-            final int servicesResourceLen = servicesResource.length();
-            String httpMethod = request.getMethod();
-            String uriPath = containerRequestContext.getUriInfo().getPath();
-
-            if (logger.isDebugEnabled()) {
-                int servicesResourceIdx = uriPath.indexOf(servicesResource);
-                String relativeRequest =
-					(servicesResourceIdx <= 0) ? uriPath : uriPath.substring(servicesResourceIdx + servicesResourceLen);
-                logger.debug("received {}s on {}", httpMethod, relativeRequest);
-            }
-
-            String resName = SecurityUtils.getResourceName(containerRequestContext.getUriInfo());
-            String resEntity = SecurityUtils.getResourceEntity(resName);
-
-            //
-            // If the resource entity is acting as a proxy then all sub-resources will map to the resource itself.
-            // This essentially means sub-resources inherit all the authz permissions of the entity.
-            //
-            if (SecurityUtils.isResourceProxied(resName)) {
-                resName = resEntity;
-            } else {
-                //
-                // If our resName is not proxied, we may need to tweak it.
-                //
-                if (resName.equals(AuthZ.REPORTS_INVOKE) || resName.equals(AuthZ.BATCH_INVOKE)) {
-                    resName = resName.replace("/*/", "/");
-                }
-            }
-            //
-            // Make sure the account of the user making the request is current and active
-            //
-            checkActive();
-
-            if (requiresAuthorization(resName)) { //see comment immediately above
-                AuthZ authZ = AuthZ.get();
-                CSpaceResource res = new URIResourceImpl(AuthN.get().getCurrentTenantId(), resName, httpMethod);
-                if (!authZ.isAccessAllowed(res)) {
-                    logger.error("Access to {} is NOT allowed to  user={}", res.getId(), AuthN.get().getUserId());
-                    Response response = Response.status(Response.Status.FORBIDDEN)
-                                                .entity(uriPath + " " + httpMethod)
-                                                .type("text/plain").build();
-                    throw new CSWebApplicationException(response);
-                } else {
-                    //
-                    // They passed the first round of security checks, so now let's check to see if they're trying
-                    // to perform a workflow state change or fulltext reindex and make sure they are allowed to this.
-                    //
-                    if (uriPath.contains(WorkflowClient.SERVICE_PATH)) {
-                        String workflowProxyResource = SecurityUtils.getWorkflowResourceName(containerRequestContext);
-                        res = new URIResourceImpl(AuthN.get().getCurrentTenantId(), workflowProxyResource, httpMethod);
-                        if (!authZ.isAccessAllowed(res)) {
-                            logger.error("Access to {}:{} is NOT allowed to  user={}", resName, res.getId(),
-                                         AuthN.get().getUserId());
-                            Response response = Response.status(Response.Status.FORBIDDEN)
-                                                        .entity(uriPath + " " + httpMethod)
-                                                        .type("text/plain").build();
-                            throw new CSWebApplicationException(response);
-                        }
-                    } else if (uriPath.contains(IndexClient.SERVICE_PATH)) {
-                        String indexProxyResource = SecurityUtils.getIndexResourceName();
-                        res = new URIResourceImpl(AuthN.get().getCurrentTenantId(), indexProxyResource, httpMethod);
-                        if (!authZ.isAccessAllowed(res)) {
-                            logger.error("Access to {}:{} is NOT allowed to  user={}", resName, res.getId(),
-                                         AuthN.get().getUserId());
-                            Response response = Response.status(Response.Status.FORBIDDEN)
-                                                        .entity(uriPath + " " + httpMethod)
-                                                        .type("text/plain").build();
-                            throw new CSWebApplicationException(response);
-                        }
-                    }
-
-                }
-                //
-                // Login to Nuxeo
-                //
-                nuxeoPreProcess();
-
-                //
-                // We've passed all the checks.  Now just log the results
-                //
-                logger.trace("Access to {} is allowed to  user={} for tenant id={}", res.getId(),
-                             AuthN.get().getUserId(),
-                             AuthN.get().getCurrentTenantName());
-            }
-        } catch (RuntimeException t) {
-            logger.error("Error in SecurityInterceptor", t);
-            throw t;
-        }
-	}
-
-	@Override
-	public void filter(ContainerRequestContext containerRequestContext,
-					   ContainerResponseContext containerResponseContext) throws IOException {
-		//
-		// Log out of the Nuxeo framework
-		//
-		nuxeoPostProcess();
-	}
 }

--- a/services/common/src/main/java/org/collectionspace/services/common/security/SecurityInterceptor.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/security/SecurityInterceptor.java
@@ -293,7 +293,7 @@ public class SecurityInterceptor implements ContainerRequestFilter, ContainerRes
 			//can't use JAXB here as this runs from the common jar which cannot
 			//depend upon the account service
 			String whereClause = "where userId = :userId";
-			HashMap<String, Object> params = new HashMap<String, Object>();
+			HashMap<String, Object> params = new HashMap<>();
 			params.put("userId", userId);
 
 			Object account = JpaStorageUtils.getEntity(
@@ -387,7 +387,7 @@ public class SecurityInterceptor implements ContainerRequestFilter, ContainerRes
     	// Use a ThreadLocal instance to keep track of the Nuxeo login context
     	//
     	if (threadLocalLoginContext == null) {
-    		threadLocalLoginContext = new ThreadLocal<LoginContext>();
+    		threadLocalLoginContext = new ThreadLocal<>();
             logger.trace("Thread ID {}: Created new ThreadLocal instance: {})", Thread.currentThread(),
                          threadLocalLoginContext);
         }

--- a/services/common/src/main/java/org/collectionspace/services/common/security/SecurityUtils.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/security/SecurityUtils.java
@@ -43,6 +43,7 @@ import org.collectionspace.services.config.service.ServiceBindingType;
 import org.collectionspace.authentication.AuthN;
 import org.collectionspace.authentication.spring.CSpacePasswordEncoderFactory;
 
+import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
 
@@ -50,7 +51,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.jboss.resteasy.spi.HttpRequest;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.core.xml.schema.XSAny;
 import org.opensaml.core.xml.schema.XSString;
@@ -132,10 +132,10 @@ public class SecurityUtils {
         }
     }
 
-    public static String getWorkflowResourceName(HttpRequest request) {
+    public static String getWorkflowResourceName(ContainerRequestContext requestContext) {
     	String result = null;
 
-    	UriInfo uriInfo = request.getUri();
+    	UriInfo uriInfo = requestContext.getUriInfo();
     	String workflowSubResName = SecurityUtils.getResourceName(uriInfo);
     	String resEntity = SecurityUtils.getResourceEntity(workflowSubResName);
 
@@ -151,35 +151,14 @@ public class SecurityUtils {
     	return result;
     }
 
-    public static String getIndexResourceName(HttpRequest request) {
-    	String result = null;
-
-    	UriInfo uriInfo = request.getUri();
-    	String indexSubResName = SecurityUtils.getResourceName(uriInfo);
-    	String resEntity = SecurityUtils.getResourceEntity(indexSubResName);
-
-		MultivaluedMap<String, String> pathParams = uriInfo.getPathParameters();
-		String indexId = pathParams.getFirst(IndexClient.INDEX_ID_PARAM);
-		if (indexId != null  && pathParams.containsKey("csid")) {
-			// e.g., intakes/*/index/fulltext
-	    	result = resEntity + "/*/" + IndexClient.SERVICE_NAME + "/" + indexId;
-		} else if (indexId != null) {
-			// e.g., intakes/index/fulltext
-	    	result = resEntity + "/" + IndexClient.SERVICE_NAME + "/" + indexId;
-		} else {
-			// e.g., intakes
-			result = resEntity;
-		}
-
-		//
+    public static String getIndexResourceName() {
+        //
 		// Overriding the result from above.
 		//
 		// Until we build out more permissions for the index resource,
 		// we're just going to return the index resource name.
 		//
-		result = IndexClient.SERVICE_NAME;
-
-    	return result;
+        return IndexClient.SERVICE_NAME;
     }
 
 	/**


### PR DESCRIPTION
**What does this do?**
* Migrate SecurityInterceptor to Container{Request,Response}Filter 
* Remove parameters from allowAnonymousAccess
* Misc cleanup, e.g. parameterized logging, pointless booleans, etc

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-2092

This is required for the upgrade process, but is something which is possible without changing any dependencies so it makes sense to do it separate and get some extra testing. Fairly straightforward change going from PreProcessInterceptor to ContainerRequestFilter and PostProcess to Response.

**How should this be tested? Do these changes have associated tests?**
* Rebuild collectionspace
* Verify that any API call which requires a nuxeo login still works, e.g. advancedsearch

**Dependencies for merging? Releasing to production?**
I actually noticed the behavior for this interceptor is a little... odd. As in it appears to be running multiple times per request (I'm not sure if it's after every filter or something else). I verified this is not a result of the changes and I believe the unbalanced login message points to this being a thing for some time. Perhaps during the RESTEasy update I'll have a chance to look at it further.

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@mikejritter has been testing locally
