### PR TITLE
DRYD-2124: Set Release to JDK 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<cspace.services.version>${revision}</cspace.services.version>
 		<cspace.services.client.version>${revision}</cspace.services.client.version>
-		<java.version>17</java.version>
+		<java.version>21</java.version>
 		<tomcat.version>9.0.99</tomcat.version>
 
 		<!-- CSpace managed dependencies -->


### PR DESCRIPTION
**What does this do?**
Sets the release to target JDK 21

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-2124

As part of the upgrade we wanted to see what version of the JDK we should land on. After research and some testing we decided on JDK 21.

**How should this be tested? Do these changes have associated tests?**
* Rebuild the project with JDK 21 w/ the changes in https://github.com/collectionspace/application/pull/354
* Deploy CollectionSpace
* Use the application to some extent

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
The release/build docs need to be updated

**Did someone actually run this code to verify it works?**
@mikejritter is currently running the integration tests...

**Have any new security vulnerabilities been handled?**
n/a
