### PR TITLE
DRYD-2138: Avoid DeURNing of ObjectNameControlleed 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add password complexity requirements to tenant bindings
 * Add password validators which verify passwords meet requirements set by tenants
 * Enable strict checksum verification so that builds fail on corrupted Maven artifact downloads
+* Remove de-urning of objectNameControlled refname in the AdvancedSearch API
 
 ## 8.3.0
 

--- a/services/advancedsearch/jaxb/src/main/java/org/collectionspace/services/advancedsearch/model/ObjectNameListModel.java
+++ b/services/advancedsearch/jaxb/src/main/java/org/collectionspace/services/advancedsearch/model/ObjectNameListModel.java
@@ -4,9 +4,9 @@ import java.util.List;
 
 import org.collectionspace.services.collectionobject.CollectionobjectsCommon;
 import org.collectionspace.services.collectionobject.ObjectNameGroup;
-import org.collectionspace.services.common.api.RefNameUtils;
 
 public class ObjectNameListModel {
+	private ObjectNameListModel() {}
 
 	/**
 	 * @param collectionObject The CollectionObject Common part
@@ -18,11 +18,8 @@ public class ObjectNameListModel {
 		if (collectionObject != null && collectionObject.getObjectNameList() != null) {
 			final List<ObjectNameGroup> objectNameGroups = collectionObject.getObjectNameList().getObjectNameGroup();
 			if (!objectNameGroups.isEmpty()) {
-				final ObjectNameGroup objectNameGroup = objectNameGroups.get(0);
-				try {
-					objectNameControlled = RefNameUtils.getDisplayName(objectNameGroup.getObjectNameControlled());
-				} catch (IllegalArgumentException ignored) {
-				}
+				final ObjectNameGroup objectNameGroup = objectNameGroups.getFirst();
+				objectNameControlled = objectNameGroup.getObjectNameControlled();
 			}
 		}
 
@@ -38,7 +35,7 @@ public class ObjectNameListModel {
 		if (collectionObject!= null && collectionObject.getObjectNameList() != null) {
 			final List<ObjectNameGroup> objectNameGroups = collectionObject.getObjectNameList().getObjectNameGroup();
 			if (!objectNameGroups.isEmpty()) {
-				final ObjectNameGroup objectNameGroup = objectNameGroups.get(0);
+				final ObjectNameGroup objectNameGroup = objectNameGroups.getFirst();
 				objectName = objectNameGroup.getObjectName();
 			}
 		}


### PR DESCRIPTION
**What does this do?**
* Removes deurning applied to objectNameControlled in the AdvancedSearch API

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-2138

Previous version of the UI relied on the field being a refname when returned by the search APIs, and by deurning the field we broke that part of the API contract. Additionally, the other fields returned by the AdvancedSearch API do not apply any deurning so this makes the response more consistent.

**How should this be tested? Do these changes have associated tests?**
* Rebuild CollectionSpace with both `core` and `anthro` enabled
* In core:
  * Create a CollectionObject with both a controlled and uncontrolled object name
  * Use the advanced search form and see that the object names render properly in the grid and list views
  * The API can also be queried to verify that the refname is being returned, e.g.
```
$ curl -s -H 'Accept: application/json' -u admin@core.collectionspace.org:Administrator 'http://localhost:8180/cspace-services/advancedsearch' | jq '.["ns3:advancedsearch-common-list"].["advancedsearch-list-item"].objectNameControlled'
```
* In anthro:
  * Create a CollectionObject with both a controlled and uncontrolled object name
  * Use the advanced search form and see that the object names render properly in the table, grid, and list views  

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
The AdvancedSearch API documentation might need to be updated

**Did someone actually run this code to verify it works?**
@mikejritter tested locally

**Have any new security vulnerabilities been handled?**
n/a
