### PR TITLE
DRYD-2122: Disable CORS for SAML endpoints

### DIFF
--- a/services/common/src/main/java/org/collectionspace/services/common/security/SecurityConfig.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/security/SecurityConfig.java
@@ -192,7 +192,7 @@ public class SecurityConfig {
 		if (relyingPartyRegistrationRepository != null && this.samlCorsConfigurations == null) {
 			// Automatically add SAML providers as allowed origins for SAML response endpoints.
 
-			this.samlCorsConfigurations = samlCorsConfigurations(relyingPartyRegistrationRepository, allowedOrigins, maxAge);
+			this.samlCorsConfigurations = samlCorsConfigurations(relyingPartyRegistrationRepository, maxAge);
 		}
 	}
 
@@ -254,7 +254,6 @@ public class SecurityConfig {
 	 */
 	private Map<String, CorsConfiguration> samlCorsConfigurations(
 		RelyingPartyRegistrationRepository relyingPartyRegistrationRepository,
-		List<String> allowedOrigins,
 		Duration maxAge)
 	{
 		ServiceConfig serviceConfig = ServiceMain.getInstance().getServiceConfig();
@@ -262,8 +261,6 @@ public class SecurityConfig {
 		Map<String, CorsConfiguration> corsConfigurations = new LinkedHashMap<>();
 
 		if (relyingPartiesConfig != null) {
-			List<String> providerOrigins = new ArrayList<>();
-
 			for (final SAMLRelyingPartyType relyingPartyConfig : relyingPartiesConfig) {
 				String id = relyingPartyConfig.getId();
 				RelyingPartyRegistration registration = relyingPartyRegistrationRepository.findByRegistrationId(id);
@@ -282,20 +279,16 @@ public class SecurityConfig {
 				if (providerUrl != null) {
 					CorsConfiguration configuration = new CorsConfiguration();
 					String responseUrl = "/login/saml2/sso/" + id;
-					String providerOrigin = providerUrl.getProtocol() + "://" + providerUrl.getAuthority();
 
-					providerOrigins.add(providerOrigin);
-
-					configuration.setAllowedOrigins(allowedOrigins);
-					configuration.addAllowedOrigin(providerOrigin);
+					// allow all origins for the sso login in order to let the idp control the cors settings
+					// and send a different origin if it is configured to
+					configuration.addAllowedOrigin("*");
 
 					if (maxAge != null) {
 						configuration.setMaxAge(maxAge);
 					}
 
-					configuration.setAllowedMethods(Arrays.asList(
-						HttpMethod.POST.toString()
-					));
+					configuration.setAllowedMethods(Arrays.asList(HttpMethod.POST.toString()));
 
 					corsConfigurations.put(responseUrl, configuration);
 				}
@@ -305,19 +298,14 @@ public class SecurityConfig {
 					CorsConfiguration configuration = new CorsConfiguration();
 					String responseUrl = "/logout/saml2/slo";
 
-					configuration.setAllowedOrigins(allowedOrigins);
-
-					for (String providerOrigin : providerOrigins) {
-						configuration.addAllowedOrigin(providerOrigin);
-					}
+					// same as for login
+					configuration.addAllowedOrigin("*");
 
 					if (maxAge != null) {
 						configuration.setMaxAge(maxAge);
 					}
 
-					configuration.setAllowedMethods(Arrays.asList(
-						HttpMethod.POST.toString()
-					));
+					configuration.setAllowedMethods(Arrays.asList(HttpMethod.POST.toString()));
 
 					corsConfigurations.put(responseUrl, configuration);
 			}


### PR DESCRIPTION
**What does this do?**
This uses a wildcard to disable cors so that IdPs can send different origins to cspace-services backend when performing sso.

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-2122

This is effecting SSO for one of the hosted clients where their IdP is sending an Origin header which is not allowed by the CORS settings of the server. This prevents the SSO login flow from completing.

**How should this be tested? Do these changes have associated tests?**
* Follow the steps in the `SSO Testing` wiki page to setup an Auth0 instance (or use my configuration which I've added to the page)
  * I'm working on getting Keycloak to work locally as well. I ran into some issues and wanted to get this PR ready so I used Auth0.
* Rebuild CollectionSpace with this PR
* Add your `service-config-sso.xml` into the `local` cspace config directory.
* Start CollectionSpace
* For the endpoint which your SSO configuration is setup for, try the login and a non-4xx (specifically non-403 but a 401 also should not be returned) response
  * Note: the second curl exec here uses a host which resolves locally for me and should be replaced with something else
```
$ curl -i -X POST 'http://localhost:8180/cspace-services/login/saml2/sso/dev-auth0' \
 -H 'Origin: http://localhost:8080' \
 -H 'Content-Type: application/x-www-form-urlencoded' \
 --data 'SAMLResponse=x'
$ curl -i -X POST 'http://localhost:8180/cspace-services/login/saml2/sso/dev-auth0' \
 -H 'Origin: http://collectionspace.lan' \
 -H 'Content-Type: application/x-www-form-urlencoded' \
 --data 'SAMLResponse=x'
```
* The Single Logout endpoint should be tested as well, as the IdP might be configured to redirect to it on logout (though tbh I don't know if the origin header would apply here). This is harder to check validity of so a non `403` response is ok.
```
$ curl -i -X POST 'http://localhost:8180/cspace-services/logout/saml2/slo' \
 -H 'Origin: http://localhost:8080' \
 -H 'Content-Type: application/x-www-form-urlencoded' \
 --data 'SAMLResponse=x'
$ curl -i -X POST 'http://localhost:8180/cspace-services/logout/saml2/slo' \
 -H 'Origin: http://collectionspace.lan' \
 -H 'Content-Type: application/x-www-form-urlencoded' \
 --data 'SAMLResponse=x'
```

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
SSO or CORS documentation could potentially be updated. 

**Did someone actually run this code to verify it works?**
@mikejritter tested locally... though against dev.

**Have any new security vulnerabilities been handled?**
n/a
