### PR TITLE
Update ES Mappings and Analysis config

### DIFF
--- a/3rdparty/nuxeo/nuxeo-server/9.10-HF30/config/proto-elasticsearch-extension.xml
+++ b/3rdparty/nuxeo/nuxeo-server/9.10-HF30/config/proto-elasticsearch-extension.xml
@@ -56,9 +56,9 @@
               "type": "path_hierarchy"
             },
             "ngram_tokenizer": {
-              "type": "nGram",
+              "type": "ngram",
               "min_gram": 3,
-              "max_gram": 12
+              "max_gram": 3
             }
           },
           "analyzer": {
@@ -137,9 +137,6 @@
         // index as small as possible. We may want to turn this on in the future, to support arbitrary
         // searches through Elasticsearch, e.g. NXQL queries for ad hoc reporting in the CSpace UI.
         "dynamic": false,
-        "_all": {
-          "enabled": false
-        },
         "properties": {
           "all_field": {
             "type": "text",

--- a/services/common/src/main/cspace/config/services/tenants/anthro/anthro-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/anthro/anthro-tenant-bindings.delta.xml
@@ -44,9 +44,6 @@
 					// index as small as possible. We may want to turn this on in the future, to support arbitrary
 					// searches through Elasticsearch, e.g. NXQL queries for ad hoc reporting in the CSpace UI.
 					"dynamic": false,
-					"_all" : {
-						"enabled": false
-					},
 					"_source": {
 						"includes": [
 							"collectionobjects_common:briefDescriptions",

--- a/services/common/src/main/cspace/config/services/tenants/bonsai/bonsai-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/bonsai/bonsai-tenant-bindings.delta.xml
@@ -15,9 +15,6 @@
 					// index as small as possible. We may want to turn this on in the future, to support arbitrary
 					// searches through Elasticsearch, e.g. NXQL queries for ad hoc reporting in the CSpace UI.
 					"dynamic": false,
-					"_all" : {
-						"enabled": false
-					},
 					"_source": {
 						"includes": [
 							"collectionobjects_common:briefDescriptions",

--- a/services/common/src/main/cspace/config/services/tenants/fcart/fcart-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/fcart/fcart-tenant-bindings.delta.xml
@@ -24,9 +24,6 @@
 					// index as small as possible. We may want to turn this on in the future, to support arbitrary
 					// searches through Elasticsearch, e.g. NXQL queries for ad hoc reporting in the CSpace UI.
 					"dynamic": false,
-					"_all" : {
-						"enabled": false
-					},
 					"_source": {
 						"includes": [
 							"collectionobjects_common:briefDescriptions",

--- a/services/common/src/main/cspace/config/services/tenants/lhmc/lhmc-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/lhmc/lhmc-tenant-bindings.delta.xml
@@ -15,9 +15,6 @@
 					// index as small as possible. We may want to turn this on in the future, to support arbitrary
 					// searches through Elasticsearch, e.g. NXQL queries for ad hoc reporting in the CSpace UI.
 					"dynamic": false,
-					"_all" : {
-						"enabled": false
-					},
 					"_source": {
 						"includes": [
 							"collectionobjects_common:briefDescriptions",

--- a/services/common/src/main/cspace/config/services/tenants/materials/materials-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/materials/materials-tenant-bindings.delta.xml
@@ -19,9 +19,6 @@
                 // index as small as possible. We may want to turn this on in the future, to support arbitrary
                 // searches through Elasticsearch, e.g. NXQL queries for ad hoc reporting in the CSpace UI.
                 "dynamic": false,
-                "_all" : {
-                  "enabled": false
-                },
                 "_source": {
                   "includes": [
                     "collectionspace_denorm:*",

--- a/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
+++ b/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
@@ -1174,9 +1174,6 @@
 					// index as small as possible. We may want to turn this on in the future, to support arbitrary
 					// searches through Elasticsearch, e.g. NXQL queries for ad hoc reporting in the CSpace UI.
 					"dynamic": false,
-					"_all" : {
-						"enabled": false
-					},
 					"_source": {
 						"includes": [
 							"collectionobjects_common:briefDescriptions",


### PR DESCRIPTION
**What does this do?**
* Remove _all meta field
* Change nGram token filter to ngram

**Why are we doing this? (with JIRA link)**
Part of https://collectionspace.atlassian.net/browse/DRYD-2111 but not a full test. I wanted to make sure that our deployment will start when ElasticSearch is enabled.

Relevant ES docs:
* _all meta removal - https://www.elastic.co/guide/en/elasticsearch/reference/7.0/breaking-changes-7.0.html#all-meta-field-removed
* nGram token filter - https://www.elastic.co/guide/en/elasticsearch/reference/7.0/breaking-changes-7.0.html#deprecated-ngram-edgengram-token-filter-cannot-be-used

**How should this be tested? Do these changes have associated tests?**
* Rebuild cspace to get the updated config
* Set `elasticsearch.enabled` to `true` before starting CollectionSpace
* See that the index is created and the ES component starts

**Dependencies for merging? Releasing to production?**
We should go through both the mapping and analysis settings again to see if there are any other changes we need to make.

**Has the application documentation been updated for these changes?**
If we have ES configuration we will need to update it.

**Did someone actually run this code to verify it works?**
@mikejritter tested using ES 7.17.29

**Have any new security vulnerabilities been handled?**
n/a
