### PR TITLE
DRYD-2073: Object Record > All Profiles > Add Home Location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CollectionSpace Services Changelog
 
+## 9.0.0
+* Add home location to collectionobject schema and advanced search
+
 ## 8.3.0
 
 * Add new endpoint for returning search results

--- a/services/advancedsearch/jaxb/src/main/java/org/collectionspace/services/advancedsearch/model/HomeLocationListModel.java
+++ b/services/advancedsearch/jaxb/src/main/java/org/collectionspace/services/advancedsearch/model/HomeLocationListModel.java
@@ -1,0 +1,32 @@
+package org.collectionspace.services.advancedsearch.model;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.collectionspace.services.advancedsearch.HomeLocations;
+import org.collectionspace.services.advancedsearch.ObjectFactory;
+import org.collectionspace.services.collectionobject.CollectionobjectsCommon;
+import org.collectionspace.services.collectionobject.HomeLocationGroup;
+
+public class HomeLocationListModel {
+
+	public static HomeLocations homeLocationList(CollectionobjectsCommon collectionObject) {
+		HomeLocations homeLocations = null;
+		final ObjectFactory objectFactory = new ObjectFactory();
+
+		if (collectionObject != null && collectionObject.getHomeLocationGroupList() != null) {
+			List<String> locations = collectionObject.getHomeLocationGroupList().getHomeLocationGroup().stream()
+					.filter(group -> group != null && group.getHomeLocation() != null
+							&& !group.getHomeLocation().isEmpty())
+					.map(HomeLocationGroup::getHomeLocation)
+					.collect(Collectors.toList());
+
+			if (!locations.isEmpty()) {
+				homeLocations = objectFactory.createHomeLocations();
+				homeLocations.getHomeLocation().addAll(locations);
+			}
+		}
+
+		return homeLocations;
+	}
+}

--- a/services/advancedsearch/jaxb/src/main/resources/advanced-search_common.xsd
+++ b/services/advancedsearch/jaxb/src/main/resources/advanced-search_common.xsd
@@ -37,6 +37,12 @@
     </xs:sequence>
   </xs:complexType>
 
+  <xs:complexType name="homeLocations">
+    <xs:sequence>
+      <xs:element name="homeLocation" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
   <xs:element name="advancedsearch-common-list">
     <xs:complexType>
       <xs:complexContent>
@@ -55,6 +61,7 @@
                   <xs:element name="objectNumber" type="xs:string" nillable="true"/>
                   <xs:element name="title" type="xs:string" nillable="true"/>
                   <xs:element name="computedCurrentLocation" type="xs:string" nillable="true"/>
+                  <xs:element name="homeLocations" type="homeLocations" nillable="true"/>
                   <xs:element name="responsibleDepartment" type="xs:string" nillable="true"/>
                   <xs:element name="briefDescription" type="xs:string" nillable="true"/>
 

--- a/services/advancedsearch/service/src/main/java/org/collectionspace/services/advancedsearch/AdvancedSearch.java
+++ b/services/advancedsearch/service/src/main/java/org/collectionspace/services/advancedsearch/AdvancedSearch.java
@@ -45,7 +45,7 @@ import org.w3c.dom.Element;
 public class AdvancedSearch
 		extends AbstractCollectionSpaceResourceImpl<AdvancedsearchListItem, AdvancedsearchListItem> {
 	// FIXME: it's not great to hardcode either of these
-	private static final String FIELDS_RETURNED = "uri|csid|refName|blobCsid|updatedAt|objectId|objectNumber|objectName|title|computedCurrentLocation|responsibleDepartments|responsibleDepartment|contentConcepts|briefDescription";
+	private static final String FIELDS_RETURNED = "uri|csid|refName|blobCsid|updatedAt|objectId|objectNumber|objectName|title|computedCurrentLocation|homeLocationGroupList|homeLocations|responsibleDepartments|responsibleDepartment|contentConcepts|briefDescription";
 
 	private final Logger logger = LoggerFactory.getLogger(AdvancedSearch.class);
 	private final CollectionObjectResource cor = new CollectionObjectResource();

--- a/services/advancedsearch/service/src/main/java/org/collectionspace/services/advancedsearch/AdvancedSearch.java
+++ b/services/advancedsearch/service/src/main/java/org/collectionspace/services/advancedsearch/AdvancedSearch.java
@@ -45,7 +45,7 @@ import org.w3c.dom.Element;
 public class AdvancedSearch
 		extends AbstractCollectionSpaceResourceImpl<AdvancedsearchListItem, AdvancedsearchListItem> {
 	// FIXME: it's not great to hardcode either of these
-	private static final String FIELDS_RETURNED = "uri|csid|refName|blobCsid|updatedAt|objectId|objectNumber|objectName|title|computedCurrentLocation|homeLocationGroupList|homeLocations|responsibleDepartments|responsibleDepartment|contentConcepts|briefDescription";
+	private static final String FIELDS_RETURNED = "uri|csid|refName|blobCsid|updatedAt|objectId|objectNumber|objectName|title|computedCurrentLocation|homeLocations|responsibleDepartments|responsibleDepartment|contentConcepts|briefDescription";
 
 	private final Logger logger = LoggerFactory.getLogger(AdvancedSearch.class);
 	private final CollectionObjectResource cor = new CollectionObjectResource();

--- a/services/advancedsearch/service/src/main/java/org/collectionspace/services/advancedsearch/mapper/CollectionObjectMapper.java
+++ b/services/advancedsearch/service/src/main/java/org/collectionspace/services/advancedsearch/mapper/CollectionObjectMapper.java
@@ -17,6 +17,7 @@ import org.collectionspace.services.advancedsearch.model.AgentModel;
 import org.collectionspace.services.advancedsearch.model.BriefDescriptionListModel;
 import org.collectionspace.services.advancedsearch.model.ContentConceptListModel;
 import org.collectionspace.services.advancedsearch.model.FieldCollectionModel;
+import org.collectionspace.services.advancedsearch.model.HomeLocationListModel;
 import org.collectionspace.services.advancedsearch.model.MaterialModel;
 import org.collectionspace.services.advancedsearch.model.NAGPRACategoryModel;
 import org.collectionspace.services.advancedsearch.model.ObjectNameListModel;
@@ -111,6 +112,7 @@ public class CollectionObjectMapper {
             item.setBriefDescription(BriefDescriptionListModel.briefDescriptionListToDisplayString(
                     collectionObject.getBriefDescriptions()));
             item.setComputedCurrentLocation(collectionObject.getComputedCurrentLocation());
+            item.setHomeLocations(HomeLocationListModel.homeLocationList(collectionObject));
 
             item.setTitle(TitleGroupListModel.titleGroupListToDisplayString(collectionObject.getTitleGroupList()));
             item.setResponsibleDepartment(

--- a/services/collectionobject/jaxb/src/main/resources/collectionobjects_common.xsd
+++ b/services/collectionobject/jaxb/src/main/resources/collectionobjects_common.xsd
@@ -49,6 +49,7 @@
                 <xs:element name="titleGroupList" type="titleGroupList"/>
                 <xs:element name="recordStatus" type="xs:string"/>
                 <xs:element name="computedCurrentLocation" type="xs:string"/>
+                <xs:element name="homeLocationGroupList" type="homeLocationGroupList"/>
 
                 <!-- Object Description Information -->
                 <xs:element name="age" type="xs:integer"/>
@@ -460,6 +461,19 @@
     <xs:complexType name="formList">
         <xs:sequence>
             <xs:element name="form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="homeLocationGroupList">
+        <xs:sequence>
+            <xs:element name="homeLocationGroup" type="homeLocationGroup" minOccurs="0"
+                maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="homeLocationGroup">
+        <xs:sequence>
+            <xs:element name="homeLocation" type="xs:string"/>
+            <xs:element name="homeLocationNote" type="xs:string"/>
         </xs:sequence>
     </xs:complexType>
 


### PR DESCRIPTION
**What does this do?**
It adds a repeatable `homeLocationGroupList` to the collectionobject common schema. So that it is available in advanced search results and it can be displayed alongside the computed current location.

**Why are we doing this? (with JIRA link)**
We need to add a repeating group of `homeLocation` and `homeLocationNote` fields along the `computedCurrentLocation` field. We also need to display all the home locations in the advanced search results. https://collectionspace.atlassian.net/browse/DRYD-2073

**How should this be tested? Do these changes have associated tests?**
Please follow the steps in the PR: https://github.com/collectionspace/cspace-ui.js/pull/355

**Dependencies for merging? Releasing to production?**
The following PRs should be released along: 
https://github.com/collectionspace/application/pull/352
https://github.com/collectionspace/cspace-ui.js/pull/355
https://github.com/collectionspace/cspace-ui-plugin-profile-anthro.js/pull/44
https://github.com/collectionspace/cspace-ui-plugin-profile-fcart.js/pull/33
https://github.com/collectionspace/cspace-ui-plugin-profile-lhmc.js/pull/34
https://github.com/collectionspace/cspace-ui-plugin-profile-materials.js/pull/22
https://github.com/collectionspace/cspace-ui-plugin-profile-publicart.js/pull/35

**Has the application documentation been updated for these changes?**
The changelog has been updated.

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally

**Have any new security vulnerabilities been handled?**
no new vulnerabilities introduced
