### PR TITLE
DRYD-2162: Remove Punctuation From Fulltext Index

### DIFF
--- a/3rdparty/nuxeo/nuxeo-server/2023/config/proto-repo-config.xml
+++ b/3rdparty/nuxeo/nuxeo-server/2023/config/proto-repo-config.xml
@@ -37,17 +37,26 @@
 			<pathOptimizations enabled="true"/>
 			<idType>varchar</idType>
 			<indexing>
-			<fulltext disabled="false" analyzer="public.cspace_english">
-			  <index name="default">
-				<!-- all props implied -->
-			  </index>
-			  <index name="title">
-				<field>dc:title</field>
-			  </index>
-			  <index name="description">
-				<field>dc:description</field>
-			  </index>
-			</fulltext>
+				<excludedTypes>
+					<type>Root</type>
+					<type>Workspace</type>
+					<type>WorkspaceRoot</type>
+					<type>AdministrativeStatus</type>
+					<type>AdministrativeStatusContainer</type>
+					<type>Domain</type>
+				</excludedTypes>
+				<fulltext disabled="false" analyzer="public.cspace_english">
+					<index name="default">
+						<!-- exclude core fields -->
+						<excludeField>collectionspace_core:uri</excludeField>
+						<excludeField>collectionspace_core:refName</excludeField>
+						<excludeField>collectionspace_core:tenantId</excludeField>
+						<excludeField>collectionspace_core:createdAt</excludeField>
+						<excludeField>collectionspace_core:updatedAt</excludeField>
+						<excludeField>collectionspace_core:createdBy</excludeField>
+						<excludeField>collectionspace_core:updatedBy</excludeField>
+					</index>
+				</fulltext>
 			</indexing>
 			<usersSeparator key="," />
 			<property name="ServerName">@DB_SERVER_HOSTNAME@</property>

--- a/3rdparty/nuxeo/nuxeo-server/2023/config/proto-repo-config.xml
+++ b/3rdparty/nuxeo/nuxeo-server/2023/config/proto-repo-config.xml
@@ -55,6 +55,11 @@
 						<excludeField>collectionspace_core:updatedAt</excludeField>
 						<excludeField>collectionspace_core:createdBy</excludeField>
 						<excludeField>collectionspace_core:updatedBy</excludeField>
+						<!-- exclude dublin core -->
+						<excludeField>dc:title</excludeField>
+						<excludeField>dc:creator</excludeField>
+						<excludeField>dc:contributors</excludeField>
+						<excludeField>dc:lastContributor</excludeField>
 					</index>
 				</fulltext>
 			</indexing>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@
 * Add password complexity requirements to tenant bindings
 * Add password validators which verify passwords meet requirements set by tenants
 * Enable strict checksum verification so that builds fail on corrupted Maven artifact downloads
-* Remove de-urning of objectNameControlled refname in the AdvancedSearch API
+* Add database trigger for the fulltext index to strip punctuation
 
 ### Bug Fixes
 
 * Fix es indexing of Media records when relating/unrelating to Collection Objects
+* Remove de-urning of objectNameControlled refname in the AdvancedSearch API
 
 ## 8.3.0
 

--- a/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
+++ b/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
@@ -82,6 +82,10 @@
 						<service:key>sqlScriptName</service:key>
 						<service:value>deurn_function.sql</service:value>
 					</service:property>
+					<service:property>
+						<service:key>sqlScriptName</service:key>
+						<service:value>fulltext_triggers.sql</service:value>
+					</service:property>
 				</service:params>
 			</service:initHandler>
 		</tenant:serviceBindings>

--- a/services/common/src/main/resources/db/postgresql/fulltext_triggers.sql
+++ b/services/common/src/main/resources/db/postgresql/fulltext_triggers.sql
@@ -1,4 +1,6 @@
-CREATE OR REPLACE FUNCTION fulltext_rm_punctuation() RETURNS TRIGGER AS $$
+-- Remove punctuation from fulltext columns
+-- Note: There is a nuxeo trigger which sets the fulltext.fulltext column by coalescing the simpletext and binarytext.
+CREATE OR REPLACE FUNCTION fulltext_normalize() RETURNS TRIGGER AS $$
 BEGIN
   NEW.simpletext = regexp_replace(NEW.simpletext, '[^\w]+', ' ', 'gi');
   NEW.binarytext = regexp_replace(NEW.binarytext, '[^\w]+', ' ', 'gi');
@@ -6,8 +8,8 @@ BEGIN
 END
 $$ LANGUAGE plpgsql;
 
-DROP TRIGGER IF EXISTS fulltext_rm_punct_trigger ON fulltext;
-CREATE TRIGGER fulltext_rm_punct_trigger
+DROP TRIGGER IF EXISTS fulltext_normalize_trigger ON fulltext;
+CREATE TRIGGER fulltext_normalize_trigger
 BEFORE INSERT OR UPDATE ON fulltext
 FOR EACH ROW
-EXECUTE FUNCTION fulltext_rm_punctuation();
+EXECUTE FUNCTION fulltext_normalize();

--- a/services/common/src/main/resources/db/postgresql/fulltext_triggers.sql
+++ b/services/common/src/main/resources/db/postgresql/fulltext_triggers.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE FUNCTION fulltext_rm_punctuation() RETURNS TRIGGER AS $$
+BEGIN
+  NEW.simpletext = regexp_replace(NEW.simpletext, '[^\w]+', ' ', 'gi');
+  NEW.binarytext = regexp_replace(NEW.binarytext, '[^\w]+', ' ', 'gi');
+  RETURN NEW;
+END
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS fulltext_rm_punct_trigger ON fulltext;
+CREATE TRIGGER fulltext_rm_punct_trigger
+BEFORE INSERT OR UPDATE ON fulltext
+FOR EACH ROW
+EXECUTE FUNCTION fulltext_rm_punctuation();


### PR DESCRIPTION
**What does this do?**
* Create a trigger before insert/update to the fulltext index to remove punctuation
* Exclude system types from indexing
* Exclude collectionspace_core and dublin core fields from indexing

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-2162

Fulltext indexing was changed in the Nuxeo upgrade and included punctuation. This had some unintended side effects in that certain searches were no longer returning results. When we query, we strip (most) punctuation from the query so e.g. a query string of `hello.world` would be converted to `hello world` and fail to match. Removing the punctuation limit wasn't viable because some punctuation would cause exceptions, meaning we could have provided a limited set of punctuation which is allowed but it would look and feel arbitrary.

**How should this be tested? Do these changes have associated tests?**
* Create a CollectionObject with a description which includes punctuation, e.g. `hello.world`
* Use the keyword search to search on that description including punctuation

In addition, the integration tests should be run:
* Rebuild collectionspace with the tenants required for running integration tests, i.e. core, anthro, botgarden, materials, and testsci
* Start collectionspace and run the integration tests using `mvn test`

**Dependencies for merging? Releasing to production?**
README needs to be updated. 

**Has the application documentation been updated for these changes?**
Keyword searches should be documented better in the user manual. There's some which exists in the technical docs but it's otherwise limited.

**Did someone actually run this code to verify it works?**
@mikejritter tested locally and ran the integration tests

**Have any new security vulnerabilities been handled?**
n/a
