### PR TITLE
No Jira: Update Maven Enforcer Configuration

### DIFF
--- a/3rdparty/nuxeo/nuxeo-server/pom.xml
+++ b/3rdparty/nuxeo/nuxeo-server/pom.xml
@@ -667,4 +667,13 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/common-lib/pom.xml
+++ b/common-lib/pom.xml
@@ -320,4 +320,13 @@
       <version>1.25</version>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -379,6 +379,46 @@
 					<artifactId>maven-remote-resources-plugin</artifactId>
 					<version>3.3.0</version>
 				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-enforcer-plugin</artifactId>
+					<version>3.6.2</version>
+					<executions>
+						<execution>
+							<id>enforce-banned-dependencies</id>
+							<goals>
+								<goal>enforce</goal>
+							</goals>
+							<configuration>
+								<rules>
+									<!-- Configure banned dependencies to try and make Nuxeo/Hibernate/RESTEasy work together. This can be
+										updated as needed depending on what versions we end up targeting. e.g. Hibernate will also pull
+										in javax.activation.
+									-->
+									<bannedDependencies>
+										<excludes>
+											<exclude>jakarta.inject:jakarta.inject-api</exclude>
+											<exclude>jakarta.mail:jakarta.mail-api</exclude>
+											<exclude>jakarta.persistence:jakarta.persistence-api</exclude>
+											<exclude>jakarta.servlet:jakarta.servlet-api</exclude>
+											<exclude>jakarta.transaction:jakarta.transaction-api</exclude>
+											<exclude>jakarta.ws.rs:jakarta.ws.rs-api</exclude>
+											<exclude>jakarta.xml.soap:jakarta.xml.soap-api</exclude>
+										</excludes>
+										<message>Only jakarta activation, annotation, xml bind, and validation apis should be used</message>
+									</bannedDependencies>
+									<bannedDependencies>
+										<excludes>
+											<exclude>javax.xml.bind:jaxb-api</exclude>
+										</excludes>
+										<message>Do not use javax JAXB API</message>
+									</bannedDependencies>
+								</rules>
+							</configuration>
+						</execution>
+					</executions>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 
@@ -466,45 +506,6 @@
 				</configuration>
 			</plugin>
 
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>3.6.2</version>
-				<executions>
-					<execution>
-						<id>enforce-banned-dependencies</id>
-						<goals>
-							<goal>enforce</goal>
-						</goals>
-						<configuration>
-							<rules>
-								<!-- Configure banned dependencies to try and make Nuxeo/Hibernate/RESTEasy work together. This can be
-										 updated as needed depending on what versions we end up targeting. e.g. Hibernate will also pull
-										 in javax.activation.
-								-->
-								<bannedDependencies>
-									<excludes>
-										<exclude>jakarta.inject:jakarta.inject-api</exclude>
-										<exclude>jakarta.mail:jakarta.mail-api</exclude>
-										<exclude>jakarta.persistence:jakarta.persistence-api</exclude>
-										<exclude>jakarta.servlet:jakarta.servlet-api</exclude>
-										<exclude>jakarta.transaction:jakarta.transaction-api</exclude>
-										<exclude>jakarta.ws.rs:jakarta.ws.rs-api</exclude>
-										<exclude>jakarta.xml.soap:jakarta.xml.soap-api</exclude>
-									</excludes>
-									<message>Only jakarta activation, annotation, xml bind, and validation apis should be used</message>
-								</bannedDependencies>
-								<bannedDependencies>
-									<excludes>
-										<exclude>javax.xml.bind:jaxb-api</exclude>
-									</excludes>
-									<message>Do not use javax JAXB API</message>
-								</bannedDependencies>
-							</rules>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 

--- a/services/JaxRsServiceProvider/pom.xml
+++ b/services/JaxRsServiceProvider/pom.xml
@@ -931,7 +931,7 @@
                         <manifestEntries>
                             <Vendor>CollectionSpace Services</Vendor>
                             <Package>${project.groupId}</Package>
-                            <Release>${project.version</Release>
+                            <Release>${project.version}</Release>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/services/JaxRsServiceProvider/pom.xml
+++ b/services/JaxRsServiceProvider/pom.xml
@@ -936,6 +936,10 @@
                     </archive>
                 </configuration>
             </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+          </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
**What does this do?**
Adjust the maven enforcer plugin to only run on the following modules:
* services.jaxrs.provider
* cspace-nuxeo-deployment
* common-lib

**Why are we doing this? (with JIRA link)**
No Jira. This just helps to reduce build time a little bit by being more deliberate about when we run the maven-enforcer-plugin

**How should this be tested? Do these changes have associated tests?**
Rebuild and see fewer execs of the plugin

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@mikejritter built locally

**Have any new security vulnerabilities been handled?**
n/a
