### PR TITLE
DRYD-2117: Procedure/Object > Ability to set Priority Image

### DIFF
--- a/3rdparty/nuxeo/nuxeo-platform-elasticsearch/src/main/java/org/collectionspace/services/nuxeo/elasticsearch/DefaultESDocumentWriter.java
+++ b/3rdparty/nuxeo/nuxeo-platform-elasticsearch/src/main/java/org/collectionspace/services/nuxeo/elasticsearch/DefaultESDocumentWriter.java
@@ -59,7 +59,7 @@ public class DefaultESDocumentWriter extends JsonESDocumentWriter {
 			denormConceptFields(doc, denormValues);
 			denormMaterialFields(doc, denormValues);
 			denormObjectNameFields(doc, denormValues);
-			denormPriorityImageList(doc, session, tenantId, denormValues);
+			denormMediaPriorityList(doc, session, tenantId, denormValues);
 
 			// Compute the title of the record for the public browser, and store it so that it can
 			// be used for sorting ES query results.
@@ -212,7 +212,7 @@ private void denormExhibitionRecords(CoreSession session, String csid, String te
 
 	/**
 	 * Denormalize the csid, blob csid, title, and alt text of each media record referenced by
-	 * the priorityImageList field of a collectionobject, so that the priority/sort
+	 * the mediaPriorityList field of a collectionobject, so that the priority/sort
 	 * order set by the user can be displayed and searched.
 	 *
 	 * @param doc the collectionobject document
@@ -220,17 +220,17 @@ private void denormExhibitionRecords(CoreSession session, String csid, String te
 	 * @param tenantId the tenant id
 	 * @param denormValues the json node for denormalized fields
 	 */
-	private void denormPriorityImageList(DocumentModel doc, CoreSession session, String tenantId, ObjectNode denormValues) {
-		List<String> priorityImageList = (List<String>) doc.getProperty("collectionobjects_common", "priorityImageList");
-		List<JsonNode> priorityImages = new ArrayList<>();
+	private void denormMediaPriorityList(DocumentModel doc, CoreSession session, String tenantId, ObjectNode denormValues) {
+		List<String> mediaPriorityList = (List<String>) doc.getProperty("collectionobjects_common", "mediaPriorityList");
+		List<JsonNode> mediaPriorityNodes = new ArrayList<>();
 
-		if (priorityImageList != null) {
-			for (String priorityImage : priorityImageList) {
-				if (StringUtils.isNotEmpty(priorityImage)) {
+		if (mediaPriorityList != null) {
+			for (String mediaPriority : mediaPriorityList) {
+				if (StringUtils.isNotEmpty(mediaPriority)) {
 					String mediaCsid = null;
 
 					try {
-						mediaCsid = RefNameUtils.parseAuthorityInfo(priorityImage).csid;
+						mediaCsid = RefNameUtils.parseAuthorityInfo(mediaPriority).csid;
 					} catch (IllegalArgumentException e) {
 						// Not a parseable refName; nothing to denormalize for this entry.
 					}
@@ -243,21 +243,21 @@ private void denormExhibitionRecords(CoreSession session, String csid, String te
 							String title = (String) mediaDoc.getProperty("media_common", "title");
 							String altText = (String) mediaDoc.getProperty("media_common", "altText");
 
-							ObjectNode priorityImageNode = objectMapper.createObjectNode();
+							ObjectNode mediaPriorityNode = objectMapper.createObjectNode();
 
-							priorityImageNode.put("csid", mediaCsid);
-							priorityImageNode.put("blobCsid", blobCsid);
-							priorityImageNode.put("title", title);
-							priorityImageNode.put("altText", altText);
+							mediaPriorityNode.put("csid", mediaCsid);
+							mediaPriorityNode.put("blobCsid", blobCsid);
+							mediaPriorityNode.put("title", title);
+							mediaPriorityNode.put("altText", altText);
 
-							priorityImages.add(priorityImageNode);
+							mediaPriorityNodes.add(mediaPriorityNode);
 						}
 					}
 				}
 			}
 		}
 
-		denormValues.putArray("priorityImageList").addAll(priorityImages);
+		denormValues.putArray("mediaPriorityList").addAll(mediaPriorityNodes);
 	}
 
 	/**

--- a/3rdparty/nuxeo/nuxeo-platform-elasticsearch/src/main/java/org/collectionspace/services/nuxeo/elasticsearch/DefaultESDocumentWriter.java
+++ b/3rdparty/nuxeo/nuxeo-platform-elasticsearch/src/main/java/org/collectionspace/services/nuxeo/elasticsearch/DefaultESDocumentWriter.java
@@ -59,6 +59,7 @@ public class DefaultESDocumentWriter extends JsonESDocumentWriter {
 			denormConceptFields(doc, denormValues);
 			denormMaterialFields(doc, denormValues);
 			denormObjectNameFields(doc, denormValues);
+			denormPriorityImageList(doc, session, tenantId, denormValues);
 
 			// Compute the title of the record for the public browser, and store it so that it can
 			// be used for sorting ES query results.
@@ -208,6 +209,56 @@ private void denormExhibitionRecords(CoreSession session, String csid, String te
 
 	denormValues.putArray("exhibition").addAll(exhibitions);
 }
+
+	/**
+	 * Denormalize the csid, blob csid, title, and alt text of each media record referenced by
+	 * the priorityImageList field of a collectionobject, so that the priority/sort
+	 * order set by the user can be displayed and searched.
+	 *
+	 * @param doc the collectionobject document
+	 * @param session the current session
+	 * @param tenantId the tenant id
+	 * @param denormValues the json node for denormalized fields
+	 */
+	private void denormPriorityImageList(DocumentModel doc, CoreSession session, String tenantId, ObjectNode denormValues) {
+		List<String> priorityImageList = (List<String>) doc.getProperty("collectionobjects_common", "priorityImageList");
+		List<JsonNode> priorityImages = new ArrayList<>();
+
+		if (priorityImageList != null) {
+			for (String priorityImage : priorityImageList) {
+				if (StringUtils.isNotEmpty(priorityImage)) {
+					String mediaCsid = null;
+
+					try {
+						mediaCsid = RefNameUtils.parseAuthorityInfo(priorityImage).csid;
+					} catch (IllegalArgumentException e) {
+						// Not a parseable refName; nothing to denormalize for this entry.
+					}
+
+					if (mediaCsid != null) {
+						DocumentModel mediaDoc = getRecordByCsid(session, tenantId, "Media", mediaCsid);
+
+						if (mediaDoc != null && isMediaPublished(mediaDoc)) {
+							String blobCsid = (String) mediaDoc.getProperty("media_common", "blobCsid");
+							String title = (String) mediaDoc.getProperty("media_common", "title");
+							String altText = (String) mediaDoc.getProperty("media_common", "altText");
+
+							ObjectNode priorityImageNode = objectMapper.createObjectNode();
+
+							priorityImageNode.put("csid", mediaCsid);
+							priorityImageNode.put("blobCsid", blobCsid);
+							priorityImageNode.put("title", title);
+							priorityImageNode.put("altText", altText);
+
+							priorityImages.add(priorityImageNode);
+						}
+					}
+				}
+			}
+		}
+
+		denormValues.putArray("priorityImageList").addAll(priorityImages);
+	}
 
 	/**
 	 * Denormalize the material group list for a collectionobject in order to index the controlled or uncontrolled term

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 9.0.0
 * Add home location to collectionobject schema and advanced search
+* Denormalize priority image list
 
 ## 8.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 9.0.0
 * Add home location to collectionobject schema and advanced search
-* Denormalize priority image list
+* Denormalize media priority list
 
 ## 8.3.0
 

--- a/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
+++ b/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
@@ -1201,6 +1201,7 @@
 							"collectionobjects_common:objectStatusList",
 							"collectionobjects_common:otherNumberList",
 							"collectionobjects_common:ownersContributionNote",
+							"collectionobjects_common:priorityImageList",
 							"collectionobjects_common:publishedRelatedLinkGroupList",
 							"collectionobjects_common:publishToList",
 							"collectionobjects_common:responsibleDepartments",
@@ -1416,6 +1417,35 @@
 						"collectionobjects_common:responsibleDepartments": {
 							"type": "keyword",
 							"copy_to": "all_field"
+						},
+						"collectionobjects_common:priorityImageList": {
+							"type": "keyword",
+							"copy_to": "all_field",
+							"fields": {
+								"displayName": {
+									"type": "keyword",
+									"normalizer": "refname_displayname_normalizer"
+								}
+							}
+						},
+						"collectionspace_denorm:priorityImageList": {
+							"type": "object",
+							"properties": {
+								"csid": {
+									"type": "keyword"
+								},
+								"blobCsid": {
+									"type": "keyword"
+								},
+								"title": {
+									"type": "text",
+									"copy_to": "all_field"
+								},
+								"altText": {
+									"type": "text",
+									"copy_to": "all_field"
+								}
+							}
 						},
 						"collectionobjects_common:contentConcepts": {
 							"type": "keyword",

--- a/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
+++ b/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
@@ -1201,7 +1201,7 @@
 							"collectionobjects_common:objectStatusList",
 							"collectionobjects_common:otherNumberList",
 							"collectionobjects_common:ownersContributionNote",
-							"collectionobjects_common:priorityImageList",
+							"collectionobjects_common:mediaPriorityList",
 							"collectionobjects_common:publishedRelatedLinkGroupList",
 							"collectionobjects_common:publishToList",
 							"collectionobjects_common:responsibleDepartments",
@@ -1418,7 +1418,7 @@
 							"type": "keyword",
 							"copy_to": "all_field"
 						},
-						"collectionobjects_common:priorityImageList": {
+						"collectionobjects_common:mediaPriorityList": {
 							"type": "keyword",
 							"copy_to": "all_field",
 							"fields": {
@@ -1428,7 +1428,7 @@
 								}
 							}
 						},
-						"collectionspace_denorm:priorityImageList": {
+						"collectionspace_denorm:mediaPriorityList": {
 							"type": "object",
 							"properties": {
 								"csid": {


### PR DESCRIPTION
**What does this do?**
it adds the `denormPriorityImageList` at the `DefaultESDocumentWriter.java` to denormalize each media record referenced by the `priorityImageList` of collection objects.

**Why are we doing this? (with JIRA link)**
This is part of the https://collectionspace.atlassian.net/browse/DRYD-2117. The `priorityImageList` field is being prepopulated in cspace-ui with the related Media Handling records of a Collection Object. The denormalizer takes care of adding the necessary fields of the published records to the collection object es document so that they can be displayed in the public browser.

**How should this be tested? Do these changes have associated tests?**
Please follow the steps in the cspace-ui PR: https://github.com/collectionspace/cspace-ui.js/pull/360

**Dependencies for merging? Releasing to production?**
It should be released along the:
https://github.com/collectionspace/application/pull/356
https://github.com/collectionspace/cspace-ui.js/pull/360
https://github.com/collectionspace/cspace-public-browser.js/pull/57

**Has the application documentation been updated for these changes?**
Changelog has been updated

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally

**Have any new security vulnerabilities been handled?**
no new security vulnerabilities
