### PR TITLE
no-jira: changed tenant.ui.profile.plugin build branch to develop;

### DIFF
--- a/cspace-ui/anthro/build.properties
+++ b/cspace-ui/anthro/build.properties
@@ -4,7 +4,7 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-anthro
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileAnthro
 tenant.ui.profile.plugin.version=9.2
-tenant.ui.profile.plugin.build.branch=main
+tenant.ui.profile.plugin.build.branch=develop
 
 # If not set, defaults to /gateway/${tenant.shortname} on the current host.
 # tenant.public.browser.gateway.url=https://core.dev.collectionspace.org/gateway/${tenant.shortname}

--- a/cspace-ui/bonsai/build.properties
+++ b/cspace-ui/bonsai/build.properties
@@ -4,7 +4,7 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-bonsai
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileBonsai
 tenant.ui.profile.plugin.version=7.1
-tenant.ui.profile.plugin.build.branch=main
+tenant.ui.profile.plugin.build.branch=develop
 
 # If not set, defaults to /gateway/${tenant.shortname} on the current host.
 # tenant.public.browser.gateway.url=https://core.dev.collectionspace.org/gateway/${tenant.shortname}

--- a/cspace-ui/botgarden/build.properties
+++ b/cspace-ui/botgarden/build.properties
@@ -4,7 +4,7 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-botgarden
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileBotGarden
 tenant.ui.profile.plugin.version=4.0
-tenant.ui.profile.plugin.build.branch=main
+tenant.ui.profile.plugin.build.branch=develop
 
 # If not set, defaults to /gateway/${tenant.shortname} on the current host.
 # tenant.public.browser.gateway.url=https://core.dev.collectionspace.org/gateway/${tenant.shortname}

--- a/cspace-ui/fcart/build.properties
+++ b/cspace-ui/fcart/build.properties
@@ -4,7 +4,7 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-fcart
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileFCart
 tenant.ui.profile.plugin.version=8.2
-tenant.ui.profile.plugin.build.branch=main
+tenant.ui.profile.plugin.build.branch=develop
 
 # If not set, defaults to /gateway/${tenant.shortname} on the current host.
 # tenant.public.browser.gateway.url=https://core.dev.collectionspace.org/gateway/${tenant.shortname}

--- a/cspace-ui/herbarium/build.properties
+++ b/cspace-ui/herbarium/build.properties
@@ -4,7 +4,7 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-herbarium
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileHerbarium
 tenant.ui.profile.plugin.version=3.0
-tenant.ui.profile.plugin.build.branch=main
+tenant.ui.profile.plugin.build.branch=develop
 
 # If not set, defaults to /gateway/${tenant.shortname} on the current host.
 # tenant.public.browser.gateway.url=https://core.dev.collectionspace.org/gateway/${tenant.shortname}

--- a/cspace-ui/lhmc/build.properties
+++ b/cspace-ui/lhmc/build.properties
@@ -4,7 +4,7 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-lhmc
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileLHMC
 tenant.ui.profile.plugin.version=8.2
-tenant.ui.profile.plugin.build.branch=main
+tenant.ui.profile.plugin.build.branch=develop
 
 # If not set, defaults to /gateway/${tenant.shortname} on the current host.
 # tenant.public.browser.gateway.url=https://core.dev.collectionspace.org/gateway/${tenant.shortname}

--- a/cspace-ui/materials/build.properties
+++ b/cspace-ui/materials/build.properties
@@ -4,7 +4,7 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-materials
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileMaterials
 tenant.ui.profile.plugin.version=4.1
-tenant.ui.profile.plugin.build.branch=main
+tenant.ui.profile.plugin.build.branch=develop
 
 # If not set, defaults to /gateway/${tenant.shortname} on the current host.
 # tenant.public.browser.gateway.url=https://core.dev.collectionspace.org/gateway/${tenant.shortname}

--- a/cspace-ui/publicart/build.properties
+++ b/cspace-ui/publicart/build.properties
@@ -4,7 +4,7 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-publicart
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfilePublicArt
 tenant.ui.profile.plugin.version=7.1
-tenant.ui.profile.plugin.build.branch=main
+tenant.ui.profile.plugin.build.branch=develop
 
 # If not set, defaults to /gateway/${tenant.shortname} on the current host.
 # tenant.public.browser.gateway.url=https://core.dev.collectionspace.org/gateway/${tenant.shortname}


### PR DESCRIPTION
**What does this do?**
It changes the `tenant.ui.profile.plugin.build.branch` build property to `develop` from `main` for all the profiles.

**Why are we doing this? (with JIRA link)**
Now the new ui profile plugin patch versions are getting released automatically. So for all the ui profile plugin repos, we need a ready-to-release `main` branch and a `develop` one for the development work. Similar to the cspace-ui. We also need to build the `develop` branch instead of the `main` branch when deploying with `CSPACE_UI_BUILD` env var set to true. 

**How should this be tested? Do these changes have associated tests?**
Locally, please set the `CSPACE_UI_BUILD` env var to `true`. Then build and deploy. Confirm that the build is green and when opening the different http://localhost:8180/cspace/{profile}/welcome screens, the UI version commit is set to the one last pushed to the `develop` branch (for the botgarden, herbarium and bonsai the commit is the same in both `main` and `develop` branch). Please check all the profiles:
- anthro
- publicart
- materials
- lhmc
- fcart
- botgarden
- herbarium
- bonsai

**Dependencies for merging? Releasing to production?**
No dependencies

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally

**Have any new security vulnerabilities been handled?**
N/A
