### PR TITLE
No Jira: Disable DTD when Parsing XML

### DIFF
--- a/services/client/src/main/java/org/collectionspace/services/client/PoxPayload.java
+++ b/services/client/src/main/java/org/collectionspace/services/client/PoxPayload.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -15,6 +16,8 @@ import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamReader;
 import javax.xml.transform.stream.StreamSource;
 
 import com.sun.xml.bind.api.impl.NameConverter;
@@ -29,8 +32,8 @@ import org.dom4j.Namespace;
 import org.dom4j.io.SAXReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
 
-// TODO: Auto-generated Javadoc
 /**
  * The Class PoxPayload.
  *
@@ -81,8 +84,19 @@ public abstract class PoxPayload<PT extends PayloadPart> {
 		return validRootElementLabels;
 	}
 
-	private void setDomDocument(Document dom) throws DocumentException {
-		this.domDocument = dom;
+	private void setDomDocument(final String xmlPayload) throws DocumentException {
+		SAXReader reader = new SAXReader();
+		try {
+			reader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+			reader.setFeature("http://xml.org/sax/features/external-general-entities", false);
+			reader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+		} catch (SAXException saxException) {
+			final String error = "Unable to disable Doctype features, aborting document read";
+			logger.error(error, saxException);
+			throw new DocumentException(error);
+		}
+
+        this.domDocument = reader.read(new StringReader(xmlPayload));
 		this.parts = null;
 
 		String label = domDocument.getRootElement().getName().toLowerCase();
@@ -141,13 +155,11 @@ public abstract class PoxPayload<PT extends PayloadPart> {
 	 * Instantiates a new PoxPayload by parsing the payload into a DOM4j
 	 * Document instance
 	 *
-	 * @param payloadName the payload name
+	 * @param xmlPayload the payload
 	 */
 	protected PoxPayload(String xmlPayload) throws DocumentException {
 		this.xmlPayload = xmlPayload;
-		SAXReader reader = new SAXReader();
-		Document dom  = reader.read(new StringReader(xmlPayload));
-		setDomDocument(dom);
+		setDomDocument(xmlPayload);
 	}
 
     /**
@@ -158,10 +170,8 @@ public abstract class PoxPayload<PT extends PayloadPart> {
      * @throws IOException Signals that an I/O exception has occurred.
      */
     protected PoxPayload(File file) throws DocumentException, IOException {
-    	this.xmlPayload = FileUtils.readFileToString(file);
-        SAXReader reader = new SAXReader();
-        Document dom = reader.read(file);
-		setDomDocument(dom);
+    	this.xmlPayload = FileUtils.readFileToString(file, Charset.defaultCharset());
+		setDomDocument(xmlPayload);
     }
 
 	/**
@@ -365,7 +375,11 @@ public abstract class PoxPayload<PT extends PayloadPart> {
 		public static Object toObject(Element elementInput) {
 			Object result = null;
 
+
 			try {
+				final XMLInputFactory xmlInputFactory = XMLInputFactory.newFactory();
+				xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+				xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
 				Namespace namespace = elementInput.getNamespace();
 
 				if (StringUtils.isNotEmpty(namespace.getURI())) {
@@ -373,13 +387,12 @@ public abstract class PoxPayload<PT extends PayloadPart> {
 					JAXBContext jc = JAXBContext.newInstance(thePackage);
 					Unmarshaller um = jc.createUnmarshaller();
 
-					result = um.unmarshal(new StreamSource(new StringReader(elementInput.asXML())));
+					XMLStreamReader xmlStream = xmlInputFactory.createXMLStreamReader(
+						new StreamSource(new StringReader(elementInput.asXML())));
+					result = um.unmarshal(xmlStream);
 				}
 			} catch (Exception e) {
-				if (logger.isInfoEnabled()) {
-					String msg = String.format("Could not unmarshal XML element '%s' into a JAXB object.", elementInput.getName());
-					logger.info(msg);
-				}
+				logger.error("Could not unmarshal XML element '{}' into a JAXB object.", elementInput.getName(), e);
 			}
 
 			return result;
@@ -412,9 +425,7 @@ public abstract class PoxPayload<PT extends PayloadPart> {
     		Document doc = DocumentHelper.parseText(text);
     		result = doc.getRootElement(); //FIXME: REM - call .detach() to free the element
     	} catch (Exception e) {
-    		String msg = String.format("Could not marshal JAXB object '%s' to an XML element.",
-    				jaxbObject.toString());
-    		logger.error(msg);
+    		logger.error("Could not marshal JAXB object '{}' to an XML element.", jaxbObject, e);
     	}
 
     	return result;


### PR DESCRIPTION
**What does this do?**
This cherry picks commit 5ecf54a into main

**Why are we doing this? (with JIRA link)**
No jira. This disables the Doctype declaration on XML preventing external entities from being loaded.

**How should this be tested? Do these changes have associated tests?**
* Rebuild and start
  * Reminder: this is the current release which uses JDK 8
* Try to POST or PUT to the collectionspace API with XML that includes a doctype declaration, e.g.
```
<?xml version="1.0"?>
<!DOCTYPE document []>
<document>
  <ns2:collectionobjects_common xmlns:ns2="http://collectionspace.org/services/collectionobject">
    <objectNumber>2027.0.1</objectNumber>
  </ns2:collectionobjects_common>
</document>
```
* See that server rejects the request

**Dependencies for merging? Releasing to production?**
This includes the version bump for 8.3.1 so maybe #538 should be merged first. We might also want to create a ticket for creating tests for this. Although the manual check is fine, something more comprehensive would probably be good.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally

**Have any new security vulnerabilities been handled?**
This handles the same vuln from #535 