### PR TITLE
DRYD-2094: Replace ClientResponse with Response

### DIFF
--- a/services/account/client/pom.xml
+++ b/services/account/client/pom.xml
@@ -76,34 +76,26 @@
         <finalName>cspace-services-account-client</finalName>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>subs-hibernate-config</id>
-                        <phase>generate-test-resources</phase>
+                        <phase>process-test-resources</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <property name="runtime-classpath" refid="maven.runtime.classpath"/>
                                 <ant target="setup_hibernate.cfg" inheritRefs="true"/>
-                            </tasks>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
         </plugins>
-		<filters>
-			<filter>../../../build.properties</filter>
-		</filters>
-		<resources>
-			<resource>
-				<directory>src/main/resources</directory>
-				<filtering>true</filtering>
-			</resource>
-		</resources>
-
     </build>
 
 </project>

--- a/services/citation/client/src/main/java/org/collectionspace/services/client/CitationAuthorityClientUtils.java
+++ b/services/citation/client/src/main/java/org/collectionspace/services/client/CitationAuthorityClientUtils.java
@@ -22,7 +22,6 @@ import org.collectionspace.services.client.test.ServiceRequestType;
 import org.collectionspace.services.common.api.Tools;
 
 import org.dom4j.DocumentException;
-import org.jboss.resteasy.client.ClientResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/services/claim/client/src/main/java/org/collectionspace/services/client/ClaimProxy.java
+++ b/services/claim/client/src/main/java/org/collectionspace/services/client/ClaimProxy.java
@@ -24,15 +24,14 @@
 
 package org.collectionspace.services.client;
 
-import org.jboss.resteasy.client.ClientResponse;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
 
 import org.collectionspace.services.client.workflow.WorkflowClient;
-import org.collectionspace.services.jaxb.AbstractCommonList;
 
 /**
  * ClaimProxy.java
@@ -48,25 +47,25 @@ public interface ClaimProxy extends CollectionSpaceCommonListPoxProxy {
     // Sorted list
     @GET
     @Produces({"application/xml"})
-    ClientResponse<AbstractCommonList> readListSortedBy(
+    Response readListSortedBy(
         @QueryParam(IClientQueryParams.ORDER_BY_PARAM) String sortFieldName);
     
     @Override
 	@GET
     @Produces({"application/xml"})
-    ClientResponse<AbstractCommonList> readIncludeDeleted(
+    Response readIncludeDeleted(
             @QueryParam(WorkflowClient.WORKFLOW_QUERY_DELETED_QP) String includeDeleted);
 
     @Override
     @GET
     @Produces({"application/xml"})
-    ClientResponse<AbstractCommonList> keywordSearchIncludeDeleted(
+    Response keywordSearchIncludeDeleted(
     		@QueryParam(IQueryManager.SEARCH_TYPE_KEYWORDS_KW) String keywords,
             @QueryParam(WorkflowClient.WORKFLOW_QUERY_DELETED_QP) String includeDeleted);
 
     @GET
     @Produces({"application/xml"})
-    ClientResponse<AbstractCommonList> keywordSearchSortedBy(
+    Response keywordSearchSortedBy(
         @QueryParam(IQueryManager.SEARCH_TYPE_KEYWORDS_KW) String keywords,
         @QueryParam(IClientQueryParams.ORDER_BY_PARAM) String sortFieldName);
 }

--- a/services/client/src/main/java/org/collectionspace/services/client/CollectionSpaceCommonListPoxProxy.java
+++ b/services/client/src/main/java/org/collectionspace/services/client/CollectionSpaceCommonListPoxProxy.java
@@ -7,7 +7,6 @@ import javax.ws.rs.core.Response;
 
 import org.collectionspace.services.client.workflow.WorkflowClient;
 import org.collectionspace.services.jaxb.AbstractCommonList;
-import org.jboss.resteasy.client.ClientResponse;
 
 public interface CollectionSpaceCommonListPoxProxy extends CollectionSpacePoxProxy<AbstractCommonList> {
     @GET

--- a/services/client/src/main/java/org/collectionspace/services/client/CollectionSpacePoxClient.java
+++ b/services/client/src/main/java/org/collectionspace/services/client/CollectionSpacePoxClient.java
@@ -3,7 +3,6 @@ package org.collectionspace.services.client;
 import javax.ws.rs.core.Response;
 
 import org.collectionspace.services.jaxb.AbstractCommonList;
-//import org.jboss.resteasy.client.ClientResponse;
 
 /*
  * <LT> = List type

--- a/services/contact/client/src/main/java/org/collectionspace/services/client/AuthorityWithContactsClient.java
+++ b/services/contact/client/src/main/java/org/collectionspace/services/client/AuthorityWithContactsClient.java
@@ -2,9 +2,6 @@ package org.collectionspace.services.client;
 
 import javax.ws.rs.core.Response;
 
-import org.collectionspace.services.jaxb.AbstractCommonList;
-import org.jboss.resteasy.client.ClientResponse;
-
 /*
  * LT - List type
  * ILT - Authority item list type

--- a/services/contact/client/src/main/java/org/collectionspace/services/client/AuthorityWithContactsProxy.java
+++ b/services/contact/client/src/main/java/org/collectionspace/services/client/AuthorityWithContactsProxy.java
@@ -9,9 +9,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 
-import org.collectionspace.services.jaxb.AbstractCommonList;
-import org.jboss.resteasy.client.ClientResponse;
-
 /*
  * ILT = Item list type
  * LT = List type

--- a/services/organization/client/src/main/java/org/collectionspace/services/client/OrgAuthorityClientUtils.java
+++ b/services/organization/client/src/main/java/org/collectionspace/services/client/OrgAuthorityClientUtils.java
@@ -41,7 +41,6 @@ import org.collectionspace.services.organization.OrgauthoritiesCommon;
 import org.collectionspace.services.organization.OrgTermGroup;
 import org.collectionspace.services.organization.OrgTermGroupList;
 
-import org.jboss.resteasy.client.ClientResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/services/place/client/src/main/java/org/collectionspace/services/client/PlaceAuthorityClientUtils.java
+++ b/services/place/client/src/main/java/org/collectionspace/services/client/PlaceAuthorityClientUtils.java
@@ -21,7 +21,6 @@ import org.collectionspace.services.place.PlaceauthoritiesCommon;
 import org.collectionspace.services.place.PlacesCommon;
 
 import org.dom4j.DocumentException;
-import org.jboss.resteasy.client.ClientResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/services/taxonomy/client/src/main/java/org/collectionspace/services/client/TaxonomyAuthorityClientUtils.java
+++ b/services/taxonomy/client/src/main/java/org/collectionspace/services/client/TaxonomyAuthorityClientUtils.java
@@ -20,7 +20,6 @@ import org.collectionspace.services.taxonomy.TaxonTermGroup;
 import org.collectionspace.services.taxonomy.TaxonTermGroupList;
 import org.collectionspace.services.taxonomy.TaxonomyauthorityCommon;
 import org.dom4j.DocumentException;
-import org.jboss.resteasy.client.ClientResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/services/work/client/src/main/java/org/collectionspace/services/client/WorkAuthorityClientUtils.java
+++ b/services/work/client/src/main/java/org/collectionspace/services/client/WorkAuthorityClientUtils.java
@@ -18,9 +18,7 @@ import org.collectionspace.services.work.WorkTermGroup;
 import org.collectionspace.services.work.WorkTermGroupList;
 import org.collectionspace.services.work.WorkauthoritiesCommon;
 import org.collectionspace.services.work.WorksCommon;
-
 import org.dom4j.DocumentException;
-import org.jboss.resteasy.client.ClientResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/services/workflow/client/src/test/java/org/collectionspace/services/client/test/WorkflowServiceTest.java
+++ b/services/workflow/client/src/test/java/org/collectionspace/services/client/test/WorkflowServiceTest.java
@@ -33,7 +33,6 @@ import org.collectionspace.services.workflow.WorkflowCommon;
 import org.collectionspace.services.client.DimensionClient;
 import org.collectionspace.services.client.workflow.WorkflowClient;
 import org.collectionspace.services.dimension.DimensionsCommon;
-import org.jboss.resteasy.client.ClientResponse;
 import org.testng.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
**What does this do?**
* Replace ClientResponse with javax Response
* Remove unused ClientResponse imports
* Update antrun plugin config 

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-2094

This is another small change for RESTEasy 3.x before we upgrade so that we can deploy to dev and do some early testing there. This should also make the move to the jakarta namespace a bit easier as the imports are all the same.

When running the integration tests there was an error in the AccountClientTest related to the hibernate.cfg.xml and caused the update to the plugin in the pom.xml.

**How should this be tested? Do these changes have associated tests?**
Most of these have no functional changes that need to be tested. Only the ClaimProxy had return types updated should have its test suite ran to check as that is the only usage.

For the plugin configuration, in the project directory for `services/account/client`, run `mvn clean package -DskipTests` and see that the hibernate.xml.cfg which is written to `target/test-classes` has correct settings for the database configuration. The tests in `services/account/client` can be ran as well.

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter ran the integration tests locally

**Have any new security vulnerabilities been handled?**
n/a
