### PR TITLE
DRYD-2123: Nuxeo > Corrupted jars make build fail silently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,5 @@ bin
 *.diff
 logged_schemas
 logs
-.mvn
+.mvn/*
+!.mvn/maven.config

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+--strict-checksums

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 9.0.0
 * Add home location to collectionobject schema and advanced search
+* Enable strict checksum verification so that builds fail on corrupted Maven artifact downloads
 
 ## 8.3.0
 


### PR DESCRIPTION
**What does this do?**
Added .mvn/maven.config containing `--strict-checksums`. So that the flag is applied to all ant build.xml files that exec mvn and to any mvn command a developer or CI runs. 

**Why are we doing this? (with JIRA link)**
We need to make mvn builds fail when downloading corrupted jars: https://collectionspace.atlassian.net/browse/DRYD-2123

**How should this be tested? Do these changes have associated tests?**
Confirm the flag is actually applied:
1. Add an unknown option in maven.config `--blah-flag`
2. `mvn -N validate` should fail with `Unable to parse maven.config file options: Unrecognized option: --strict-checksums --blah-flag`
3. Remove the wrong flag and rerun `mvn -N validate`. It should pass
4. You may run the check from a subdirectory too, to confirm that .mvn/maven.config is discovered in those cases too.

Confirm a bad checksum fails build loudly
1. Build a fake repo with a jar whose .sha1 is wrong
2. Create a `fake-repo/test/dummy/1.0/` folder anywhere in the filesystem to mimic Maven's artifacts folder structure (groupId/artifactId/version/files)
3. Inside the 1.0 folder, create four text files: 
* dummy-1.0.jar with any text content like `test`. This is like the html page the dead Nexus responded.
* dummy-1.0.jar.sha1 with a single line of 10 hex characters so that is not the real checksum of the file above.
* dummy-1.0.pom, a minimal artifact descriptor
```
<project xmlns="http://maven.apache.org/POM/4.0.0">
    <modelVersion>4.0.0</modelVersion>
    <groupId>test</groupId>
    <artifactId>dummy</artifactId>
    <version>1.0</version>
  </project>
```
*  dummy-1.0.pom.sha1, same single like of 10 hex characters
4. From inside the services run `mvn org.apache.maven.plugins:maven-dependency-plugin:3.6.1:get -Dartifact=test:dummy:1.0 -DremoteRepositories=fake::default::file:///path/to/fake-repo`
5. Expected: BUILD FAILURE with Checksum validation failed, expected '0123456789' but is actually '…'. 
6. Run the same command from a folder outside the repo and you'll see the old behavior: just a [WARNING] and a successful build — the silent fail.
7. Clean up your m2 cache by deleting the ~/.m2/repository/test folder

Confirm the real build is unaffected
1. Run ant deploy. It should complete as before.

**Dependencies for merging? Releasing to production?**
No dependencies

**Has the application documentation been updated for these changes?**
Changelog has been updated

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally

**Have any new security vulnerabilities been handled?**
No new security vulns
