### PR TITLE
DRYD-2123   Nuxeo > Corrupted jars make build fail silently

### DIFF
--- a/3rdparty/nuxeo/nuxeo-server/pom.xml
+++ b/3rdparty/nuxeo/nuxeo-server/pom.xml
@@ -16,16 +16,16 @@
 
   <repositories>
     <repository>
-      <id>nuxeo-public-releases</id>
-      <url>https://maven-eu.nuxeo.org/nexus/content/repositories/public-releases</url>
+      <id>cspace-nuxeo-public-releases</id>
+      <url>https://cspace-maven-repo.s3-us-west-2.amazonaws.com/nuxeo/public-releases</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
     </repository>
 
     <repository>
-      <id>nuxeo-vendor-releases</id>
-      <url>https://maven-eu.nuxeo.org/nexus/content/repositories/vendor-releases</url>
+      <id>cspace-nuxeo-vendor-releases</id>
+      <url>https://cspace-maven-repo.s3-us-west-2.amazonaws.com/nuxeo/vendor-releases</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CollectionSpace Services Changelog
 
+## 8.3.2
+
+### Bug Fixes
+
+* Fix Nuxeo embedded server failing to start (ZipException / missing hibernate-core) by pointing the nuxeo-server module at the cspace S3 Maven mirror instead of the legacy maven-eu.nuxeo.org repo
+
 ## 8.3.0
 
 * Add new endpoint for returning search results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@
 
 ### Bug Fixes
 
-* Fix Nuxeo embedded server failing to start (ZipException / missing hibernate-core) by pointing the nuxeo-server module at the cspace S3 Maven mirror instead of the legacy maven-eu.nuxeo.org repo
+* Fix Nuxeo embedded server failing to start (ZipException / missing hibernate-core) by pointing the nuxeo-server module at the cspace S3 Maven mirror instead of the legacy maven-eu.nuxeo.org repo.
+
+## 8.3.1
+
+### Security
+* Disable Doctype declaration on XML preventing external entities from being loaded.
 
 ## 8.3.0
 


### PR DESCRIPTION
**What does this do?**
It replaces dead Nuxeo public/vendor release repos with cspace S3 mirror in nuxeo-server pom.

**Why are we doing this? (with JIRA link)**
https://collectionspace.atlassian.net/browse/DRYD-2123

**How should this be tested? Do these changes have associated tests?**
1. Please purge your local m2 cache
2. Clear the previously-deployed Nuxeo bundles/lib in Tomcat: `rm -rf "$CSPACE_JEESERVER_HOME/nuxeo-server/bundles"/* "$CSPACE_JEESERVER_HOME/nuxeo-server/lib"/*`
3. Rebuild and redeploy

Confirm that services start normal, the `java.util.zip.ZipException: error in opening zip file` runtime error should be gone.

**Dependencies for merging? Releasing to production?**
No dependencies

**Has the application documentation been updated for these changes?**
Changelog has been updated

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally

**Have any new security vulnerabilities been handled?**
no new security vulnerabilities
