### PR TITLE
DRYD-2101: Update Authority Fulltext Queries

### DIFF
--- a/services/client/src/main/java/org/collectionspace/services/client/IQueryManager.java
+++ b/services/client/src/main/java/org/collectionspace/services/client/IQueryManager.java
@@ -30,93 +30,91 @@ import java.util.List;
 
 public interface IQueryManager {
 
-	final static String SEARCH_COMBINE_QUERY_PARAM = "combine";
-	final static String SEARCH_COMBINE_AND = "and";
-	final static String SEARCH_COMBINE_OR = "or";
-	final static String SEARCH_GROUP_OPEN = "(";
-	final static String SEARCH_GROUP_CLOSE = ")";
-	final static String SEARCH_TERM_SEPARATOR = " ";
-	final static String SEARCH_LIKE = " LIKE ";
-	final static String SEARCH_ILIKE = " ILIKE ";
-	final static String SEARCH_TYPE_KEYWORDS = "keywords";
-	final static String SEARCH_TYPE_KEYWORDS_KW = "kw";
-	final static String SEARCH_TYPE_KEYWORDS_AS = "as";
-	final static String SEARCH_TYPE_PARTIALTERM = "pt";
-	final static String SEARCH_TYPE_DOCTYPE = "doctype";
-	final static String SEARCH_TYPE_FILENAME = "filename";
-	final static String SEARCH_TYPE_CLASS_NAME = "classname";
-	final static String SEARCH_TYPE_INVOCATION_MODE = "mode";
-	final static String SEARCH_TYPE_INVOCATION = "inv";
-	final static String SEARCH_QUALIFIER_AND = SEARCH_TERM_SEPARATOR + "AND" + SEARCH_TERM_SEPARATOR;
-	final static String SEARCH_QUALIFIER_OR = SEARCH_TERM_SEPARATOR + "OR" + SEARCH_TERM_SEPARATOR;
-	final static String DEFAULT_SELECT_CLAUSE = "SELECT * FROM ";
-	final static String CSID_QUERY_PARAM = "csid";
-	final static String TAG_QUERY_PARAM = "servicetag";
+	String SEARCH_COMBINE_QUERY_PARAM = "combine";
+	String SEARCH_COMBINE_AND = "and";
+	String SEARCH_COMBINE_OR = "or";
+	String SEARCH_GROUP_OPEN = "(";
+	String SEARCH_GROUP_CLOSE = ")";
+	String SEARCH_TERM_SEPARATOR = " ";
+	String SEARCH_LIKE = " LIKE ";
+	String SEARCH_ILIKE = " ILIKE ";
+	String SEARCH_TYPE_KEYWORDS = "keywords";
+	String SEARCH_TYPE_KEYWORDS_KW = "kw";
+	String SEARCH_TYPE_KEYWORDS_AS = "as";
+	String SEARCH_TYPE_PARTIALTERM = "pt";
+	String SEARCH_TYPE_DOCTYPE = "doctype";
+	String SEARCH_TYPE_FILENAME = "filename";
+	String SEARCH_TYPE_CLASS_NAME = "classname";
+	String SEARCH_TYPE_INVOCATION_MODE = "mode";
+	String SEARCH_TYPE_INVOCATION = "inv";
+	String SEARCH_QUALIFIER_AND = SEARCH_TERM_SEPARATOR + "AND" + SEARCH_TERM_SEPARATOR;
+	String SEARCH_QUALIFIER_OR = SEARCH_TERM_SEPARATOR + "OR" + SEARCH_TERM_SEPARATOR;
+	String DEFAULT_SELECT_CLAUSE = "SELECT * FROM ";
+	String CSID_QUERY_PARAM = "csid";
+	String TAG_QUERY_PARAM = "servicetag";
 
 
 	//
 	// Nuxeo pseudo-values (and filters) for special document properties.
 	//
-	final static String NUXEO_UUID = "ecm:uuid";
-	final static String NUXEO_IS_PROXY = "ecm:isProxy";
-	final static String NUXEO_IS_PROXY_FILTER = NUXEO_IS_PROXY + " = 0";
-	final static String NUXEO_IS_VERSION = "ecm:isCheckedInVersion";
-	final static String NUXEO_IS_VERSION_FILTER = NUXEO_IS_VERSION + " = 0";
+    String NUXEO_UUID = "ecm:uuid";
+	String NUXEO_IS_PROXY = "ecm:isProxy";
+	String NUXEO_IS_PROXY_FILTER = NUXEO_IS_PROXY + " = 0";
+	String NUXEO_IS_VERSION = "ecm:isCheckedInVersion";
+	String NUXEO_IS_VERSION_FILTER = NUXEO_IS_VERSION + " = 0";
 	// In the CMIS context, the prefix is nuxeo, not ecm
-	final static String NUXEO_CMIS_IS_VERSION = "nuxeo:isVersion";
-	final static String NUXEO_CMIS_IS_VERSION_FILTER = NUXEO_CMIS_IS_VERSION + " = false";
+    String NUXEO_CMIS_IS_VERSION = "nuxeo:isVersion";
+	String NUXEO_CMIS_IS_VERSION_FILTER = NUXEO_CMIS_IS_VERSION + " = false";
 
 	//
 	// Query params for CMIS queries on the relationship (Relation) table.
 	//
-	final static String SEARCH_RELATED_TO_CSID_AS_SUBJECT = "rtSbj";
-	final static String SEARCH_RELATED_TO_CSID_AS_OBJECT = "rtObj";
-	final static String SEARCH_RELATED_PREDICATE = "rtPredicate";
+    String SEARCH_RELATED_TO_CSID_AS_SUBJECT = "rtSbj";
+	String SEARCH_RELATED_TO_CSID_AS_OBJECT = "rtObj";
+	String SEARCH_RELATED_PREDICATE = "rtPredicate";
 
-	final static String SEARCH_RELATED_TO_CSID_AS_EITHER = "rtSbjOrObj";
-	final static String SEARCH_RELATED_MATCH_OBJ_DOCTYPES = "rtObjDocTypes";
-	final static String SELECT_DOC_TYPE_FIELD = "selectDocType";
+	String SEARCH_RELATED_TO_CSID_AS_EITHER = "rtSbjOrObj";
+	String SEARCH_RELATED_MATCH_OBJ_DOCTYPES = "rtObjDocTypes";
+	String SELECT_DOC_TYPE_FIELD = "selectDocType";
 
-	final static String MARK_RELATED_TO_CSID_AS_SUBJECT = "mkRtSbj";
-	final static String MARK_RELATED_TO_CSID_AS_EITHER = "mkRtSbjOrObj";
+	String MARK_RELATED_TO_CSID_AS_SUBJECT = "mkRtSbj";
+	String MARK_RELATED_TO_CSID_AS_EITHER = "mkRtSbjOrObj";
 
 	//
 	// Generic CMIS property mapping constants
 	//
-	final static String CMIS_OBJECT_ID = "cmis:objectId";
-	final static String CMIS_NUXEO_PATHSEGMENT = "nuxeo:pathSegment";
+    String CMIS_OBJECT_ID = "cmis:objectId";
+	String CMIS_NUXEO_PATHSEGMENT = "nuxeo:pathSegment";
 	//
 	// Nuxeo related CMIS property mapping constants
-	final static String CMIS_NUXEO_ID = CMIS_OBJECT_ID;
-	final static String CMIS_NUXEO_NAME = CMIS_NUXEO_PATHSEGMENT;
-	final static String CMIS_NUXEO_TITLE = "dc:title";
-	final static String CMIS_CS_UPDATED_AT = CollectionSpaceClient.COLLECTIONSPACE_CORE_SCHEMA + ":" +
-			CollectionSpaceClient.COLLECTIONSPACE_CORE_UPDATED_AT;
+    String CMIS_NUXEO_ID = CMIS_OBJECT_ID;
+	String CMIS_NUXEO_NAME = CMIS_NUXEO_PATHSEGMENT;
+	String CMIS_NUXEO_TITLE = "dc:title";
+	String CMIS_CS_UPDATED_AT = CollectionSpaceClient.COLLECTIONSPACE_CORE_SCHEMA + ":" +
+                                      CollectionSpaceClient.COLLECTIONSPACE_CORE_UPDATED_AT;
 
 	// CollectionSpace CMIS property mapping constants
-	final static String CMIS_TARGET_PREFIX = "DOC";
-	final static String CMIS_CORESCHEMA_PREFIX = "CORE";
+    String CMIS_TARGET_PREFIX = "DOC";
+	String CMIS_CORESCHEMA_PREFIX = "CORE";
 	// Relations CMIS property mapping constants
-	final static String CMIS_RELATIONS_PREFIX = "REL";
+    String CMIS_RELATIONS_PREFIX = "REL";
 
-	final static String CMIS_JOIN_NUXEO_IS_VERSION_FILTER =
+	String CMIS_JOIN_NUXEO_IS_VERSION_FILTER =
 			IQueryManager.CMIS_TARGET_PREFIX + "." + IQueryManager.NUXEO_CMIS_IS_VERSION_FILTER;
-	final static String CMIS_JOIN_TENANT_ID_FILTER =
+	String CMIS_JOIN_TENANT_ID_FILTER =
 			IQueryManager.CMIS_RELATIONS_PREFIX + "." + CollectionSpaceClient.CORE_TENANTID;
 
-	final static String CMIS_TARGET_NUXEO_ID = CMIS_TARGET_PREFIX + "." + CMIS_NUXEO_ID;
-	final static String CMIS_TARGET_CSID = CMIS_TARGET_PREFIX + "." + CMIS_NUXEO_NAME;
-	final static String CMIS_TARGET_TITLE = CMIS_TARGET_PREFIX + "." + CMIS_NUXEO_TITLE;
-	final static String CMIS_TARGET_NAME = CMIS_TARGET_PREFIX + "." + CMIS_NUXEO_NAME;
-	final static String CMIS_TARGET_UPDATED_AT = CMIS_TARGET_PREFIX + "." + CMIS_CS_UPDATED_AT;
+	String CMIS_TARGET_NUXEO_ID = CMIS_TARGET_PREFIX + "." + CMIS_NUXEO_ID;
+	String CMIS_TARGET_CSID = CMIS_TARGET_PREFIX + "." + CMIS_NUXEO_NAME;
+	String CMIS_TARGET_TITLE = CMIS_TARGET_PREFIX + "." + CMIS_NUXEO_TITLE;
+	String CMIS_TARGET_NAME = CMIS_TARGET_PREFIX + "." + CMIS_NUXEO_NAME;
+	String CMIS_TARGET_UPDATED_AT = CMIS_TARGET_PREFIX + "." + CMIS_CS_UPDATED_AT;
 
-	final static String TENANT_USES_STARTING_WILDCARD_FOR_PARTIAL_TERM = "ptStartingWildcard";
-        final static String MAX_LIST_ITEMS_RETURNED_LIMIT_ON_JDBC_QUERIES = "maxListItemsReturnedLimitOnJdbcQueries";
-        final static String JDBC_QUERIES_ARE_TENANT_ID_RESTRICTED = "jdbcQueriesAreTenantIdRestricted";
+	String TENANT_USES_STARTING_WILDCARD_FOR_PARTIAL_TERM = "ptStartingWildcard";
+        String MAX_LIST_ITEMS_RETURNED_LIMIT_ON_JDBC_QUERIES = "maxListItemsReturnedLimitOnJdbcQueries";
+        String JDBC_QUERIES_ARE_TENANT_ID_RESTRICTED = "jdbcQueriesAreTenantIdRestricted";
 
-	public void execQuery(String queryString);
-
-	public String getDatasourceName();
+	String getDatasourceName();
 
 	/**
 	 * Creates the where clause from keywords.
@@ -128,10 +126,10 @@ public interface IQueryManager {
 	 */
     String createWhereClauseFromKeywords(String keywords, boolean clean);
 
-	public String createWhereClauseFromAdvancedSearch(String advancedSearch);
+	String createWhereClauseFromAdvancedSearch(String advancedSearch);
 
-	final static boolean FILTER_EXCLUDE = true;
-	final static boolean FILTER_INCLUDE = false;
+	boolean FILTER_EXCLUDE = true;
+	boolean FILTER_INCLUDE = false;
 
 	/**
 	 * Creates a query to filter a qualified (string) field according to a list of string values.
@@ -141,7 +139,7 @@ public interface IQueryManager {
 	 * 					If false, will require qualifiedField does match one of the filters strings.
 	 * @return queryString
 	 */
-	public String createWhereClauseToFilterFromStringList(String qualifiedField, String[] filterTerms, boolean fExclude);
+    String createWhereClauseToFilterFromStringList(String qualifiedField, String[] filterTerms, boolean fExclude);
 
 	/**
 	 * Creates the where clause for partial term match.
@@ -151,12 +149,12 @@ public interface IQueryManager {
 	 *
 	 * @return the string
 	 */
-	public String createWhereClauseForPartialMatch(String dataSourceName,
-			String repositoryName,
-			String cspaceInstanceId,
-			String field,
-			boolean startingWildcard,
-			String partialTerm);
+    String createWhereClauseForPartialMatch(String dataSourceName,
+                                            String repositoryName,
+                                            String cspaceInstanceId,
+                                            String field,
+                                            boolean startingWildcard,
+                                            String partialTerm);
 
 	/**
 	 * Creates a filtering where clause from docType, for invocables.
@@ -166,7 +164,7 @@ public interface IQueryManager {
 	 *
 	 * @return the string
 	 */
-	public String createWhereClauseForInvocableByDocType(String schema, String docType);
+    String createWhereClauseForInvocableByDocType(String schema, String docType);
 
 
 	/**
@@ -176,7 +174,7 @@ public interface IQueryManager {
 	 * @param docType the filename
 	 * @return        the where clause
 	 */
-	public String createWhereClauseForInvocableByFilename(String schema, String filename);
+    String createWhereClauseForInvocableByFilename(String schema, String filename);
 
 	/**
 	 * Creates a filtering where clause from class name, for invocables.
@@ -185,7 +183,7 @@ public interface IQueryManager {
 	 * @param docType the class name
 	 * @return        the where clause
 	 */
-	public String createWhereClauseForInvocableByClassName(String schema, String className);
+    String createWhereClauseForInvocableByClassName(String schema, String className);
 
 	/**
 	 * Creates a filtering where clause from invocation mode, for invocables.
@@ -195,13 +193,13 @@ public interface IQueryManager {
 	 *
 	 * @return the string
 	 */
-	public String createWhereClauseForInvocableByMode(String schema, String mode);
+    String createWhereClauseForInvocableByMode(String schema, String mode);
 
-	public String createWhereClauseForInvocableByMode(String schema, List<String> modes);
+	String createWhereClauseForInvocableByMode(String schema, List<String> modes);
 
 	/*
 	 *
 	 */
-	public String createWhereClauseFromCsid(String csid);
+    String createWhereClauseFromCsid(String csid);
 
 }

--- a/services/client/src/main/java/org/collectionspace/services/client/IQueryManager.java
+++ b/services/client/src/main/java/org/collectionspace/services/client/IQueryManager.java
@@ -122,10 +122,11 @@ public interface IQueryManager {
 	 * Creates the where clause from keywords.
 	 *
 	 * @param keywords the keywords
+	 * @param clean if punctuation should be removed from the keywords
 	 *
 	 * @return the string
 	 */
-	public String createWhereClauseFromKeywords(String keywords);
+    String createWhereClauseFromKeywords(String keywords, boolean clean);
 
 	public String createWhereClauseFromAdvancedSearch(String advancedSearch);
 

--- a/services/common/src/main/java/org/collectionspace/services/common/query/QueryManager.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/query/QueryManager.java
@@ -37,7 +37,7 @@ import org.collectionspace.services.common.query.nuxeo.QueryManagerNuxeoImpl;
 import org.collectionspace.services.config.tenant.TenantBindingType;
 
 public class QueryManager {
-	static private final IQueryManager queryManager = new QueryManagerNuxeoImpl();
+	private static final IQueryManager queryManager = new QueryManagerNuxeoImpl();
 
 	/**
 	 * Creates the where clause from keywords.
@@ -46,8 +46,8 @@ public class QueryManager {
 	 *
 	 * @return the string
 	 */
-	static public String createWhereClauseFromKeywords(String keywords) {
-		return queryManager.createWhereClauseFromKeywords(keywords);
+    public static String createWhereClauseFromKeywords(String keywords) {
+		return queryManager.createWhereClauseFromKeywords(keywords, true);
 	}
 
 	public static String createWhereClauseFromKeywords(String keywords, boolean clean) {
@@ -58,7 +58,7 @@ public class QueryManager {
 		return queryManager.createWhereClauseFromAdvancedSearch(keywords);
 	}
 
-	static public String createWhereClauseFromCsid(String csid) {
+	public static String createWhereClauseFromCsid(String csid) {
 		return queryManager.createWhereClauseFromCsid(csid);
 	}
 
@@ -70,7 +70,7 @@ public class QueryManager {
 	 *
 	 * @return the string
 	 */
-	static public String createWhereClauseForPartialMatch(ServiceContext ctx,
+    public static String createWhereClauseForPartialMatch(ServiceContext ctx,
 			String field,
 			String partialTerm) throws Exception {
 		String cspaceInstanceId = ServiceMain.getInstance().getCspaceInstanceId();
@@ -96,7 +96,7 @@ public class QueryManager {
 	 * 					If false, will require qualifiedField does match one of the filters strings.
 	 * @return queryString
 	 */
-	static public String createWhereClauseToFilterFromStringList(String qualifiedField, String[] filterTerms, boolean fExclude) {
+    public static String createWhereClauseToFilterFromStringList(String qualifiedField, String[] filterTerms, boolean fExclude) {
 		return queryManager.createWhereClauseToFilterFromStringList(qualifiedField, filterTerms, fExclude);
 	}
 
@@ -109,7 +109,7 @@ public class QueryManager {
 	 *
 	 * @return the string
 	 */
-	static public String createWhereClauseForInvocableByDocType(String schema, String docType) {
+    public static String createWhereClauseForInvocableByDocType(String schema, String docType) {
 		return queryManager.createWhereClauseForInvocableByDocType(schema, docType);
 	}
 
@@ -120,7 +120,7 @@ public class QueryManager {
 	 * @param docType the filename
 	 * @return        the where clause
 	 */
-	static public String createWhereClauseForInvocableByFilename(String schema, String filename) {
+    public static String createWhereClauseForInvocableByFilename(String schema, String filename) {
 		return queryManager.createWhereClauseForInvocableByFilename(schema, filename);
 	}
 
@@ -131,7 +131,7 @@ public class QueryManager {
 	 * @param docType the class name
 	 * @return        the where clause
 	 */
-	static public String createWhereClauseForInvocableByClassName(String schema, String className) {
+    public static String createWhereClauseForInvocableByClassName(String schema, String className) {
 		return queryManager.createWhereClauseForInvocableByClassName(schema, className);
 	}
 
@@ -143,11 +143,11 @@ public class QueryManager {
 	 *
 	 * @return the string
 	 */
-	static public String createWhereClauseForInvocableByMode(String schema, String mode) {
+    public static String createWhereClauseForInvocableByMode(String schema, String mode) {
 		return queryManager.createWhereClauseForInvocableByMode(schema, mode);
 	}
 
-	static public String createWhereClauseForInvocableByMode(String schema, List<String> modes) {
+	public static String createWhereClauseForInvocableByMode(String schema, List<String> modes) {
 		return queryManager.createWhereClauseForInvocableByMode(schema, modes);
 	}
 }

--- a/services/common/src/main/java/org/collectionspace/services/common/query/QueryManager.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/query/QueryManager.java
@@ -50,7 +50,11 @@ public class QueryManager {
 		return queryManager.createWhereClauseFromKeywords(keywords);
 	}
 
-	static public String createWhereClauseFromAdvancedSearch(String keywords) {
+	public static String createWhereClauseFromKeywords(String keywords, boolean clean) {
+		return queryManager.createWhereClauseFromKeywords(keywords, clean);
+	}
+
+	public static String createWhereClauseFromAdvancedSearch(String keywords) {
 		return queryManager.createWhereClauseFromAdvancedSearch(keywords);
 	}
 

--- a/services/common/src/main/java/org/collectionspace/services/common/query/nuxeo/QueryManagerNuxeoImpl.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/query/nuxeo/QueryManagerNuxeoImpl.java
@@ -46,8 +46,7 @@ import org.slf4j.LoggerFactory;
 
 public class QueryManagerNuxeoImpl implements IQueryManager {
 
-	private static String ECM_FULLTEXT_LIKE = "ecm:fulltext"
-			+ SEARCH_TERM_SEPARATOR + IQueryManager.SEARCH_LIKE;
+	private static String ECM_FULLTEXT_LIKE = "ecm:fulltext" + SEARCH_TERM_SEPARATOR + IQueryManager.SEARCH_LIKE;
 	private static String SEARCH_LIKE_FORM = null;
 
 	private final Logger logger = LoggerFactory
@@ -82,22 +81,6 @@ public class QueryManagerNuxeoImpl implements IQueryManager {
 		return JDBCTools.NUXEO_DATASOURCE_NAME;
 	}
 
-	// TODO: This is currently just an example fixed query. This should
-	// eventually be
-	// removed or replaced with a more generic method.
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.collectionspace.services.common.query.IQueryManager#execQuery(java
-	 * .lang.String)
-	 */
-	@Override
-	@Deprecated
-	public void execQuery(String queryString) {
-		// Intentionally left blank
-	}
-
 	@Override
 	public String createWhereClauseFromAdvancedSearch(String advancedSearch) {
 		String result = null;
@@ -105,14 +88,12 @@ public class QueryManagerNuxeoImpl implements IQueryManager {
 		// Process search term.  FIXME: REM - Do we need to perform any string filtering here?
 		//
 		if (advancedSearch != null && !advancedSearch.isEmpty()) {
-                        // Filtering of advanced searches on a single '%' char, per CSPACE-5828
-                    	Matcher regexMatcher = advSearchSqlWildcard.matcher(advancedSearch.trim());
-                        if (regexMatcher.matches()) {
-                            return "";
-                        }
-			StringBuffer advancedSearchWhereClause = new StringBuffer(
-					advancedSearch);
-			result = advancedSearchWhereClause.toString();
+			// Filtering of advanced searches on a single '%' char, per CSPACE-5828
+			Matcher regexMatcher = advSearchSqlWildcard.matcher(advancedSearch.trim());
+			if (regexMatcher.matches()) {
+				return "";
+			}
+			result = advancedSearch;
 		}
 
 		return result;

--- a/services/common/src/main/java/org/collectionspace/services/common/query/nuxeo/QueryManagerNuxeoImpl.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/query/nuxeo/QueryManagerNuxeoImpl.java
@@ -125,10 +125,10 @@ public class QueryManagerNuxeoImpl implements IQueryManager {
 	 * createWhereClauseFromKeywords(java.lang.String)
 	 */
 	@Override
-	public String createWhereClauseFromKeywords(String keywords) {
-		StringBuffer fullTextWhereClause = new StringBuffer();
+	public String createWhereClauseFromKeywords(String keywords, boolean clean) {
+		StringBuilder fullTextWhereClause = new StringBuilder();
 
-		String cleanKeywords = kwdSearchProblemChars.matcher(keywords).replaceAll(" ").trim();
+		String cleanKeywords = clean ? kwdSearchProblemChars.matcher(keywords).replaceAll(" ").trim() : keywords;
 		Matcher regexMatcher = kwdTokenizer.matcher(cleanKeywords);
 
 		boolean addNOT = false;

--- a/services/common/src/main/java/org/collectionspace/services/common/vocabulary/RefNameServiceUtils.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/vocabulary/RefNameServiceUtils.java
@@ -84,20 +84,20 @@ import org.collectionspace.services.nuxeo.util.NuxeoUtils;
  */
 public class RefNameServiceUtils {
 
-    public static enum SpecifierForm {
+    public enum SpecifierForm {
         CSID, URN_NAME // Either a CSID or a short ID
-    };
+    }
 
     public static class Specifier {
         //
         // URN statics for things like urn:cspace:name(grover)
         //
-        final static String URN_PREFIX = "urn:cspace:";
-        final static int URN_PREFIX_LEN = URN_PREFIX.length();
-        final static String URN_PREFIX_NAME = "name(";
-        final static int URN_NAME_PREFIX_LEN = URN_PREFIX_LEN + URN_PREFIX_NAME.length();
-        final static String URN_PREFIX_ID = "id(";
-        final static int URN_ID_PREFIX_LEN = URN_PREFIX_LEN + URN_PREFIX_ID.length();
+        static final String URN_PREFIX = "urn:cspace:";
+        static final int URN_PREFIX_LEN = URN_PREFIX.length();
+        static final String URN_PREFIX_NAME = "name(";
+        static final int URN_NAME_PREFIX_LEN = URN_PREFIX_LEN + URN_PREFIX_NAME.length();
+        static final String URN_PREFIX_ID = "id(";
+        static final int URN_ID_PREFIX_LEN = URN_PREFIX_LEN + URN_PREFIX_ID.length();
 
         public SpecifierForm form;
         public String value;
@@ -379,7 +379,7 @@ public class RefNameServiceUtils {
 	public static List<AuthRefConfigInfo> getConfiguredAuthorityRefs(ServiceContext<PoxPayloadIn, PoxPayloadOut> ctx) {
 		List<String> authRefFields = ((AbstractServiceContextImpl) ctx).getAllPartsPropertyValues(
 				ServiceBindingUtils.AUTH_REF_PROP, ServiceBindingUtils.QUALIFIED_PROP_NAMES);
-		ArrayList<AuthRefConfigInfo> authRefsInfo = new ArrayList<AuthRefConfigInfo>(authRefFields.size());
+		ArrayList<AuthRefConfigInfo> authRefsInfo = new ArrayList<>(authRefFields.size());
 		for (String spec : authRefFields) {
 			AuthRefConfigInfo arci = new AuthRefConfigInfo(spec);
 			authRefsInfo.add(arci);
@@ -405,8 +405,8 @@ public class RefNameServiceUtils {
         List<AuthorityRefDocList.AuthorityRefDocItem> list =
                 wrapperList.getAuthorityRefDocItem();
 
-        Map<String, ServiceBindingType> queriedServiceBindings = new HashMap<String, ServiceBindingType>();
-        Map<String, List<AuthRefConfigInfo>> authRefFieldsByService = new HashMap<String, List<AuthRefConfigInfo>>();
+        Map<String, ServiceBindingType> queriedServiceBindings = new HashMap<>();
+        Map<String, List<AuthRefConfigInfo>> authRefFieldsByService = new HashMap<>();
 
         NuxeoRepositoryClientImpl nuxeoRepoClient = (NuxeoRepositoryClientImpl) repoClient;
         try {
@@ -485,7 +485,7 @@ public class RefNameServiceUtils {
 
     private static ArrayList<String> getRefNameServiceTypes() {
         if (refNameServiceTypes == null) {
-            refNameServiceTypes = new ArrayList<String>();
+            refNameServiceTypes = new ArrayList<>();
             refNameServiceTypes.add(ServiceBindingUtils.SERVICE_TYPE_AUTHORITY);
             refNameServiceTypes.add(ServiceBindingUtils.SERVICE_TYPE_OBJECT);
             refNameServiceTypes.add(ServiceBindingUtils.SERVICE_TYPE_PROCEDURE);
@@ -504,8 +504,8 @@ public class RefNameServiceUtils {
             String oldRefName,
             String newRefName,
             String refPropName) throws Exception {
-        Map<String, ServiceBindingType> queriedServiceBindings = new HashMap<String, ServiceBindingType>();
-        Map<String, List<AuthRefConfigInfo>> authRefFieldsByService = new HashMap<String, List<AuthRefConfigInfo>>();
+        Map<String, ServiceBindingType> queriedServiceBindings = new HashMap<>();
+        Map<String, List<AuthRefConfigInfo>> authRefFieldsByService = new HashMap<>();
 
         int docsScanned = 0;
         int nRefsFound = 0;
@@ -642,7 +642,7 @@ public class RefNameServiceUtils {
         // Filter the list for current user rights
         servicebindings = SecurityUtils.getReadableServiceBindingsForCurrentUser(servicebindings);
 
-        ArrayList<String> docTypes = new ArrayList<String>();
+        ArrayList<String> docTypes = new ArrayList<>();
 
         String query = computeWhereClauseForAuthorityRefDocs(refName, refPropName, docTypes, servicebindings, // REM - Side effect that docTypes, authRefFieldsByService, and queriedServiceBindings get set/change.  Any others?
                 queriedServiceBindings, authRefFieldsByService);
@@ -671,7 +671,7 @@ public class RefNameServiceUtils {
         return docList;
     }
 
-    private static final DocumentModelList findDocs(
+    private static DocumentModelList findDocs(
     		RepositoryClient<PoxPayloadIn, PoxPayloadOut> repoClient,
             ServiceContext<PoxPayloadIn, PoxPayloadOut> ctx,
             CoreSessionInterface repoSession,
@@ -755,7 +755,7 @@ public class RefNameServiceUtils {
             if (authRefFieldPaths.isEmpty()) {
                 continue;
             }
-            ArrayList<AuthRefConfigInfo> authRefsInfo = new ArrayList<AuthRefConfigInfo>();
+            ArrayList<AuthRefConfigInfo> authRefsInfo = new ArrayList<>();
             for (String spec : authRefFieldPaths) {
                 AuthRefConfigInfo arci = new AuthRefConfigInfo(spec);
                 authRefsInfo.add(arci);
@@ -914,7 +914,7 @@ public class RefNameServiceUtils {
                 UriTemplateRegistryKey key = new UriTemplateRegistryKey(tenantId, docType);
                 StoredValuesUriTemplate template = registry.get(key);
                 if (template != null) {
-                    Map<String, String> additionalValues = new HashMap<String, String>();
+                    Map<String, String> additionalValues = new HashMap<>();
                     if (template.getUriTemplateType() == UriTemplateFactory.RESOURCE) {
                         additionalValues.put(UriTemplateFactory.IDENTIFIER_VAR, csid);
                         uri = template.buildUri(additionalValues);
@@ -962,7 +962,7 @@ public class RefNameServiceUtils {
                         "getAuthorityRefDocs: internal logic error: can't fetch authRefFields for DocType.");
             }
 
-            ArrayList<RefNameServiceUtils.AuthRefInfo> foundProps = new ArrayList<RefNameServiceUtils.AuthRefInfo>();
+            ArrayList<RefNameServiceUtils.AuthRefInfo> foundProps = new ArrayList<>();
             try {
                 findAuthRefPropertiesInDoc(docModel, matchingAuthRefFields, refName, matchBaseOnly, foundProps); // REM - side effect that foundProps is set
                 if(!foundProps.isEmpty()) {

--- a/services/common/src/main/java/org/collectionspace/services/common/vocabulary/RefNameServiceUtils.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/vocabulary/RefNameServiceUtils.java
@@ -775,22 +775,21 @@ public class RefNameServiceUtils {
         // we compute actual matches.
         AuthorityTermInfo authTermInfo = RefNameUtils.parseAuthorityTermInfo(refName);
 
-        // Example refname: urn:cspace:pahma.cspace.berkeley.edu:personauthorities:name(person):item:name(ReneRichie1586477168934)
-        // Corresponding phrase: "urn cspace pahma cspace berkeley edu personauthorities name person item name ReneRichie1586477168934
+        // As of Nuxeo LTS 2019, fulltext no longer has punctuation removed and as such when looking for authority
+        // references we want to provide a search string with the authority name, authority vocabulary name, and the
+        // short ID of the authority
+        // e.g.
+        // urn:cspace:pahma.cspace.berkeley.edu:personauthorities:name(person):item:name(ReneRichie1586477168934)
+        // becomes
+        // personauthorities person ReneRichie1586477168934
+        // We also no longer need a phrase search because we would be required to retain punctuation
+        final var refnameQuery = authTermInfo.inAuthority.resource
+                                 + " " + authTermInfo.inAuthority.name
+                                 + " " + authTermInfo.name;
 
-        String refnamePhrase = String.format("urn cspace %s %s name %s item name %s",
-        		RefNameUtils.domainToPhrase(authTermInfo.inAuthority.domain),
-        		authTermInfo.inAuthority.resource,
-        		authTermInfo.inAuthority.name,
-        		authTermInfo.name
-        		);
-        refnamePhrase = String.format("\"%s\"", refnamePhrase); // surround the phase in double quotes to indicate this is a NXQL phrase search
+        String whereClauseStr = QueryManager.createWhereClauseFromKeywords(refnameQuery, false);
 
-        String whereClauseStr = QueryManager.createWhereClauseFromKeywords(refnamePhrase);
-
-        if (logger.isTraceEnabled()) {
-            logger.trace("The 'where' clause to find refObjs is: ", refnamePhrase);
-        }
+        logger.trace("The 'where' clause to find refObjs is: {}", refnameQuery);
 
         return whereClauseStr;
     }


### PR DESCRIPTION
**What does this do?**
* Update fulltext query for authority refs
* Add boolean parameter for toggling cleaning of keywords
* Various cleanup (type inf, modifier sorting, etc)

**Why are we doing this? (with JIRA link)**
https://collectionspace.atlassian.net/browse/DRYD-2101

The way fulltext data is extracted has changed which has caused a few APIs to return incorrect results. This was being caused by assumptions about the structure of the fulltext column and what the data looks like. The update changes how the query is being made to only use the authority, authority instance name, and the short id of the authority. This allows us to still identify specific instances of authorities (e.g. `vocabularies inventorystatus instorage`. 

In addition, by changing from a phrase search to a normal fulltext search, our own query builder was modifying the keywords and changing the structure of the query. This would have an impact on terms like `not_approved` which would become `-approved`. The `clean` parameter was added so that we skip the preprocessing which strips punctuation and searches for additional keywords. It might be worth reviewing our keyword searching to see if we want to make changes to what is allowed again.

**How should this be tested? Do these changes have associated tests?**
* Rebuild and start collectionspace
* Create some procedures and authorities and relate them
* In the authorities, see that the `Terms Used` and `Used By` panels populate appropriately
* When searching, verify that the keyword search returns the expected results

**Dependencies for merging? Releasing to production?**
Might be some follow up tasks for this. Also need to check if the old indexing will continue to work with how the queries have changed.

**Has the application documentation been updated for these changes?**
No. We should check the current keyword search docs to see if anything needs to change.

**Did someone actually run this code to verify it works?**
@mikejritter has been testing locally

**Have any new security vulnerabilities been handled?**
n/a
