### PR TITLE
DRYD-2117 Procedure/Object > Ability to set Priority Image - top media priority image as search results thumbnail

### DIFF
--- a/3rdparty/nuxeo/nuxeo-platform-listener/updaterelationsondelete/src/main/java/org/collectionspace/services/listener/UpdateMediaPriorityOnDelete.java
+++ b/3rdparty/nuxeo/nuxeo-platform-listener/updaterelationsondelete/src/main/java/org/collectionspace/services/listener/UpdateMediaPriorityOnDelete.java
@@ -7,11 +7,9 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.collectionspace.services.common.api.RefNameUtils;
 import org.collectionspace.services.nuxeo.client.java.CoreSessionInterface;
 import org.collectionspace.services.nuxeo.client.java.CoreSessionWrapper;
 import org.collectionspace.services.nuxeo.listener.AbstractCSEventSyncListenerImpl;
-import org.collectionspace.services.nuxeo.util.NuxeoUtils;
 
 import org.nuxeo.ecm.core.api.DocumentModel;
 import org.nuxeo.ecm.core.api.event.DocumentEventTypes;
@@ -35,6 +33,8 @@ public class UpdateMediaPriorityOnDelete extends AbstractCSEventSyncListenerImpl
     final static String COLLECTIONOBJECTS_COMMON_SCHEMA = "collectionobjects_common";
     final static String SUBJECT_CSID_PROPERTY = "subjectCsid";
     final static String OBJECT_CSID_PROPERTY = "objectCsid";
+    final static String SUBJECT_REFNAME_PROPERTY = "subjectRefName";
+    final static String OBJECT_REFNAME_PROPERTY = "objectRefName";
     final static String SUBJECT_DOCTYPE_PROPERTY = "subjectDocumentType";
     final static String OBJECT_DOCTYPE_PROPERTY = "objectDocumentType";
     final static String MEDIA_PRIORITY_LIST_FIELD = "mediaPriorityList";
@@ -65,14 +65,14 @@ public class UpdateMediaPriorityOnDelete extends AbstractCSEventSyncListenerImpl
         String subjectDocType = (String) relationDocModel.getProperty(RELATIONS_COMMON_SCHEMA, SUBJECT_DOCTYPE_PROPERTY);
         String objectDocType = (String) relationDocModel.getProperty(RELATIONS_COMMON_SCHEMA, OBJECT_DOCTYPE_PROPERTY);
 
-        String mediaCsid;
+        String mediaRefName;
         String collectionObjectCsid;
 
         if (MEDIA_DOCTYPE.equals(subjectDocType) && COLLECTIONOBJECT_DOCTYPE.equals(objectDocType)) {
-            mediaCsid = (String) relationDocModel.getProperty(RELATIONS_COMMON_SCHEMA, SUBJECT_CSID_PROPERTY);
+            mediaRefName = (String) relationDocModel.getProperty(RELATIONS_COMMON_SCHEMA, SUBJECT_REFNAME_PROPERTY);
             collectionObjectCsid = (String) relationDocModel.getProperty(RELATIONS_COMMON_SCHEMA, OBJECT_CSID_PROPERTY);
         } else if (MEDIA_DOCTYPE.equals(objectDocType) && COLLECTIONOBJECT_DOCTYPE.equals(subjectDocType)) {
-            mediaCsid = (String) relationDocModel.getProperty(RELATIONS_COMMON_SCHEMA, OBJECT_CSID_PROPERTY);
+            mediaRefName = (String) relationDocModel.getProperty(RELATIONS_COMMON_SCHEMA, OBJECT_REFNAME_PROPERTY);
             collectionObjectCsid = (String) relationDocModel.getProperty(RELATIONS_COMMON_SCHEMA, SUBJECT_CSID_PROPERTY);
         } else {
             // Not a media/collectionobject relation.
@@ -96,7 +96,7 @@ public class UpdateMediaPriorityOnDelete extends AbstractCSEventSyncListenerImpl
 
         List<String> updatedList = new ArrayList<>(mediaPriorityList);
 
-        if (!updatedList.removeIf(refName -> mediaCsid.equals(RefNameUtils.parseAuthorityInfo(refName).csid))) {
+        if (!updatedList.removeAll(List.of(mediaRefName))) {
             // The media record was not in the priority list.
             return;
         }
@@ -106,7 +106,7 @@ public class UpdateMediaPriorityOnDelete extends AbstractCSEventSyncListenerImpl
         session.saveDocument(collectionObjectDocModel);
 
         logger.info("Removed media record {} from the media priority list of collectionobject {}",
-                mediaCsid, NuxeoUtils.getCsid(collectionObjectDocModel));
+                mediaRefName, collectionObjectCsid);
     }
 
     @Override

--- a/3rdparty/nuxeo/nuxeo-platform-listener/updaterelationsondelete/src/main/java/org/collectionspace/services/listener/UpdateMediaPriorityOnDelete.java
+++ b/3rdparty/nuxeo/nuxeo-platform-listener/updaterelationsondelete/src/main/java/org/collectionspace/services/listener/UpdateMediaPriorityOnDelete.java
@@ -1,0 +1,116 @@
+package org.collectionspace.services.listener;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.collectionspace.services.common.api.RefNameUtils;
+import org.collectionspace.services.nuxeo.client.java.CoreSessionInterface;
+import org.collectionspace.services.nuxeo.client.java.CoreSessionWrapper;
+import org.collectionspace.services.nuxeo.listener.AbstractCSEventSyncListenerImpl;
+import org.collectionspace.services.nuxeo.util.NuxeoUtils;
+
+import org.nuxeo.ecm.core.api.DocumentModel;
+import org.nuxeo.ecm.core.api.event.DocumentEventTypes;
+import org.nuxeo.ecm.core.event.Event;
+import org.nuxeo.ecm.core.event.EventContext;
+import org.nuxeo.ecm.core.event.impl.DocumentEventContext;
+
+/**
+ * Event listener that removes entries from a collectionobject's media priority list when the
+ * media record an entry refers to is unrelated from the collectionobject, or deleted.
+ */
+public class UpdateMediaPriorityOnDelete extends AbstractCSEventSyncListenerImpl {
+
+    private static final Logger logger = LoggerFactory.getLogger(UpdateMediaPriorityOnDelete.class);
+
+    // FIXME: Get these constant values from external sources rather than redeclaring here
+    final static String RELATION_DOCTYPE = "Relation";
+    final static String MEDIA_DOCTYPE = "Media";
+    final static String COLLECTIONOBJECT_DOCTYPE = "CollectionObject";
+    final static String RELATIONS_COMMON_SCHEMA = "relations_common";
+    final static String COLLECTIONOBJECTS_COMMON_SCHEMA = "collectionobjects_common";
+    final static String SUBJECT_CSID_PROPERTY = "subjectCsid";
+    final static String OBJECT_CSID_PROPERTY = "objectCsid";
+    final static String SUBJECT_DOCTYPE_PROPERTY = "subjectDocumentType";
+    final static String OBJECT_DOCTYPE_PROPERTY = "objectDocumentType";
+    final static String MEDIA_PRIORITY_LIST_FIELD = "mediaPriorityList";
+
+    @Override
+    public boolean shouldHandleEvent(Event event) {
+        EventContext eventContext = event.getContext();
+
+        if (!(eventContext instanceof DocumentEventContext)) {
+            return false;
+        }
+
+        DocumentModel docModel = ((DocumentEventContext) eventContext).getSourceDocument();
+
+        if (!documentMatchesType(docModel, RELATION_DOCTYPE)) {
+            return false;
+        }
+
+        return DocumentEventTypes.ABOUT_TO_REMOVE.equals(event.getName())
+                || isDocumentSoftDeletedEvent(eventContext);
+    }
+
+    @Override
+    public void handleCSEvent(Event event) {
+        DocumentEventContext docContext = (DocumentEventContext) event.getContext();
+        DocumentModel relationDocModel = docContext.getSourceDocument();
+
+        String subjectDocType = (String) relationDocModel.getProperty(RELATIONS_COMMON_SCHEMA, SUBJECT_DOCTYPE_PROPERTY);
+        String objectDocType = (String) relationDocModel.getProperty(RELATIONS_COMMON_SCHEMA, OBJECT_DOCTYPE_PROPERTY);
+
+        String mediaCsid;
+        String collectionObjectCsid;
+
+        if (MEDIA_DOCTYPE.equals(subjectDocType) && COLLECTIONOBJECT_DOCTYPE.equals(objectDocType)) {
+            mediaCsid = (String) relationDocModel.getProperty(RELATIONS_COMMON_SCHEMA, SUBJECT_CSID_PROPERTY);
+            collectionObjectCsid = (String) relationDocModel.getProperty(RELATIONS_COMMON_SCHEMA, OBJECT_CSID_PROPERTY);
+        } else if (MEDIA_DOCTYPE.equals(objectDocType) && COLLECTIONOBJECT_DOCTYPE.equals(subjectDocType)) {
+            mediaCsid = (String) relationDocModel.getProperty(RELATIONS_COMMON_SCHEMA, OBJECT_CSID_PROPERTY);
+            collectionObjectCsid = (String) relationDocModel.getProperty(RELATIONS_COMMON_SCHEMA, SUBJECT_CSID_PROPERTY);
+        } else {
+            // Not a media/collectionobject relation.
+            return;
+        }
+
+        CoreSessionInterface session = new CoreSessionWrapper(docContext.getCoreSession());
+        DocumentModel collectionObjectDocModel = getCurrentDocModelFromCsid(session, collectionObjectCsid);
+
+        if (collectionObjectDocModel == null || !isActiveDocument(collectionObjectDocModel)) {
+            return;
+        }
+
+        @SuppressWarnings("unchecked")
+        List<String> mediaPriorityList = (List<String>) collectionObjectDocModel.getProperty(
+                COLLECTIONOBJECTS_COMMON_SCHEMA, MEDIA_PRIORITY_LIST_FIELD);
+
+        if (mediaPriorityList == null) {
+            return;
+        }
+
+        List<String> updatedList = new ArrayList<>(mediaPriorityList);
+
+        if (!updatedList.removeIf(refName -> mediaCsid.equals(RefNameUtils.parseAuthorityInfo(refName).csid))) {
+            // The media record was not in the priority list.
+            return;
+        }
+
+        collectionObjectDocModel.setProperty(COLLECTIONOBJECTS_COMMON_SCHEMA, MEDIA_PRIORITY_LIST_FIELD,
+                (Serializable) updatedList);
+        session.saveDocument(collectionObjectDocModel);
+
+        logger.info("Removed media record {} from the media priority list of collectionobject {}",
+                mediaCsid, NuxeoUtils.getCsid(collectionObjectDocModel));
+    }
+
+    @Override
+    public Logger getLogger() {
+        return this.logger;
+    }
+}

--- a/3rdparty/nuxeo/nuxeo-platform-listener/updaterelationsondelete/src/main/resources/OSGI-INF/ecm-types-contrib.xml
+++ b/3rdparty/nuxeo/nuxeo-platform-listener/updaterelationsondelete/src/main/resources/OSGI-INF/ecm-types-contrib.xml
@@ -7,5 +7,13 @@
             <event>lifecycle_transition_event</event>
         </listener>
     </extension>
-    
+
+    <extension target="org.nuxeo.ecm.core.event.EventServiceComponent" point="listener">
+        <listener name="updatemediapriorityondeletelistener" async="false" postCommit="false"
+                          class="org.collectionspace.services.listener.UpdateMediaPriorityOnDelete">
+            <event>aboutToRemove</event>
+            <event>lifecycle_transition_event</event>
+        </listener>
+    </extension>
+
 </component>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add home location to collectionobject schema and advanced search
 * Denormalize media priority list
+* Use the top media priority record for the thumbnail in advanced search results
 * Add password complexity requirements to tenant bindings
 * Add password validators which verify passwords meet requirements set by tenants
 * Enable strict checksum verification so that builds fail on corrupted Maven artifact downloads

--- a/services/advancedsearch/service/src/main/java/org/collectionspace/services/advancedsearch/AdvancedSearch.java
+++ b/services/advancedsearch/service/src/main/java/org/collectionspace/services/advancedsearch/AdvancedSearch.java
@@ -1,6 +1,11 @@
 package org.collectionspace.services.advancedsearch;
 
+import static org.collectionspace.services.client.CollectionSpaceClient.PART_COMMON_LABEL;
+import static org.collectionspace.services.client.CollectionSpaceClient.PART_LABEL_SEPARATOR;
+
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -18,11 +23,16 @@ import jakarta.xml.bind.Unmarshaller;
 import org.collectionspace.services.MediaJAXBSchema;
 import org.collectionspace.services.advancedsearch.AdvancedsearchCommonList.AdvancedsearchListItem;
 import org.collectionspace.services.advancedsearch.mapper.CollectionObjectMapper;
+import org.collectionspace.services.client.CollectionObjectClient;
 import org.collectionspace.services.client.IClientQueryParams;
 import org.collectionspace.services.client.IQueryManager;
+import org.collectionspace.services.client.PayloadOutputPart;
+import org.collectionspace.services.client.PoxPayloadOut;
+import org.collectionspace.services.client.workflow.WorkflowClient;
 import org.collectionspace.services.collectionobject.CollectionObjectResource;
 import org.collectionspace.services.common.AbstractCollectionSpaceResourceImpl;
 import org.collectionspace.services.common.UriInfoWrapper;
+import org.collectionspace.services.common.api.RefNameUtils;
 import org.collectionspace.services.common.context.RemoteServiceContextFactory;
 import org.collectionspace.services.common.context.ServiceContextFactory;
 import org.collectionspace.services.common.relation.RelationResource;
@@ -34,7 +44,9 @@ import org.collectionspace.services.nuxeo.client.handler.UnfilteredDocumentModel
 import org.collectionspace.services.relation.RelationsCommonList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 
 /**
  * This class defines the advanced search endpoints.
@@ -56,14 +68,18 @@ public class AdvancedSearch
 	private static final String PAGE_NUM = "0";
 	private static final String MEDIA_SORT_BY = "media_common:title";
 
+	private static final String COLLECTIONOBJECT_COMMON_PART_NAME =
+			CollectionObjectClient.SERVICE_NAME + PART_LABEL_SEPARATOR + PART_COMMON_LABEL;
+	private static final String MEDIA_PRIORITY_FIELD = "mediaPriority";
+
 	public AdvancedSearch() {
 		super();
 	}
 
 	/**
 	 * Primary advanced search API endpoint.
-	 * 
-	 * @param request The incoming request. Injected. 
+	 *
+	 * @param request The incoming request. Injected.
 	 * @param uriInfo The URI info of the incoming request, including query parameters and other search control parameters. Injected.
 	 * @return A possibly-empty AbstractCommonList of the advanced search results corresponding to the query
 	 */
@@ -96,8 +112,12 @@ public class AdvancedSearch
 		final UriInfoWrapper relUriInfo = relationUriInfo(uriInfo);
 		for (CSDocumentModelResponse response : collectionObjectList.getResponseList()) {
 			String csid = response.getCsid();
-			UriInfoWrapper blobUriInfo = new UriInfoWrapper(uriInfo);
-			Map<String, String> blobInfo = findBlobInfo(csid, blobUriInfo);
+			Map<String, String> blobInfo = findPriorityBlobInfo(uriInfo, response);
+
+			if (blobInfo.isEmpty()) {
+				UriInfoWrapper blobUriInfo = new UriInfoWrapper(uriInfo);
+				blobInfo = findBlobInfo(csid, blobUriInfo);
+			}
 
 			AdvancedsearchListItem listItem = responseMapper.asListItem(response, blobInfo);
 			if (listItem != null) {
@@ -127,9 +147,9 @@ public class AdvancedSearch
 		return wrapper;
 	}
 
-	/** 
+	/**
 	 * Retrieves the blob CSIDs associated with a given object's CSID
-	 * 
+	 *
 	 * @param csid The CSID of an object whose associated blobs (thumbnails) is desired
 	 * @param wrappedUriInfo The wrapped (mutable) UriInfo of the incoming query that ultimately triggered this call
 	 * @return A possibly-empty list of strings of the blob CSIDs associated with CSID
@@ -141,8 +161,17 @@ public class AdvancedSearch
 		wrappedQueryParams.add(IClientQueryParams.PAGE_SIZE_PARAM, PAGE_SIZE);
 		wrappedQueryParams.add(IClientQueryParams.START_PAGE_PARAM, PAGE_NUM);
 		wrappedQueryParams.add(IClientQueryParams.ORDER_BY_PARAM, MEDIA_SORT_BY);
-		AbstractCommonList associatedMedia = mr.getList(wrappedUriInfo);
-		if (associatedMedia == null || associatedMedia.getListItem() == null) {
+		return blobInfoFromList(mr.getList(wrappedUriInfo));
+	}
+
+	/**
+	 * Extracts the blob info (blob CSID and alt text) from the first item of a media list.
+	 *
+	 * @param mediaList The media list to extract from
+	 * @return A possibly-empty map of the blob info of the first media list item
+	 */
+	private Map<String, String> blobInfoFromList(AbstractCommonList mediaList) {
+		if (mediaList == null || mediaList.getListItem() == null) {
 			return Collections.emptyMap();
 		}
 
@@ -151,11 +180,83 @@ public class AdvancedSearch
 		Predicate<Element> tagNotEmpty = (element -> element.getTextContent()  != null &&
 													 !element.getTextContent().isEmpty());
 
-        return associatedMedia.getListItem().stream()
+        return mediaList.getListItem().stream()
 			.filter(item -> item != null && item.getAny() != null)
 			.flatMap(li -> li.getAny().stream())
 			.filter(tagFilter.and(tagNotEmpty))
 			.collect(Collectors.toMap(Element::getTagName, Element::getTextContent));
+	}
+
+	/**
+	 * Retrieves the blob info (blob CSID and alt text) for the top entry of an object's media priority list,
+	 *
+	 * @param uriInfo The URI info of the incoming request that triggered the search
+	 * @param response The response from the CollectionObjectResource for a single object
+	 * @return A possibly-empty map of the top media priority record's blob info.
+	 */
+	private Map<String, String> findPriorityBlobInfo(UriInfo uriInfo, CSDocumentModelResponse response) {
+		PoxPayloadOut payload = response.getPayload();
+
+		if (payload == null) {
+			return Collections.emptyMap();
+		}
+
+		PayloadOutputPart commonPart = payload.getPart(COLLECTIONOBJECT_COMMON_PART_NAME);
+		List<String> refNames = elementTextValues(commonPart, MEDIA_PRIORITY_FIELD);
+
+		if (refNames.isEmpty()) {
+			return Collections.emptyMap();
+		}
+
+		String mediaCsid = RefNameUtils.parseAuthorityInfo(refNames.get(0)).csid;
+
+		return findMediaBlobInfo(mediaCsid, new UriInfoWrapper(uriInfo));
+	}
+
+	/**
+	 * Retrieves the blob info (blob CSID and alt text) of a single media record.
+	 *
+	 * @param mediaCsid The CSID of the media record
+	 * @param wrappedUriInfo The wrapped (mutable) UriInfo of the incoming query that ultimately triggered this call
+	 * @return A possibly-empty map of the media record's blob info.
+	 */
+	private Map<String, String> findMediaBlobInfo(String mediaCsid, UriInfoWrapper wrappedUriInfo) {
+		MultivaluedMap<String, String> wrappedQueryParams = wrappedUriInfo.getQueryParameters();
+		wrappedQueryParams.clear();
+		wrappedQueryParams.add(IQueryManager.SEARCH_TYPE_KEYWORDS_AS, "ecm:name=\"" + mediaCsid + "\"");
+		wrappedQueryParams.add(WorkflowClient.WORKFLOW_QUERY_DELETED_QP, Boolean.FALSE.toString());
+		wrappedQueryParams.add(IClientQueryParams.PAGE_SIZE_PARAM, PAGE_SIZE);
+		wrappedQueryParams.add(IClientQueryParams.START_PAGE_PARAM, PAGE_NUM);
+
+		return blobInfoFromList(mr.getList(wrappedUriInfo));
+	}
+
+	/**
+	 * Retrieves the non-empty text values of all elements with a given local name within a payload part.
+	 *
+	 * @param part The payload part to search, which may be null
+	 * @param localName The local name of the elements to find
+	 * @return A possibly-empty list of the non-empty text values, in document order
+	 */
+	private List<String> elementTextValues(PayloadOutputPart part, String localName) {
+		List<String> values = new ArrayList<>();
+
+		if (part == null) {
+			return values;
+		}
+
+		Document doc = (Document) part.getBody();
+		NodeList nodes = doc.getDocumentElement().getElementsByTagName(localName);
+
+		for (int i = 0; i < nodes.getLength(); i++) {
+			String text = nodes.item(i).getTextContent();
+
+			if (text != null && !text.isEmpty()) {
+				values.add(text);
+			}
+		}
+
+		return values;
 	}
 
 	@Override

--- a/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
+++ b/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
@@ -29,6 +29,9 @@
 			<tenant:eventListenerConfig id="UpdateRelationsOnDelete">
 				<tenant:className>org.collectionspace.services.listener.UpdateRelationsOnDelete</tenant:className>
 			</tenant:eventListenerConfig>
+			<tenant:eventListenerConfig id="UpdateMediaPriorityOnDelete">
+				<tenant:className>org.collectionspace.services.listener.UpdateMediaPriorityOnDelete</tenant:className>
+			</tenant:eventListenerConfig>
 			<tenant:eventListenerConfig id="ReindexSupport">
 				<tenant:className>org.collectionspace.services.listener.ReindexSupport</tenant:className>
 			</tenant:eventListenerConfig>


### PR DESCRIPTION
**What does this do?**
It includes two changes, to make search-result thumbnails be populated according to the media priority order (along the current way). The changes are:
* In `AdvancedSearch.java`, check if a collectionobject has a media priority list and pick the top entry as the thumbnail in search results. If the list is empty, the endpoint falls back to the existing behavior.
* A new event listener `UpdateMediaPriorityOnDelete`, that removes entries from media priority list when the media record is unrelated or deleted.

**Why are we doing this? (with JIRA link)**
This is requested in the scope of the https://collectionspace.atlassian.net/browse/DRYD-2117. The record at the top of the Media priority should be the image shown in the grid and detail-list search result views. The listener is added to avoid showing unrelated/deleted media records as thumbnails. https://collectionspace.atlassian.net/browse/DRYD-2141

**How should this be tested? Do these changes have associated tests?**
1. Create a collectionobject related to two or more media records (with blobs), and set the Media Priority order so the top record is not the alphabetically-first one by title.
2. Search for the object in the staff UI. The grid and detail-list thumbnails should show the top-priority record's image.
3. Search for an object with related media but no priority list. The thumbnail should be unchanged (legacy title-sort behavior).
4. Unrelate the top-priority media record. It should disappear from the object's Media Priority panel, and the thumbnail should shift to the next entry.
5. Delete a top-priority media record. Same result to unrelate.

**Dependencies for merging? Releasing to production?**
No dependencies

**Has the application documentation been updated for these changes?**
Changelog has been updated

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally

**Have any new security vulnerabilities been handled?**
No new vulns
