### PR TITLE
NO-JIRA: Bugfix/reindex media on relate

### DIFF
--- a/3rdparty/nuxeo/nuxeo-platform-listener/reindex/src/main/java/org/collectionspace/services/listener/Reindex.java
+++ b/3rdparty/nuxeo/nuxeo-platform-listener/reindex/src/main/java/org/collectionspace/services/listener/Reindex.java
@@ -43,6 +43,7 @@ public class Reindex extends AbstractCSEventPostCommitListenerImpl {
 	public static final String PREV_EXH_CURATORIAL_NOTE_KEY = "Reindex.PREV_EXH_CURATORIAL_NOTE";
 	public static final String PREV_EXH_PUBLISH_TO_KEY = "Reindex.PREV_EXH_PUBLISH_TO";
 	public static final String PREV_RELATED_COLLECTION_OBJECT_CSID_KEY = "Reindex.PREV_RELATED_COLLECTION_OBJECT_CSID";
+	public static final String PREV_RELATED_MEDIA_CSID_KEY = "Reindex.PREV_RELATED_MEDIA_CSID";
 	public static final String ELASTICSEARCH_ENABLED_PROP = "elasticsearch.enabled";
 
 	@Override
@@ -200,10 +201,27 @@ public class Reindex extends AbstractCSEventPostCommitListenerImpl {
 					String collectionObjectCsid = (String) doc.getProperty("relations_common", "objectCsid");
 
 					reindexCollectionObject(doc.getRepositoryName(), collectionObjectCsid);
+
+					if (subjectDocumentType.equals("Media")) {
+						String mediaCsid = (String) doc.getProperty("relations_common", "subjectCsid");
+
+						reindexMedia(doc.getRepositoryName(), mediaCsid);
+					}
+				}
+				else if (
+					subjectDocumentType.equals("CollectionObject")
+					&& objectDocumentType.equals("Media")
+				) {
+					String collectionObjectCsid = (String) doc.getProperty("relations_common", "subjectCsid");
+					String mediaCsid = (String) doc.getProperty("relations_common", "objectCsid");
+
+					reindexCollectionObject(doc.getRepositoryName(), collectionObjectCsid);
+					reindexMedia(doc.getRepositoryName(), mediaCsid);
 				}
 			}
 			else if (eventName.equals(DocumentEventTypes.DOCUMENT_REMOVED)) {
 				reindexPrevRelatedCollectionObjects(eventContext);
+				reindexPrevRelatedMedia(eventContext);
 			}
 		}
 	}
@@ -261,12 +279,33 @@ public class Reindex extends AbstractCSEventPostCommitListenerImpl {
 		}
 	}
 
+	private void reindexPrevRelatedMedia(DocumentEventContext eventContext) {
+		List<String> prevRelatedMediaCsids = (List<String>) eventContext.getProperty(PREV_RELATED_MEDIA_CSID_KEY);
+
+		if (prevRelatedMediaCsids != null) {
+			for (String prevRelatedMediaCsid : prevRelatedMediaCsids) {
+				reindexMedia(eventContext.getRepositoryName(), prevRelatedMediaCsid);
+			}
+		}
+	}
+
 	private void reindexCollectionObject(String repositoryName, String csid) {
 		if (StringUtils.isEmpty(csid)) {
 			return;
 		}
 
 		String query = String.format("SELECT ecm:uuid FROM CollectionObject WHERE ecm:name = '%s'", csid);
+
+		ElasticSearchComponent es = (ElasticSearchComponent) Framework.getService(ElasticSearchService.class);
+		es.runReindexingWorker(repositoryName, query);
+	}
+
+	private void reindexMedia(String repositoryName, String csid) {
+		if (StringUtils.isEmpty(csid)) {
+			return;
+		}
+
+		String query = String.format("SELECT ecm:uuid FROM Media WHERE ecm:name = '%s'", csid);
 
 		ElasticSearchComponent es = (ElasticSearchComponent) Framework.getService(ElasticSearchService.class);
 		es.runReindexingWorker(repositoryName, query);

--- a/3rdparty/nuxeo/nuxeo-platform-listener/reindex/src/main/java/org/collectionspace/services/listener/ReindexSupport.java
+++ b/3rdparty/nuxeo/nuxeo-platform-listener/reindex/src/main/java/org/collectionspace/services/listener/ReindexSupport.java
@@ -146,6 +146,22 @@ public class ReindexSupport extends AbstractCSEventSyncListenerImpl {
 					String collectionObjectCsid = (String) doc.getProperty("relations_common", "objectCsid");
 
 					eventContext.setProperty(Reindex.PREV_RELATED_COLLECTION_OBJECT_CSID_KEY, (Serializable) Arrays.asList(collectionObjectCsid));
+
+					if (subjectDocumentType.equals("Media")) {
+						String mediaCsid = (String) doc.getProperty("relations_common", "subjectCsid");
+
+						eventContext.setProperty(Reindex.PREV_RELATED_MEDIA_CSID_KEY, (Serializable) Arrays.asList(mediaCsid));
+					}
+				}
+				else if (
+					subjectDocumentType.equals("CollectionObject")
+					&& objectDocumentType.equals("Media")
+				) {
+					String collectionObjectCsid = (String) doc.getProperty("relations_common", "subjectCsid");
+					String mediaCsid = (String) doc.getProperty("relations_common", "objectCsid");
+
+					eventContext.setProperty(Reindex.PREV_RELATED_COLLECTION_OBJECT_CSID_KEY, (Serializable) Arrays.asList(collectionObjectCsid));
+					eventContext.setProperty(Reindex.PREV_RELATED_MEDIA_CSID_KEY, (Serializable) Arrays.asList(mediaCsid));
 				}
 			}
 		}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## 9.0.0
 * Add home location to collectionobject schema and advanced search
 
+### Bug Fixes
+
+* Fix es indexing of Media records when relating/unrelating to Collection Objects
+
 ## 8.3.0
 
 * Add new endpoint for returning search results


### PR DESCRIPTION
**What does this do?**
* Reindex the related Media when a Relation between Collection Object and a Media is created or deleted. So that the media's `collectionspace_denorm:objectCsid` field stays in sync with its relations.
* Handles both directions (subject=Media/object=CollectionObject and subject=CollectionObject/object=Media)

**Why are we doing this? (with JIRA link)**
The public browser detail page image gallery finds media by querying `collectionspace_denorm:objectCsid` on Media docs. That field is only written when the Media doc itself is indexed, but relation create/delete events previously only reindexed the Collection Object. As a result newly related medias do not appear in the public browser until the media record is saved which triggers a reindex. Similarly, unrelated/deleted media keep showing until edited.

**How should this be tested? Do these changes have associated tests?**
1. Create a media with an image, published to All
2. From the media record, relate it to a collection object that is published to the public browser. Without editing the media, verify the image appears on the object's public browser detail page.
3. Repeat the relation from the collection object's detail view and verify.
4. Unrelate the media (from both the media side and the object side). Verify the image disappears from the public browser without editing the media.

**Dependencies for merging? Releasing to production?**
No dependencies

**Has the application documentation been updated for these changes?**
Changelog has been updated

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally

**Have any new security vulnerabilities been handled?**
no new security vulns
