### PR TITLE
DRYD-1193: Sysinfo endpoint healthcheck

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -13,3 +13,6 @@
 **Has the application documentation been updated for these changes?**
 
 **Did someone actually run this code to verify it works?**
+
+**Have any new security vulnerabilities been handled?**
+[Check SonarQube for IDE plugin for any security vulnerabilities introduced and describe how they have been handled]

--- a/services/IntegrationTests/src/test/java/org/collectionspace/services/IntegrationTests/test/HealthEndpointIntegrationTest.java
+++ b/services/IntegrationTests/src/test/java/org/collectionspace/services/IntegrationTests/test/HealthEndpointIntegrationTest.java
@@ -1,0 +1,133 @@
+package org.collectionspace.services.IntegrationTests.test;
+
+import static org.testng.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.util.Iterator;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.conn.HttpHostConnectException;
+import org.apache.http.util.EntityUtils;
+import org.testng.Assert;
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Integration tests for the GET /health endpoint. The endpoint is unauthenticated
+ * and returns JSON with overall status and component checks (database, nuxeo, elasticsearch).
+ * Requires a running CollectionSpace services server at {@link #BASE_URL}. If the server
+ * is not reachable, tests are skipped (e.g. when running in CI without a deployed server).
+ */
+public class HealthEndpointIntegrationTest {
+
+    public static final String HOST = "localhost";
+    public static final int PORT = 8180;
+    public static final String BASE_URL = "http://" + HOST + ":" + PORT + "/cspace-services/";
+    public static final String HEALTH_PATH = "health";
+
+    private String getUrl(String path) {
+        return BASE_URL + path;
+    }
+
+    /**
+     * Performs GET on the health endpoint. Skips the test if the server is not reachable
+     * (Connection refused), so that mvn test can pass when no server is running.
+     */
+    private HttpResponse getHealthResponse() throws IOException {
+        try {
+            return Request.Get(getUrl(HEALTH_PATH))
+                .addHeader("Accept", "application/json")
+                .execute()
+                .returnResponse();
+        } catch (HttpHostConnectException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof ConnectException && "Connection refused".equals(cause.getMessage())) {
+                throw new SkipException(
+                    "CollectionSpace server not running at " + BASE_URL + " - skip integration test");
+            }
+            throw e;
+        }
+    }
+
+    @Test
+    public void testHealthReturnsOkOrServiceUnavailable() throws IOException {
+        HttpResponse response = getHealthResponse();
+        int status = response.getStatusLine().getStatusCode();
+        Assert.assertTrue(status == 200 || status == 503,
+            "Expected 200 or 503, got " + status);
+        String body = EntityUtils.toString(response.getEntity());
+        JsonNode root = new ObjectMapper().readTree(body);
+        Assert.assertTrue(root.has("status"), "Response should have 'status' field");
+        String statusVal = root.get("status").asText();
+        Assert.assertTrue(
+            "pass".equals(statusVal) || "warn".equals(statusVal) || "fail".equals(statusVal),
+            "status should be pass, warn, or fail; got: " + statusVal);
+    }
+
+    @Test
+    public void testHealthResponseStructure() throws IOException {
+        HttpResponse response = getHealthResponse();
+        int status = response.getStatusLine().getStatusCode();
+        Assert.assertTrue(status == 200 || status == 503,
+            "Expected 200 or 503, got " + status);
+        String body = EntityUtils.toString(response.getEntity());
+        JsonNode root = new ObjectMapper().readTree(body);
+        Assert.assertTrue(root.has("status"), "Response should have 'status' field");
+        Assert.assertTrue(root.has("checks"), "Response should have 'checks' object");
+        JsonNode checks = root.get("checks");
+        Assert.assertTrue(checks.isObject(), "checks should be an object");
+
+        Assert.assertTrue(checks.has("database:cspace"),
+            "checks should contain 'database:cspace'");
+        assertValidCheckStatus(checks.get("database:cspace").get("status").asText(), "database:cspace");
+
+        Assert.assertTrue(checks.has("database:csadmin"),
+            "checks should contain 'database:csadmin'");
+        assertValidCheckStatus(checks.get("database:csadmin").get("status").asText(), "database:csadmin");
+
+        // database:nuxeo: either single "database:nuxeo" (warn when no tenants) or "database:nuxeo:<repoName>" per repo
+        boolean hasNuxeoCheck = checks.has("database:nuxeo");
+        if (!hasNuxeoCheck) {
+            Iterator<String> keys = checks.fieldNames();
+            while (keys.hasNext()) {
+                if (keys.next().startsWith("database:nuxeo:")) {
+                    hasNuxeoCheck = true;
+                    break;
+                }
+            }
+        }
+        Assert.assertTrue(hasNuxeoCheck,
+            "checks should contain 'database:nuxeo' or at least one 'database:nuxeo:*'");
+
+        // Every database:* check must have status one of pass, warn, fail, disabled
+        Iterator<String> keyIt = checks.fieldNames();
+        while (keyIt.hasNext()) {
+            String key = keyIt.next();
+            if (key.startsWith("database:")) {
+                Assert.assertTrue(checks.get(key).has("status"),
+                    "check '" + key + "' should have 'status'");
+                String checkStatus = checks.get(key).get("status").asText();
+                assertValidCheckStatus(checkStatus, key);
+            }
+        }
+    }
+
+    private static void assertValidCheckStatus(String status, String checkKey) {
+        assertTrue(
+            "pass".equals(status) || "warn".equals(status) || "fail".equals(status) || "disabled".equals(status),
+            "check " + checkKey + " status should be pass, warn, fail, or disabled; got: " + status);
+    }
+
+    @Test
+    public void testHealthNoAuthRequired() throws IOException {
+        HttpResponse response = getHealthResponse();
+        int status = response.getStatusLine().getStatusCode();
+        Assert.assertTrue(status == 200 || status == 503,
+            "Health endpoint should be accessible without auth (200 or 503); got " + status);
+    }
+}

--- a/services/JaxRsServiceProvider/src/main/java/org/collectionspace/services/jaxrs/CollectionSpaceJaxRsApplication.java
+++ b/services/JaxRsServiceProvider/src/main/java/org/collectionspace/services/jaxrs/CollectionSpaceJaxRsApplication.java
@@ -67,6 +67,7 @@ import org.collectionspace.services.advancedsearch.AdvancedSearch;
 import org.collectionspace.services.dimension.DimensionResource;
 import org.collectionspace.services.servicegroup.ServiceGroupResource;
 import org.collectionspace.services.structureddate.StructuredDateResource;
+import org.collectionspace.services.systeminfo.HealthResource;
 import org.collectionspace.services.systeminfo.SystemInfoResource;
 import org.collectionspace.services.contact.ContactResource;
 import org.collectionspace.services.vocabulary.VocabularyResource;
@@ -129,6 +130,7 @@ public class CollectionSpaceJaxRsApplication extends Application implements Reso
         singletons.add(new ExportResource());
         singletons.add(new StructuredDateResource());
         singletons.add(new SystemInfoResource());
+        singletons.add(new HealthResource());
         singletons.add(new IndexResource());
         singletons.add(new LoginResource());
         singletons.add(new LogoutResource());

--- a/services/common/src/main/java/org/collectionspace/services/common/security/SecurityConfig.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/security/SecurityConfig.java
@@ -411,6 +411,9 @@ public class SecurityConfig {
 						// Exclude the resource path to request system info.
 						.requestMatchers("/systeminfo").permitAll()
 
+						// Exclude the resource path for health check (load balancers).
+						.requestMatchers("/health").permitAll()
+
 						// Handle CORS (preflight OPTIONS requests must be anonymous).
 						.requestMatchers(HttpMethod.OPTIONS).permitAll()
 

--- a/services/common/src/main/java/org/collectionspace/services/common/security/SecurityInterceptor.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/security/SecurityInterceptor.java
@@ -86,6 +86,7 @@ public class SecurityInterceptor implements ContainerRequestFilter, ContainerRes
 	private static final String LOGIN = LoginClient.SERVICE_NAME;
 	private static final String LOGOUT = LogoutClient.SERVICE_NAME;
 	private static final String SYSTEM_INFO = SystemInfoClient.SERVICE_NAME;
+	private static final String HEALTH = "health";
 	private static final String NUXEO_ADMIN = null;
     //
     // Use this thread specific member instance to hold our login context with Nuxeo
@@ -104,15 +105,17 @@ public class SecurityInterceptor implements ContainerRequestFilter, ContainerRes
     private boolean isAnonymousRequest(ContainerRequestContext requestContext) {
     	boolean result = false;
 
-		String resName = SecurityUtils.getResourceName(requestContext.getUriInfo()).toLowerCase();
-        if (resName.equals(AuthZ.PASSWORD_RESET)
-            || resName.equals(AuthZ.PROCESS_PASSWORD_RESET)
-            || resName.equals(LOGIN)
-            || resName.equals(LOGOUT)
-            || resName.equals(SYSTEM_INFO)
-            || resName.isEmpty()) {
-            return true;
-        }
+		String resName = SecurityUtils.getResourceName(request.getUri()).toLowerCase();
+		switch (resName) {
+			case AuthZ.PASSWORD_RESET:
+			case AuthZ.PROCESS_PASSWORD_RESET:
+			case LOGIN:
+			case LOGOUT:
+			case SYSTEM_INFO:
+			case HEALTH:
+			case "":
+				return true;
+		}
 
 		Class<?> resourceClass = resourceInfo.getResourceClass();
 		try {

--- a/services/common/src/main/java/org/collectionspace/services/common/security/SecurityInterceptor.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/security/SecurityInterceptor.java
@@ -105,7 +105,7 @@ public class SecurityInterceptor implements ContainerRequestFilter, ContainerRes
     private boolean isAnonymousRequest(ContainerRequestContext requestContext) {
     	boolean result = false;
 
-		String resName = SecurityUtils.getResourceName(request.getUri()).toLowerCase();
+		String resName = SecurityUtils.getResourceName(requestContext.getUriInfo());
 		switch (resName) {
 			case AuthZ.PASSWORD_RESET:
 			case AuthZ.PROCESS_PASSWORD_RESET:

--- a/services/common/src/main/java/org/collectionspace/services/common/security/SecurityInterceptor.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/security/SecurityInterceptor.java
@@ -105,7 +105,7 @@ public class SecurityInterceptor implements ContainerRequestFilter, ContainerRes
     private boolean isAnonymousRequest(ContainerRequestContext requestContext) {
     	boolean result = false;
 
-		String resName = SecurityUtils.getResourceName(requestContext.getUriInfo());
+		String resName = SecurityUtils.getResourceName(requestContext.getUriInfo()).toLowerCase();
 		switch (resName) {
 			case AuthZ.PASSWORD_RESET:
 			case AuthZ.PROCESS_PASSWORD_RESET:

--- a/services/systeminfo/service/pom.xml
+++ b/services/systeminfo/service/pom.xml
@@ -64,6 +64,11 @@
             <artifactId>resteasy-multipart-provider</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/services/systeminfo/service/src/main/java/org/collectionspace/services/systeminfo/HealthResource.java
+++ b/services/systeminfo/service/src/main/java/org/collectionspace/services/systeminfo/HealthResource.java
@@ -1,0 +1,373 @@
+package org.collectionspace.services.systeminfo;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Callable;
+
+import javax.naming.NamingException;
+
+import javax.sql.DataSource;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.collectionspace.services.common.ServiceMain;
+import org.collectionspace.services.common.config.ConfigUtils;
+import org.collectionspace.services.common.config.TenantBindingConfigReaderImpl;
+import org.collectionspace.services.common.context.ServiceContext;
+import org.collectionspace.services.common.storage.JDBCTools;
+import org.collectionspace.services.config.tenant.TenantBindingType;
+import org.collectionspace.services.nuxeo.client.java.CoreSessionInterface;
+import org.collectionspace.services.nuxeo.client.java.NuxeoConnectorEmbedded;
+import org.nuxeo.elasticsearch.ElasticSearchComponent;
+import org.nuxeo.elasticsearch.api.ElasticSearchService;
+import org.nuxeo.runtime.api.Framework;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * JAX-RS resource for the /health endpoint. Returns JSON health status
+ * suitable for load balancers and Kubernetes (200/503, IETF draft health format).
+ */
+@Path("/health")
+@Produces(MediaType.APPLICATION_JSON)
+public class HealthResource {
+
+    private static final Logger logger = LoggerFactory.getLogger(HealthResource.class);
+    private static final String DESCRIPTION = "CollectionSpace Services";
+
+    @GET
+    public Response get() {
+        Map<String, Object> root = new LinkedHashMap<>();
+        Map<String, Object> checks = new LinkedHashMap<>();
+        root.put("checks", checks);
+
+        try {
+            root.put("description", DESCRIPTION);
+            root.put("version", getApplicationVersion());
+            root.put("releaseId", readGitCommitId());
+            root.put("serviceId", getServiceId());
+
+            String cspaceInstanceId = null;
+            try {
+                cspaceInstanceId = ServiceMain.getInstance().getCspaceInstanceId();
+            } catch (Exception e) {
+                logger.debug("Could not get instance id", e);
+            }
+
+            List<String> repoNames = resolveAllRepositoryNames();
+            String firstRepoName = repoNames.isEmpty() ? null : repoNames.get(0);
+            boolean requiredFailed = false;
+            boolean hasWarn = false;
+
+            // Check: database:cspace (required)
+            Map<String, Object> cspaceCheck = checkDatabaseCspace();
+            checks.put("database:cspace", cspaceCheck);
+            if ("fail".equals(cspaceCheck.get("status"))) {
+                requiredFailed = true;
+            }
+
+            // Check: database:csadmin (optional)
+            Map<String, Object> csadminCheck = checkDatabaseCsadmin();
+            checks.put("database:csadmin", csadminCheck);
+            if ("fail".equals(csadminCheck.get("status"))) {
+                hasWarn = true;
+            }
+
+            // Check: database:nuxeo per repository (required for each)
+            if (repoNames.isEmpty()) {
+                Map<String, Object> warnCheck = new LinkedHashMap<>();
+                warnCheck.put("status", "warn");
+                warnCheck.put("output", "no tenants configured");
+                checks.put("database:nuxeo", warnCheck);
+                hasWarn = true;
+            } else {
+                for (String repoName : repoNames) {
+                    Map<String, Object> nuxeoDbCheck = checkDatabaseNuxeo(repoName, cspaceInstanceId);
+                    checks.put("database:nuxeo:" + repoName, nuxeoDbCheck);
+                    if ("fail".equals(nuxeoDbCheck.get("status"))) {
+                        requiredFailed = true;
+                    }
+                }
+            }
+
+            // Check: nuxeo:repository (first repo only, required)
+            if (firstRepoName != null) {
+                Map<String, Object> repoCheck = checkNuxeoRepository(firstRepoName);
+                checks.put("nuxeo:repository", repoCheck);
+                if ("fail".equals(repoCheck.get("status"))) {
+                    requiredFailed = true;
+                }
+            } else {
+                Map<String, Object> warnCheck = new LinkedHashMap<>();
+                warnCheck.put("status", "warn");
+                warnCheck.put("output", "no tenants configured");
+                checks.put("nuxeo:repository", warnCheck);
+                hasWarn = true;
+            }
+
+            // Check: database:nuxeo_reader per repository (optional)
+            for (String repoName : repoNames) {
+                Map<String, Object> readerCheck = checkDatabaseNuxeoReader(repoName, cspaceInstanceId);
+                checks.put("database:nuxeo_reader:" + repoName, readerCheck);
+                if ("fail".equals(readerCheck.get("status"))) {
+                    hasWarn = true;
+                }
+            }
+
+            // Check: database:csadmin_nuxeo per repository (optional)
+            for (String repoName : repoNames) {
+                Map<String, Object> csadminNuxeoCheck = checkDatabaseCsadminNuxeo(repoName, cspaceInstanceId);
+                checks.put("database:csadmin_nuxeo:" + repoName, csadminNuxeoCheck);
+                if ("fail".equals(csadminNuxeoCheck.get("status"))) {
+                    hasWarn = true;
+                }
+            }
+
+            // Check: elasticsearch (optional)
+            Map<String, Object> esCheck = checkElasticsearch();
+            checks.put("elasticsearch", esCheck);
+            if ("fail".equals(esCheck.get("status"))) {
+                hasWarn = true;
+            }
+
+            // Overall status
+            String overall;
+            if (requiredFailed) {
+                overall = "fail";
+                root.put("output", firstFailingCheckMessage(checks));
+            } else if (hasWarn) {
+                overall = "warn";
+            } else {
+                overall = "pass";
+            }
+            root.put("status", overall);
+
+            String json = new ObjectMapper().writeValueAsString(root);
+            int statusCode = "fail".equals(overall) ? 503 : 200;
+            return Response.status(statusCode).entity(json).type(MediaType.APPLICATION_JSON).build();
+
+        } catch (Throwable t) {
+            logger.error("Error building health response", t);
+            Map<String, Object> failRoot = new LinkedHashMap<>();
+            failRoot.put("status", "fail");
+            failRoot.put("description", DESCRIPTION);
+            failRoot.put("output", t.getMessage() != null ? t.getMessage() : t.getClass().getSimpleName());
+            try {
+                String json = new ObjectMapper().writeValueAsString(failRoot);
+                return Response.status(503).entity(json).type(MediaType.APPLICATION_JSON).build();
+            } catch (Exception e) {
+                return Response.status(503).entity("{\"status\":\"fail\",\"output\":\"Error serializing response\"}")
+                    .type(MediaType.APPLICATION_JSON).build();
+            }
+        }
+    }
+
+    private String getApplicationVersion() {
+        String v = SystemInfoResource.class.getPackage().getImplementationVersion();
+        return v != null ? v : "unknown";
+    }
+
+    private String readGitCommitId() {
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream("git.properties")) {
+            if (in == null) {
+                return "unknown";
+            }
+            Properties props = new Properties();
+            props.load(in);
+            String abbrev = props.getProperty("git.commit.id.abbrev");
+            return abbrev != null ? abbrev : "unknown";
+        } catch (IOException e) {
+            return "unknown";
+        }
+    }
+
+    private String getServiceId() {
+        try {
+            return ServiceMain.getInstance().getCspaceInstanceId();
+        } catch (Exception e) {
+            return "unknown";
+        }
+    }
+
+    private String resolveFirstRepositoryName() {
+        List<String> all = resolveAllRepositoryNames();
+        return all.isEmpty() ? null : all.get(0);
+    }
+
+    /**
+     * Returns all repository names from tenant bindings (deduplicated).
+     */
+    private List<String> resolveAllRepositoryNames() {
+        List<String> result = new ArrayList<>();
+        try {
+            TenantBindingConfigReaderImpl reader = ServiceMain.getInstance().getTenantBindingConfigReader();
+            Hashtable<String, TenantBindingType> bindings = reader.getTenantBindings();
+            if (bindings == null || bindings.isEmpty()) {
+                return result;
+            }
+            for (TenantBindingType tenant : bindings.values()) {
+                List<String> repoList = ConfigUtils.getRepositoryNameList(tenant);
+                if (repoList != null) {
+                    for (String repoName : repoList) {
+                        if (repoName != null && !result.contains(repoName)) {
+                            result.add(repoName);
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logger.debug("Could not resolve repository names", e);
+        }
+        return result;
+    }
+
+    /**
+     * Runs a database health check: obtains a connection via the supplier,
+     * executes SELECT 1, reads product/version from metadata, and returns
+     * a check map with status pass/fail/disabled. When {@code namingExceptionAsDisabled}
+     * is true, NamingException results in status "disabled" instead of "fail".
+     */
+    private Map<String, Object> checkDatabase(Callable<Connection> connectionSupplier,
+            boolean namingExceptionAsDisabled) {
+        Map<String, Object> check = new LinkedHashMap<>();
+        check.put("componentType", "datastore");
+        Connection conn = null;
+        try {
+            conn = connectionSupplier.call();
+            try (Statement stmt = conn.createStatement()) {
+                stmt.executeQuery("SELECT 1");
+            }
+            DatabaseMetaData meta = conn.getMetaData();
+            String product = meta.getDatabaseProductName();
+            String version = meta.getDatabaseProductVersion();
+            check.put("status", "pass");
+            check.put("observedValue", product + " " + version);
+        } catch (NamingException e) {
+            if (namingExceptionAsDisabled) {
+                check.put("status", "disabled");
+                check.put("output", "datasource not configured");
+            } else {
+                check.put("status", "fail");
+                check.put("output", e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName());
+            }
+        } catch (Exception e) {
+            check.put("status", "fail");
+            check.put("output", e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName());
+        } finally {
+            if (conn != null) {
+                try {
+                    conn.close();
+                } catch (Exception e) {
+                    logger.trace("Error closing connection", e);
+                }
+            }
+        }
+        return check;
+    }
+
+    private Map<String, Object> checkDatabaseCspace() {
+        return checkDatabase(() -> {
+            DataSource ds = JDBCTools.getDataSource(JDBCTools.CSPACE_DATASOURCE_NAME);
+            return ds.getConnection();
+        }, false);
+    }
+
+    private Map<String, Object> checkDatabaseCsadmin() {
+        return checkDatabase(() -> {
+            DataSource ds = JDBCTools.getDataSource(JDBCTools.CSADMIN_DATASOURCE_NAME);
+            return ds.getConnection();
+        }, true);
+    }
+
+    private Map<String, Object> checkDatabaseNuxeo(String repositoryName, String cspaceInstanceId) {
+        return checkDatabase(
+                () -> JDBCTools.getConnection(JDBCTools.NUXEO_DATASOURCE_NAME, repositoryName, cspaceInstanceId),
+                false);
+    }
+
+    private Map<String, Object> checkDatabaseNuxeoReader(String repositoryName, String cspaceInstanceId) {
+        return checkDatabase(
+                () -> JDBCTools.getConnection(JDBCTools.NUXEO_READER_DATASOURCE_NAME, repositoryName, cspaceInstanceId),
+                true);
+    }
+
+    private Map<String, Object> checkDatabaseCsadminNuxeo(String repositoryName, String cspaceInstanceId) {
+        return checkDatabase(
+                () -> JDBCTools.getConnection(JDBCTools.CSADMIN_NUXEO_DATASOURCE_NAME, repositoryName, cspaceInstanceId),
+                true);
+    }
+
+    private Map<String, Object> checkNuxeoRepository(String repoName) {
+        Map<String, Object> check = new LinkedHashMap<>();
+        check.put("componentType", "component");
+        CoreSessionInterface session = null;
+        try {
+            NuxeoConnectorEmbedded connector = NuxeoConnectorEmbedded.getInstance();
+            session = connector.getClient().openRepository(repoName, ServiceContext.DEFAULT_TX_TIMEOUT);
+            session.getRepositoryName();
+            check.put("status", "pass");
+            check.put("observedValue", repoName);
+        } catch (Exception e) {
+            check.put("status", "fail");
+            check.put("output", e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName());
+        } finally {
+            if (session != null) {
+                try {
+                    NuxeoConnectorEmbedded.getInstance().releaseRepositorySession(session);
+                } catch (Exception e) {
+                    logger.trace("Error releasing repository session", e);
+                }
+            }
+        }
+        return check;
+    }
+
+    private Map<String, Object> checkElasticsearch() {
+        Map<String, Object> check = new LinkedHashMap<>();
+        if (!Framework.isBooleanPropertyTrue("elasticsearch.enabled")) {
+            check.put("status", "disabled");
+            return check;
+        }
+        try {
+            ElasticSearchComponent es = (ElasticSearchComponent) Framework.getService(ElasticSearchService.class);
+            Object client = es != null ? es.getClient() : null;
+            if (client != null) {
+                check.put("status", "pass");
+            } else {
+                check.put("status", "fail");
+                check.put("output", "Elasticsearch client not available");
+            }
+        } catch (Exception e) {
+            check.put("status", "fail");
+            check.put("output", e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName());
+        }
+        return check;
+    }
+
+    private String firstFailingCheckMessage(Map<String, Object> checks) {
+        for (Map.Entry<String, Object> entry : checks.entrySet()) {
+            if (entry.getValue() instanceof Map) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> c = (Map<String, Object>) entry.getValue();
+                if ("fail".equals(c.get("status"))) {
+                    return entry.getKey() + " check failed";
+                }
+            }
+        }
+        return "health check failed";
+    }
+}

--- a/services/systeminfo/service/src/main/java/org/collectionspace/services/systeminfo/HealthResource.java
+++ b/services/systeminfo/service/src/main/java/org/collectionspace/services/systeminfo/HealthResource.java
@@ -48,6 +48,7 @@ public class HealthResource {
 
     private static final Logger logger = LoggerFactory.getLogger(HealthResource.class);
     private static final String DESCRIPTION = "CollectionSpace Services";
+    private static final String INCLUDE_OBSERVED_VALUE_PROPERTY = "cspace.health.includeObservedValue";
 
     @GET
     public Response get() {
@@ -250,7 +251,7 @@ public class HealthResource {
             String product = meta.getDatabaseProductName();
             String version = meta.getDatabaseProductVersion();
             check.put("status", "pass");
-            check.put("observedValue", product + " " + version);
+            putObservedValueIfEnabled(check, product + " " + version);
         } catch (NamingException e) {
             if (namingExceptionAsDisabled) {
                 check.put("status", "disabled");
@@ -298,7 +299,7 @@ public class HealthResource {
             session = connector.getClient().openRepository(repoName, ServiceContext.DEFAULT_TX_TIMEOUT);
             session.getRepositoryName();
             check.put("status", "pass");
-            check.put("observedValue", repoName);
+            putObservedValueIfEnabled(check, repoName);
         } catch (Exception e) {
             check.put("status", "fail");
             check.put("output", e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName());
@@ -347,5 +348,11 @@ public class HealthResource {
             }
         }
         return "health check failed";
+    }
+
+    private void putObservedValueIfEnabled(Map<String, Object> check, String observedValue) {
+        if (Framework.isBooleanPropertyTrue(INCLUDE_OBSERVED_VALUE_PROPERTY)) {
+            check.put("observedValue", observedValue);
+        }
     }
 }

--- a/services/systeminfo/service/src/main/java/org/collectionspace/services/systeminfo/HealthResource.java
+++ b/services/systeminfo/service/src/main/java/org/collectionspace/services/systeminfo/HealthResource.java
@@ -56,17 +56,12 @@ public class HealthResource {
         root.put("checks", checks);
 
         try {
+            String cspaceInstanceId = getServiceId();
+
             root.put("description", DESCRIPTION);
             root.put("version", getApplicationVersion());
             root.put("releaseId", readGitCommitId());
-            root.put("serviceId", getServiceId());
-
-            String cspaceInstanceId = null;
-            try {
-                cspaceInstanceId = ServiceMain.getInstance().getCspaceInstanceId();
-            } catch (Exception e) {
-                logger.debug("Could not get instance id", e);
-            }
+            root.put("serviceId", cspaceInstanceId);
 
             List<String> repoNames = resolveAllRepositoryNames();
             String firstRepoName = repoNames.isEmpty() ? null : repoNames.get(0);
@@ -74,14 +69,16 @@ public class HealthResource {
             boolean hasWarn = false;
 
             // Check: database:cspace (required)
-            Map<String, Object> cspaceCheck = checkDatabaseCspace();
+            Map<String, Object> cspaceCheck = checkDatabaseByDatasource(JDBCTools.CSPACE_DATASOURCE_NAME, false, null,
+                    null);
             checks.put("database:cspace", cspaceCheck);
             if ("fail".equals(cspaceCheck.get("status"))) {
                 requiredFailed = true;
             }
 
             // Check: database:csadmin (optional)
-            Map<String, Object> csadminCheck = checkDatabaseCsadmin();
+            Map<String, Object> csadminCheck = checkDatabaseByDatasource(JDBCTools.CSADMIN_DATASOURCE_NAME, true, null,
+                    null);
             checks.put("database:csadmin", csadminCheck);
             if ("fail".equals(csadminCheck.get("status"))) {
                 hasWarn = true;
@@ -96,7 +93,8 @@ public class HealthResource {
                 hasWarn = true;
             } else {
                 for (String repoName : repoNames) {
-                    Map<String, Object> nuxeoDbCheck = checkDatabaseNuxeo(repoName, cspaceInstanceId);
+                    Map<String, Object> nuxeoDbCheck = checkDatabaseByDatasource(JDBCTools.NUXEO_DATASOURCE_NAME, false,
+                            repoName, cspaceInstanceId);
                     checks.put("database:nuxeo:" + repoName, nuxeoDbCheck);
                     if ("fail".equals(nuxeoDbCheck.get("status"))) {
                         requiredFailed = true;
@@ -121,7 +119,8 @@ public class HealthResource {
 
             // Check: database:nuxeo_reader per repository (optional)
             for (String repoName : repoNames) {
-                Map<String, Object> readerCheck = checkDatabaseNuxeoReader(repoName, cspaceInstanceId);
+                Map<String, Object> readerCheck = checkDatabaseByDatasource(JDBCTools.NUXEO_READER_DATASOURCE_NAME,
+                        true, repoName, cspaceInstanceId);
                 checks.put("database:nuxeo_reader:" + repoName, readerCheck);
                 if ("fail".equals(readerCheck.get("status"))) {
                     hasWarn = true;
@@ -130,7 +129,8 @@ public class HealthResource {
 
             // Check: database:csadmin_nuxeo per repository (optional)
             for (String repoName : repoNames) {
-                Map<String, Object> csadminNuxeoCheck = checkDatabaseCsadminNuxeo(repoName, cspaceInstanceId);
+                Map<String, Object> csadminNuxeoCheck = checkDatabaseByDatasource(
+                        JDBCTools.CSADMIN_NUXEO_DATASOURCE_NAME, true, repoName, cspaceInstanceId);
                 checks.put("database:csadmin_nuxeo:" + repoName, csadminNuxeoCheck);
                 if ("fail".equals(csadminNuxeoCheck.get("status"))) {
                     hasWarn = true;
@@ -201,11 +201,6 @@ public class HealthResource {
         } catch (Exception e) {
             return "unknown";
         }
-    }
-
-    private String resolveFirstRepositoryName() {
-        List<String> all = resolveAllRepositoryNames();
-        return all.isEmpty() ? null : all.get(0);
     }
 
     /**
@@ -279,36 +274,19 @@ public class HealthResource {
         return check;
     }
 
-    private Map<String, Object> checkDatabaseCspace() {
-        return checkDatabase(() -> {
-            DataSource ds = JDBCTools.getDataSource(JDBCTools.CSPACE_DATASOURCE_NAME);
+    private Map<String, Object> checkDatabaseByDatasource(String datasourceName, boolean namingExceptionAsDisabled,
+            String repositoryName, String cspaceInstanceId) {
+        return checkDatabase(() -> getConnectionForDatasource(datasourceName, repositoryName, cspaceInstanceId),
+                namingExceptionAsDisabled);
+    }
+
+    private Connection getConnectionForDatasource(String datasourceName, String repositoryName, String cspaceInstanceId)
+            throws Exception {
+        if (repositoryName == null || cspaceInstanceId == null) {
+            DataSource ds = JDBCTools.getDataSource(datasourceName);
             return ds.getConnection();
-        }, false);
-    }
-
-    private Map<String, Object> checkDatabaseCsadmin() {
-        return checkDatabase(() -> {
-            DataSource ds = JDBCTools.getDataSource(JDBCTools.CSADMIN_DATASOURCE_NAME);
-            return ds.getConnection();
-        }, true);
-    }
-
-    private Map<String, Object> checkDatabaseNuxeo(String repositoryName, String cspaceInstanceId) {
-        return checkDatabase(
-                () -> JDBCTools.getConnection(JDBCTools.NUXEO_DATASOURCE_NAME, repositoryName, cspaceInstanceId),
-                false);
-    }
-
-    private Map<String, Object> checkDatabaseNuxeoReader(String repositoryName, String cspaceInstanceId) {
-        return checkDatabase(
-                () -> JDBCTools.getConnection(JDBCTools.NUXEO_READER_DATASOURCE_NAME, repositoryName, cspaceInstanceId),
-                true);
-    }
-
-    private Map<String, Object> checkDatabaseCsadminNuxeo(String repositoryName, String cspaceInstanceId) {
-        return checkDatabase(
-                () -> JDBCTools.getConnection(JDBCTools.CSADMIN_NUXEO_DATASOURCE_NAME, repositoryName, cspaceInstanceId),
-                true);
+        }
+        return JDBCTools.getConnection(datasourceName, repositoryName, cspaceInstanceId);
     }
 
     private Map<String, Object> checkNuxeoRepository(String repoName) {


### PR DESCRIPTION
**What does this do?**
Adds a health check endpoint at `/health` that returns JSON describing the health status. Makes a very basic attempt at determining which data sources matter and degrades to a warning state if non-required components fail.

```
{
  "checks":{
    "database:cspace":{
      "componentType":"datastore",
      "status":"pass",
      "observedValue":"PostgreSQL 17.5 (Debian 17.5-1.pgdg120+1)"
    },
    "database:csadmin":{
      "componentType":"datastore",
      "status":"pass",
      "observedValue":"PostgreSQL 17.5 (Debian 17.5-1.pgdg120+1)"
    },
    "database:nuxeo:default":{
      "componentType":"datastore",
      "status":"pass",
      "observedValue":"PostgreSQL 17.5 (Debian 17.5-1.pgdg120+1)"
    },
    "nuxeo:repository":{
      "componentType":"component",
      "status":"pass",
      "observedValue":"default"
    },
    "database:nuxeo_reader:default":{
      "componentType":"datastore",
      "status":"pass",
      "observedValue":"PostgreSQL 17.5 (Debian 17.5-1.pgdg120+1)"
    },
    "database:csadmin_nuxeo:default":{
      "componentType":"datastore",
      "status":"pass",
      "observedValue":"PostgreSQL 17.5 (Debian 17.5-1.pgdg120+1)"
    },
    "elasticsearch":{
      "status":"disabled"
    }
  },
  "description":"CollectionSpace Services",
  "version":"8.3.0-RC.2",
  "releaseId":"99cd743",
  "serviceId":"_collectionspace",
  "status":"pass"
}
```

**Why are we doing this? (with JIRA link)**
https://collectionspace.atlassian.net/browse/DRYD-1193

Because hosting needs a way to determine if there's a failure communicating with the database or ElasticSearch.

**How should this be tested? Do these changes have associated tests?**
Bundled integration tests.

**Dependencies for merging? Releasing to production?**
No additional dependencies.

**Has the application documentation been updated for these changes?**
No.

**Did someone actually run this code to verify it works?**
Yes.