### PR TITLE
No Jira: Adjust Logging Output

### DIFF
--- a/services/authorization-mgt/import/src/main/resources/META-INF/persistence.xml
+++ b/services/authorization-mgt/import/src/main/resources/META-INF/persistence.xml
@@ -14,7 +14,7 @@
             <property name="javax.persistence.jdbc.url" value="@DB_CSPACE_URL@" />
             <property name="javax.persistence.jdbc.user" value="@DB_CSPACE_USER@" />
             <property name="javax.persistence.jdbc.password" value="@DB_CSPACE_PASSWORD@" />
-            <property name="hibernate.show_sql" value="true" />
+            <property name="hibernate.show_sql" value="false" />
             <!-- Disable XML Mapping so that javax.xml.bind classes do not attempt to be loaded -->
             <property name="hibernate.xml_mapping_enabled" value="false" />
         </properties>

--- a/services/client/src/main/java/org/collectionspace/services/client/PoxPayload.java
+++ b/services/client/src/main/java/org/collectionspace/services/client/PoxPayload.java
@@ -393,7 +393,7 @@ public abstract class PoxPayload<PT extends PayloadPart> {
 					result = um.unmarshal(xmlStream);
 				}
 			} catch (Exception e) {
-				logger.error("Could not unmarshal XML element '{}' into a JAXB object.", elementInput.getName(), e);
+				logger.debug("Could not unmarshal XML element '{}' into a JAXB object.", elementInput.getName(), e);
 			}
 
 			return result;
@@ -426,7 +426,7 @@ public abstract class PoxPayload<PT extends PayloadPart> {
     		Document doc = DocumentHelper.parseText(text);
     		result = doc.getRootElement(); //FIXME: REM - call .detach() to free the element
     	} catch (Exception e) {
-    		logger.error("Could not marshal JAXB object '{}' to an XML element.", jaxbObject, e);
+    		logger.debug("Could not marshal JAXB object '{}' to an XML element.", jaxbObject, e);
     	}
 
     	return result;

--- a/services/common/src/main/java/org/collectionspace/services/common/ServiceMain.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/ServiceMain.java
@@ -1293,18 +1293,17 @@ public class ServiceMain {
 		Hashtable<String, TenantBindingType> tenantBindingTypeMap = tenantBindingConfigReader.getTenantBindings();
 		for (TenantBindingType tbt : tenantBindingTypeMap.values()) {
 			List<String> repositoryNameList = ConfigUtils.getRepositoryNameList(tbt);
-			logger.debug("Getting repository name(s) for tenant " + tbt.getName());
+			logger.debug("Getting repository name(s) for tenant {}", tbt.getName());
 
-			if (repositoryNameList == null || repositoryNameList.isEmpty() == true) {
-				logger.error(String.format("Could not get repository name(s) for tenant %s", tbt.getName()));
-				continue; // break out of loop and go to the next tenant binding
+			if (repositoryNameList == null || repositoryNameList.isEmpty()) {
+				logger.error("Could not get repository name(s) for tenant {}", tbt.getName());
 			} else {
 				for (String repositoryName : repositoryNameList) {
 					if (Tools.isBlank(repositoryName)) {
-						logger.error(String.format("Repository name(s) for tenant %s was empty.", tbt.getName()));
+						logger.error("Repository name(s) for tenant {} was empty", tbt.getName());
 						continue;
 					}
-					logger.debug(String.format("Repository name is %s", repositoryName));
+					logger.trace("Repository name is {}", repositoryName);
 					//
 					// Clone the prototype copy of the Nuxeo datasource config file,
 					// thus creating a separate config file for the current repository.
@@ -1313,12 +1312,12 @@ public class ServiceMain {
 					// Update this config file by inserting values pertinent to the
 					// current repository.
 					datasourceConfigDoc = updateRepositoryDatasourceDoc(datasourceConfigDoc, repositoryName, tbt.getRepositoryDomain(), this.getCspaceInstanceId());
-					logger.debug("Updated Nuxeo datasource config file contents=\n" + datasourceConfigDoc.asXML());
 
 					// Write this config file to the Nuxeo server config directory.
 					File repofile = new File(getNuxeoConfigDir() + File.separator + repositoryName
 							+ JEEServerDeployment.NUXEO_DATASOURCE_CONFIG_FILENAME_SUFFIX);
-					logger.debug(String.format("Attempting to write Nuxeo datasource config file to %s", repofile.getAbsolutePath()));
+					logger.debug("Writing Nuxeo datasource config for repository {} into {}", repositoryName,
+								 repofile.getAbsolutePath());
 					XmlTools.xmlDocumentToFile(datasourceConfigDoc, repofile);
 				}
 			}


### PR DESCRIPTION
**What does this do?**
* Disable show_sql for hibernate during ant database tasks
* Change Marshal/Unmarshalling exceptions to debug
* Adjust datasource config logging 


**Why are we doing this? (with JIRA link)**
No jira. This is some post-upgrade cleanup that I had been wanting to do. For each change:

show_sql - This was nice to have during dev to confirm that the ant task was working as expected and making the expected changes in the db. Now it is simply adding noise to the nightly build logs.

XML Marshalling - Most of the extensions for procedures will end up triggering this, and it's really not a fatal exception. I suppose a WARN could work for it as well, but the exception often makes it look like a red herring. Note that I left the exception in as DEBUG logging is not enabled in prod but it can be removed.

DataSource Config - I didn't really see the benefit of logging the datasource configuration directly to the log, and the logging there was quite noisy. Adjusted to output the filename instead and change log levels accordingly.

**How should this be tested? Do these changes have associated tests?**
* For show_sql, `ant import` can be run. The sql output should no longer be show.
* For XML Marshalling, create a CollectionObject with some information in the annotation extension. The log should now show up as DEBUG only.
* For the DataSource Config, I'm not actually sure but I know the UCB tenants trigger this.

**Dependencies for merging? Releasing to production?**
No dependencies. I did notice some other issues when running tests related to the Apache HttpClient, but I'll make a new ticket for that. 

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@mikejritter tested the show_sql and xml marshalling logging locally

**Have any new security vulnerabilities been handled?**
n/a
