### PR TITLE
NOJIRA: Replace cspace-maven-repo

### DIFF
--- a/3rdparty/nuxeo/nuxeo-server/pom.xml
+++ b/3rdparty/nuxeo/nuxeo-server/pom.xml
@@ -17,7 +17,7 @@
   <repositories>
     <repository>
       <id>cspace-nuxeo-public-releases</id>
-      <url>https://cspace-program-production-cdn-cspace-maven.s3-us-west-2.amazonaws.com/nuxeo/public-releases</url>
+      <url>https://cspace-maven.collectionspace.org/nuxeo/public-releases</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
@@ -25,7 +25,7 @@
 
     <repository>
       <id>cspace-nuxeo-vendor-releases</id>
-      <url>https://cspace-program-production-cdn-cspace-maven.s3-us-west-2.amazonaws.com/nuxeo/vendor-releases</url>
+      <url>https://cspace-maven.collectionspace.org/nuxeo/vendor-releases</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>

--- a/3rdparty/nuxeo/nuxeo-server/pom.xml
+++ b/3rdparty/nuxeo/nuxeo-server/pom.xml
@@ -17,7 +17,7 @@
   <repositories>
     <repository>
       <id>cspace-nuxeo-public-releases</id>
-      <url>https://cspace-maven-repo.s3-us-west-2.amazonaws.com/nuxeo/public-releases</url>
+      <url>https://cspace-program-production-cdn-cspace-maven.s3-us-west-2.amazonaws.com/nuxeo/public-releases</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
@@ -25,38 +25,12 @@
 
     <repository>
       <id>cspace-nuxeo-vendor-releases</id>
-      <url>https://cspace-maven-repo.s3-us-west-2.amazonaws.com/nuxeo/vendor-releases</url>
+      <url>https://cspace-program-production-cdn-cspace-maven.s3-us-west-2.amazonaws.com/nuxeo/vendor-releases</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
     </repository>
   </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>internal-releases</id>
-      <url>https://mavenin.nuxeo.com/nexus/content/groups/internal-releases</url>
-      <name>Nuxeo virtual release repository</name>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </pluginRepository>
-    <pluginRepository>
-      <id>internal-snapshots</id>
-      <url>https://mavenin.nuxeo.com/nexus/content/groups/internal-snapshots</url>
-      <name>Nuxeo virtual snapshot repository</name>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <updatePolicy>always</updatePolicy>
-        <enabled>true</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
 
   <!-- These come from nuxeo-nxr-server as it seemed to match closest to our distribution. A number of dependencies
        have been pruned off as they weren't being used previously. It's possible we could trim this down further but

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
 		<!-- CSpace copy of nuxeo-public-releases repo. -->
 		<repository>
 			<id>cspace-nuxeo-public-releases</id>
-			<url>https://cspace-program-production-cdn-cspace-maven.s3-us-west-2.amazonaws.com/nuxeo/public-releases</url>
+			<url>https://cspace-maven.collectionspace.org/nuxeo/public-releases</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -85,7 +85,7 @@
 		<!-- CSpace copy of nuxeo-vendor-releases repo. -->
 		<repository>
 			<id>cspace-nuxeo-vendor-releases</id>
-			<url>https://cspace-program-production-cdn-cspace-maven.s3-us-west-2.amazonaws.com/nuxeo/vendor-releases</url>
+			<url>https://cspace-maven.collectionspace.org/nuxeo/vendor-releases</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -94,7 +94,7 @@
 		<repository>
 			<id>cspace-libs-release-local</id>
 			<name>cspace-libs-release-local</name>
-			<url>https://cspace-program-production-cdn-cspace-maven.s3-us-west-2.amazonaws.com/libs-release-local</url>
+			<url>https://cspace-maven.collectionspace.org/libs-release-local</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -102,7 +102,7 @@
 		<repository>
 			<id>cspace-libs-snapshot-local</id>
 			<name>cspace-libs-snapshot-local</name>
-			<url>https://cspace-program-production-cdn-cspace-maven.s3-us-west-2.amazonaws.com/libs-snapshot-local</url>
+			<url>https://cspace-maven.collectionspace.org/libs-snapshot-local</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/pom.xml
+++ b/pom.xml
@@ -40,12 +40,12 @@
 		<repository>
 			<id>cspace</id>
 			<name>cspace-libs-release-local</name>
-			<url>s3://cspace-maven-repo/libs-release-local</url>
+			<url>s3://cspace-program-production-cdn-cspace-maven/libs-release-local</url>
 		</repository>
 		<snapshotRepository>
 			<id>cspace</id>
 			<name>cspace-libs-snapshot-local</name>
-			<url>s3://cspace-maven-repo/libs-snapshot-local</url>
+			<url>s3://cspace-program-production-cdn-cspace-maven/libs-snapshot-local</url>
 		</snapshotRepository>
 	</distributionManagement>
 
@@ -73,26 +73,10 @@
 			</snapshots>
 		</repository>
 
-		<!-- <repository>
-			<id>nuxeo-public-releases</id>
-			<url>https://maven-eu.nuxeo.org/nexus/content/repositories/public-releases</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository> -->
-
-		<!-- <repository>
-			<id>nuxeo-vendor-releases</id>
-			<url>https://maven-eu.nuxeo.org/nexus/content/repositories/vendor-releases</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository> -->
-
 		<!-- CSpace copy of nuxeo-public-releases repo. -->
 		<repository>
 			<id>cspace-nuxeo-public-releases</id>
-			<url>https://cspace-maven-repo.s3-us-west-2.amazonaws.com/nuxeo/public-releases</url>
+			<url>https://cspace-program-production-cdn-cspace-maven.s3-us-west-2.amazonaws.com/nuxeo/public-releases</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -101,7 +85,7 @@
 		<!-- CSpace copy of nuxeo-vendor-releases repo. -->
 		<repository>
 			<id>cspace-nuxeo-vendor-releases</id>
-			<url>https://cspace-maven-repo.s3-us-west-2.amazonaws.com/nuxeo/vendor-releases</url>
+			<url>https://cspace-program-production-cdn-cspace-maven.s3-us-west-2.amazonaws.com/nuxeo/vendor-releases</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -110,7 +94,7 @@
 		<repository>
 			<id>cspace-libs-release-local</id>
 			<name>cspace-libs-release-local</name>
-			<url>https://cspace-maven-repo.s3-us-west-2.amazonaws.com/libs-release-local</url>
+			<url>https://cspace-program-production-cdn-cspace-maven.s3-us-west-2.amazonaws.com/libs-release-local</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -118,7 +102,7 @@
 		<repository>
 			<id>cspace-libs-snapshot-local</id>
 			<name>cspace-libs-snapshot-local</name>
-			<url>https://cspace-maven-repo.s3-us-west-2.amazonaws.com/libs-snapshot-local</url>
+			<url>https://cspace-program-production-cdn-cspace-maven.s3-us-west-2.amazonaws.com/libs-snapshot-local</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>
@@ -164,7 +148,7 @@
 		<pluginRepository>
 			<id>cspace-plugins-snapshot-local</id>
 			<name>cspace-plugins-snapshot-local</name>
-			<url>https://cspace-maven-repo.s3-us-west-2.amazonaws.com/plugins-snapshot-local</url>
+			<url>https://cspace-program-production-cdn-cspace-maven.s3-us-west-2.amazonaws.com/plugins-snapshot-local</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>


### PR DESCRIPTION
**What does this do?**
Replaces cspace-maven-repo with cspace-program-production-cdn-cspace-maven

**Why are we doing this? (with JIRA link)**
No jira. The s3 bucket with the maven repository is changing accounts and this is the new bucket name.

**How should this be tested? Do these changes have associated tests?**
Rebuild cspace with this PR

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
I got a 403 when trying to build so I assume the change hasn't been made yet. Once it builds successfully I'll set this as being ready.

**Have any new security vulnerabilities been handled?**
n/a
