### PR TITLE
No Jira: Fix Failing AccountServiceTest

### DIFF
--- a/services/account/service/src/main/java/org/collectionspace/services/account/validator/CSpacePasswordValidator.java
+++ b/services/account/service/src/main/java/org/collectionspace/services/account/validator/CSpacePasswordValidator.java
@@ -29,12 +29,8 @@ public class CSpacePasswordValidator {
 
         final var validators = new ArrayList<PasswordValidator>();
         validators.add(new MaxLengthValidator());
+        validators.add(new MinLengthValidator(config));
         if (config != null && config.isEnabled()) {
-            final var minLength = config.getMinLength();
-            if (minLength != null) {
-                validators.add(new MinLengthValidator(minLength));
-            }
-
             if (config.isRequireLowerCase()) {
                 validators.add(RegexValidator.LOWER_CASE_VALIDATOR);
             }

--- a/services/account/service/src/main/java/org/collectionspace/services/account/validator/MinLengthValidator.java
+++ b/services/account/service/src/main/java/org/collectionspace/services/account/validator/MinLengthValidator.java
@@ -1,15 +1,24 @@
 package org.collectionspace.services.account.validator;
 
+import java.util.Optional;
+
+import org.collectionspace.services.config.tenant.PasswordRequirementConfig;
+
 /**
  * Validator that checks the length of a password is greater than a given minimum length
  * @since 9.0.0
  */
 public class MinLengthValidator implements PasswordValidator {
 
+    public static final int DEFAULT_MIN_LENGTH = 8;
+
     private final int minLength;
 
-    public MinLengthValidator(final int minLength) {
-        this.minLength = minLength;
+    public MinLengthValidator(final PasswordRequirementConfig config) {
+        this.minLength = Optional.ofNullable(config)
+            .filter(PasswordRequirementConfig::isEnabled)
+            .map(PasswordRequirementConfig::getMinLength)
+            .orElse(DEFAULT_MIN_LENGTH);
     }
 
     @Override

--- a/services/account/service/src/test/java/org/collectionspace/services/account/validator/CSpacePasswordValidatorTest.java
+++ b/services/account/service/src/test/java/org/collectionspace/services/account/validator/CSpacePasswordValidatorTest.java
@@ -23,18 +23,32 @@ public class CSpacePasswordValidatorTest {
     @Test
     public void testNoConfig() {
         final var binding = genBinding(false);
-        assertTrue(validatePasswordForTenant(binding, SHORT_PASS).isValid());
+        assertTrue(validatePasswordForTenant(binding, LONG_PASS).isValid());
         assertTrue(validatePasswordForTenant(binding, LOWER_CASE_PASS).isValid());
         assertTrue(validatePasswordForTenant(binding, UPPER_CASE_PASS).isValid());
         assertTrue(validatePasswordForTenant(binding, DIGIT_PASS).isValid());
         assertTrue(validatePasswordForTenant(binding, SPECIAL_PASS).isValid());
+
+        // Min and Max length checks are enabled by default, just check minimum here
+        runInvalidCheck(SHORT_PASS, List.of(ValidationErrorCode.ERR_TOO_SHORT), binding);
     }
 
     @Test
     public void testMinLength() {
         final var binding = genBinding(true);
-        binding.getPasswordRequirementConfig().setMinLength(10);
 
+        // short passwords can be allowed
+        binding.getPasswordRequirementConfig().setMinLength(3);
+        assertTrue(validatePasswordForTenant(binding, SHORT_PASS).isValid());
+        assertTrue(validatePasswordForTenant(binding, LONG_PASS).isValid());
+
+        // short passwords can be disallowed
+        binding.getPasswordRequirementConfig().setMinLength(LONG_PASS.length() + 1);
+        runInvalidCheck(LONG_PASS, List.of(ValidationErrorCode.ERR_TOO_SHORT), binding);
+        runInvalidCheck(SHORT_PASS, List.of(ValidationErrorCode.ERR_TOO_SHORT), binding);
+
+        // validate null values do not cause exceptions
+        binding.getPasswordRequirementConfig().setMinLength(null);
         assertTrue(validatePasswordForTenant(binding, LONG_PASS).isValid());
         runInvalidCheck(SHORT_PASS, List.of(ValidationErrorCode.ERR_TOO_SHORT), binding);
     }


### PR DESCRIPTION
**What does this do?**
This updates the PasswordValidator creation to always create a Minimum Length Validator when no configuration is present. 

**Why are we doing this? (with JIRA link)**
No Jira. I saw that the nightly builds were failing due to failures in the AccountServiceTest, specifically `createWithInvalidPassword` and `updateInvalidPassword`. Both of these were relying on previous assumptions that a minimum length of 8 would be enforced for passwords. This is something that I had been considering when writing the test notes for QA so I went and added it back in as a default.

**How should this be tested? Do these changes have associated tests?**
* Rebuild CollectionSpace with the tenant require for integration tests, i.e. `anthro,botgarden,core,materials,testsci`
  * note: I actually only had anthro and core enabled and was still able to run the AccountServiceTest. Different tests have different requirements so I'm guessing this one specifically only needs core but I have not verified this.
* Navigate to `services/account/client`
* Run the tests with `mvn test`

**Dependencies for merging? Releasing to production?**
It would be good to update the cspace-ui.js validator as well to include a default minimum length check of 8 characters.

**Has the application documentation been updated for these changes?**
No. Documentation tickets are in Jira for 9.0.0.

**Did someone actually run this code to verify it works?**
@mikejritter ran the AccountServiceTest and CSpacePasswordValidatorTest locally

**Have any new security vulnerabilities been handled?**
n/a
