### PR TITLE
Prepare 9.0.0 rc.2

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -9,7 +9,7 @@ host=127.0.0.1
 #
 # Release version info
 #
-release.version=9.0.0-RC.1
+release.version=9.0.0-RC.2
 cspace.release=${release.version}
 cspace.instance.id=${env.CSPACE_INSTANCE_ID}
 
@@ -27,7 +27,7 @@ cspace.im.root=
 # UI settings
 cspace.ui.package.name=cspace-ui
 cspace.ui.library.name=cspaceUI
-cspace.ui.version=11.0.0-rc.0
+cspace.ui.version=11.0.0-rc.1
 cspace.ui.build.branch=develop
 cspace.ui.build.node.ver=20
 service.ui.library.name=${cspace.ui.library.name}-service
@@ -35,7 +35,7 @@ service.ui.library.name=${cspace.ui.library.name}-service
 # Public browser settings
 cspace.public.browser.package.name=@collectionspace/cspace-public-browser
 cspace.public.browser.library.name=cspacePublicBrowser
-cspace.public.browser.version=4.0.0-rc.0
+cspace.public.browser.version=4.0.0-rc.1
 cspace.public.browser.build.branch=main
 cspace.public.browser.build.node.ver=20
 

--- a/cspace-ui/anthro/build.properties
+++ b/cspace-ui/anthro/build.properties
@@ -3,7 +3,7 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-anthro
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileAnthro
-tenant.ui.profile.plugin.version=9.2
+tenant.ui.profile.plugin.version=9.3.0-rc.0
 tenant.ui.profile.plugin.build.branch=develop
 
 # If not set, defaults to /gateway/${tenant.shortname} on the current host.

--- a/cspace-ui/bonsai/build.properties
+++ b/cspace-ui/bonsai/build.properties
@@ -3,7 +3,7 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-bonsai
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileBonsai
-tenant.ui.profile.plugin.version=7.1
+tenant.ui.profile.plugin.version=8.0.0-rc.0
 tenant.ui.profile.plugin.build.branch=develop
 
 # If not set, defaults to /gateway/${tenant.shortname} on the current host.

--- a/cspace-ui/fcart/build.properties
+++ b/cspace-ui/fcart/build.properties
@@ -3,7 +3,7 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-fcart
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileFCart
-tenant.ui.profile.plugin.version=9.0.0-rc.0
+tenant.ui.profile.plugin.version=9.0.0-rc.1
 tenant.ui.profile.plugin.build.branch=develop
 
 # If not set, defaults to /gateway/${tenant.shortname} on the current host.

--- a/cspace-ui/publicart/build.properties
+++ b/cspace-ui/publicart/build.properties
@@ -3,7 +3,7 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-publicart
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfilePublicArt
-tenant.ui.profile.plugin.version=8.0.0-rc.0
+tenant.ui.profile.plugin.version=8.0.0-rc.1
 tenant.ui.profile.plugin.build.branch=develop
 
 # If not set, defaults to /gateway/${tenant.shortname} on the current host.

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<name>services</name>
 
 	<properties>
-		<revision>9.0.0-RC.1</revision>
+		<revision>9.0.0-RC.2</revision>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<cspace.services.version>${revision}</cspace.services.version>
 		<cspace.services.client.version>${revision}</cspace.services.client.version>


### PR DESCRIPTION
**What does this do?**
Sets the version to 9.0.0-RC.2
Updates the ui versions
* cspace-ui - 11.0.0-rc.1
* anthro - 9.3.0-rc.0
* bonsai - 8.0.0-rc.0
* fcart - 9.0.0-rc.1
* publicart - 8.0.0-rc.1

**Why are we doing this? (with JIRA link)**
No Jira. This prepares the next release candidate.

**How should this be tested? Do these changes have associated tests?**
n/a

**Dependencies for merging? Releasing to production?**
I think I need to do the public browser as well before merging.

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@mikejritter ran locally