### PR TITLE
Nojira/time core session

### DIFF
--- a/services/common/src/main/java/org/collectionspace/services/nuxeo/client/java/CoreSessionInterface.java
+++ b/services/common/src/main/java/org/collectionspace/services/nuxeo/client/java/CoreSessionInterface.java
@@ -167,5 +167,9 @@ public interface CoreSessionInterface {
      */
     public DocumentModelList getChildren(DocumentRef parent) throws NuxeoException;
 
-    
+    /**
+     * @return The time this session was acquired, using System.nanoTime
+     */
+    long getAcquisitionTime();
+
 }

--- a/services/common/src/main/java/org/collectionspace/services/nuxeo/client/java/CoreSessionInterface.java
+++ b/services/common/src/main/java/org/collectionspace/services/nuxeo/client/java/CoreSessionInterface.java
@@ -15,12 +15,12 @@ import org.nuxeo.ecm.core.api.impl.LifeCycleFilter;
 
 public interface CoreSessionInterface {
 
-	public CoreSession getCoreSession();
-	
-    public void setTransactionRollbackOnly();
-    
-    public boolean isTransactionMarkedForRollbackOnly();
-	
+    CoreSession getCoreSession();
+
+    void setTransactionRollbackOnly();
+
+    boolean isTransactionMarkedForRollbackOnly();
+
     /**
      * Gets the root document of this repository.
      *
@@ -28,8 +28,8 @@ public interface CoreSessionInterface {
      * @throws NuxeoException
      * @throws SecurityException
      */
-    public DocumentModel getRootDocument() throws NuxeoException;
-    
+    DocumentModel getRootDocument() throws NuxeoException;
+
     /**
      * Gets the current session id.
      * <p>
@@ -37,58 +37,57 @@ public interface CoreSessionInterface {
      *
      * @return the session id or null if not connected
      */
-    public String getSessionId();
+    String getSessionId();
 
     /**
-     * 
      * @throws Exception
      */
-    public void close() throws Exception;
-    
+    void close() throws Exception;
+
     /**
      * Returns the repository name against which this core session is bound.
      *
      * @return the repository name used currently used as an identifier
      */
-    public String getRepositoryName();
-    
+    String getRepositoryName();
+
     /**
      * Gets the principal that created the client session.
      *
      * @return the principal
      */
-    public Principal getPrincipal();
+    Principal getPrincipal();
 
-    public IterableQueryResult queryAndFetch(String query, String queryType,
-            Object... params) throws NuxeoException, DocumentException;
+    IterableQueryResult queryAndFetch(String query, String queryType, Object... params)
+        throws NuxeoException, DocumentException;
 
-    public DocumentModelList query(String query, Filter filter, long limit,
-            long offset, boolean countTotal) throws NuxeoException, DocumentException;
+    DocumentModelList query(String query, Filter filter, long limit, long offset, boolean countTotal)
+        throws NuxeoException, DocumentException;
 
-    public DocumentModelList query(String query) throws NuxeoException, DocumentException;
+    DocumentModelList query(String query) throws NuxeoException, DocumentException;
 
     /**
      * Executes the given NXQL query an returns the result.
      *
      * @param query the query to execute
-     * @param max number of document to retrieve
+     * @param max   number of document to retrieve
      * @return the query result
      * @throws NuxeoException
-     * @throws DocumentException 
+     * @throws DocumentException
      */
-    public DocumentModelList query(String query, int max) throws NuxeoException, DocumentException;
-    
+    DocumentModelList query(String query, int max) throws NuxeoException, DocumentException;
+
     /**
      * Executes the given NXQL query and returns the result that matches the
      * filter.
      *
-     * @param query the query to execute
+     * @param query  the query to execute
      * @param filter the filter to apply to result
      * @return the query result
-     * @throws DocumentException 
+     * @throws DocumentException
      * @throws NuxeoException
      */
-    public DocumentModelList query(String query, LifeCycleFilter workflowStateFilter) throws DocumentException;
+    DocumentModelList query(String query, LifeCycleFilter workflowStateFilter) throws DocumentException;
 
     /**
      * Gets a document model given its reference.
@@ -104,11 +103,11 @@ public interface CoreSessionInterface {
      * @throws NuxeoException
      * @throws SecurityException
      */
-    public DocumentModel getDocument(DocumentRef docRef) throws NuxeoException;
+    DocumentModel getDocument(DocumentRef docRef) throws NuxeoException;
 
-    public DocumentModel saveDocument(DocumentModel docModel) throws NuxeoException;
+    DocumentModel saveDocument(DocumentModel docModel) throws NuxeoException;
 
-    public void save() throws NuxeoException;
+    void save() throws NuxeoException;
 
     /**
      * Bulk document saving.
@@ -116,7 +115,7 @@ public interface CoreSessionInterface {
      * @param docModels the document models that needs to be saved
      * @throws NuxeoException
      */
-    public void saveDocuments(DocumentModel[] docModels) throws NuxeoException;
+    void saveDocuments(DocumentModel[] docModels) throws NuxeoException;
 
     /**
      * Removes this document and all its children, if any.
@@ -124,7 +123,7 @@ public interface CoreSessionInterface {
      * @param docRef the reference to the document to remove
      * @throws NuxeoException
      */
-    public void removeDocument(DocumentRef docRef) throws NuxeoException;
+    void removeDocument(DocumentRef docRef) throws NuxeoException;
 
     /**
      * Creates a document model using required information.
@@ -141,9 +140,8 @@ public interface CoreSessionInterface {
      * @return the initial document model
      * @throws NuxeoException
      */
-    public DocumentModel createDocumentModel(String parentPath, String id,
-            String typeName) throws NuxeoException;
-    
+    DocumentModel createDocumentModel(String parentPath, String id, String typeName) throws NuxeoException;
+
     /**
      * Creates a document using given document model for initialization.
      * <p>
@@ -155,17 +153,17 @@ public interface CoreSessionInterface {
      * @return the created document
      * @throws NuxeoException
      */
-    public DocumentModel createDocument(DocumentModel model) throws NuxeoException;
-    
+    DocumentModel createDocument(DocumentModel model) throws NuxeoException;
+
     /**
      * Gets the children of the given parent.
      *
      * @param parent the parent reference
      * @return the children if any, an empty list if no children or null if the
-     *         specified parent document is not a folder
+     * specified parent document is not a folder
      * @throws NuxeoException
      */
-    public DocumentModelList getChildren(DocumentRef parent) throws NuxeoException;
+    DocumentModelList getChildren(DocumentRef parent) throws NuxeoException;
 
     /**
      * @return The time this session was acquired, using System.nanoTime

--- a/services/common/src/main/java/org/collectionspace/services/nuxeo/client/java/CoreSessionWrapper.java
+++ b/services/common/src/main/java/org/collectionspace/services/nuxeo/client/java/CoreSessionWrapper.java
@@ -31,6 +31,7 @@ public class CoreSessionWrapper implements CoreSessionInterface {
 
 	private CoreSession repoSession;
 	private boolean transactionSetForRollback = false;
+	private final long acquisitionTime;
 
     /** The logger. */
     private static Logger logger = LoggerFactory.getLogger(CoreSessionWrapper.class);
@@ -51,6 +52,7 @@ public class CoreSessionWrapper implements CoreSessionInterface {
 
 	public CoreSessionWrapper(CoreSession repoSession) {
 		this.repoSession = repoSession;
+		this.acquisitionTime = System.nanoTime();
 	}
 
 	/*
@@ -340,6 +342,8 @@ public class CoreSessionWrapper implements CoreSessionInterface {
     	return repoSession.getChildren(parent);
     }
 
-
-
+	@Override
+    public long getAcquisitionTime() {
+        return acquisitionTime;
+    }
 }

--- a/services/common/src/main/java/org/collectionspace/services/nuxeo/client/java/NuxeoClientEmbedded.java
+++ b/services/common/src/main/java/org/collectionspace/services/nuxeo/client/java/NuxeoClientEmbedded.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
 import javax.transaction.TransactionManager;
 
 import org.collectionspace.services.common.context.ServiceContext;
@@ -329,6 +330,16 @@ public final class NuxeoClientEmbedded {
         	throw e;
         } finally {
         	repoSession.close();
+
+			long now = System.nanoTime();
+			long sessionTime = repoSession.getAcquisitionTime();
+			long elapsed = TimeUnit.NANOSECONDS.toMillis(now - sessionTime);
+			// 250ms is the default blocking time for the nuxeo pool; use it as a baseline for logging
+			// i.e. session used for longer than 250ms -> potential to block > 250ms
+			if (elapsed > 250) {
+				logger.warn("CoreSession used for {} ms", elapsed);
+			}
+
         	CoreSessionInterface wasRemoved = repositoryInstances.remove(key);
             if (logger.isTraceEnabled()) {
             	if (wasRemoved != null) {

--- a/services/common/src/main/java/org/collectionspace/services/nuxeo/client/java/NuxeoClientEmbedded.java
+++ b/services/common/src/main/java/org/collectionspace/services/nuxeo/client/java/NuxeoClientEmbedded.java
@@ -49,7 +49,7 @@ import org.springframework.aop.framework.ProxyFactory;
 public final class NuxeoClientEmbedded {
 
 	private Logger logger = LoggerFactory.getLogger(NuxeoClientEmbedded.class);
-	
+
     private final HashMap<String, CoreSessionInterface> repositoryInstances;
 
     private RepositoryManager repositoryMgr;
@@ -57,7 +57,7 @@ public final class NuxeoClientEmbedded {
     private static final NuxeoClientEmbedded instance = new NuxeoClientEmbedded();
 
 	private static final int MAX_CREATE_TRANSACTION_ATTEMPTS = 5;
-        
+
     /**
      * Constructs a new NuxeoClient. NOTE: Using {@link #getInstance()} instead
      * of this constructor is recommended.
@@ -65,7 +65,7 @@ public final class NuxeoClientEmbedded {
     private NuxeoClientEmbedded() {
         repositoryInstances = new HashMap<String, CoreSessionInterface>();
     }
-    
+
     public static NuxeoClientEmbedded getInstance() {
         return instance;
     }
@@ -82,7 +82,7 @@ public final class NuxeoClientEmbedded {
             try {
                 repo.getValue().close();
             } catch (Exception e) {
-                logger.debug("Error while trying to close " + repo, e);
+                logger.debug("Error while trying to close {}", repo, e);
             }
             it.remove();
         }
@@ -121,39 +121,40 @@ public final class NuxeoClientEmbedded {
     public CoreSessionInterface openRepository(RepositoryDomainType repoDomain) throws Exception {
         return openRepository(repoDomain.getRepositoryName(), ServiceContext.DEFAULT_TX_TIMEOUT);
     }
-    
+
     /*
      * Open a Nuxeo repo session using the passed in repoDomain and use the default tx timeout period
      */
     public CoreSessionInterface openRepository(String repoName) throws Exception {
         return openRepository(repoName, ServiceContext.DEFAULT_TX_TIMEOUT);
     }
-    
+
     private boolean startTransaction() {
     	boolean startedTransaction = false;
     	int attempts = 0;
-    	
-    	if (TransactionHelper.isTransactionActive() == false) {
-        	while (startedTransaction == false && attempts <= MAX_CREATE_TRANSACTION_ATTEMPTS) {        		
+
+    	if (!TransactionHelper.isTransactionActive()) {
+        	while (!startedTransaction && attempts <= MAX_CREATE_TRANSACTION_ATTEMPTS) {
         		try {
         			startedTransaction = TransactionHelper.startTransaction();
         		} catch (Exception e) {
-        			String traceMsg = String.format("Could not start a new transaction on thread '%d'", Thread.currentThread().getId());
+        			String traceMsg = String.format("Could not start a new transaction on thread '%d'",
+                                                    Thread.currentThread().threadId());
         			logger.trace(traceMsg);
         			boolean txState = TransactionHelper.isTransactionActive();
         			txState = TransactionHelper.isNoTransaction();
         			txState = TransactionHelper.isTransactionActiveOrMarkedRollback();
         			txState = TransactionHelper.isTransactionMarkedRollback();
         		}
-        		
-    	    	if (startedTransaction == false) {
-    	    		long currentThreadId = Thread.currentThread().getId();
+
+    	    	if (!startedTransaction) {
+    	    		long currentThreadId = Thread.currentThread().threadId();
         			boolean txState = TransactionHelper.isTransactionActive();
         			txState = TransactionHelper.isNoTransaction();
         			txState = TransactionHelper.isTransactionActiveOrMarkedRollback();
         			txState = TransactionHelper.isTransactionMarkedRollback();
-        			
-        			if (TransactionHelper.isTransactionActiveOrMarkedRollback() == true) {
+
+        			if (TransactionHelper.isTransactionActiveOrMarkedRollback()) {
         				try {
         					TransactionHelper.commitOrRollbackTransaction();
         				} catch (Exception e) {
@@ -167,8 +168,8 @@ public final class NuxeoClientEmbedded {
     		logger.warn("A request to start a new transaction was made, but a transaction is already open.");
     		startedTransaction = true;
     	}
-    		
-		if (startedTransaction == false) {
+
+		if (!startedTransaction) {
 			String errMsg = String.format("Attempted %d time(s) to start a new transaction, but failed.", attempts);
     		logger.error(errMsg);
         }
@@ -178,7 +179,7 @@ public final class NuxeoClientEmbedded {
 
     public CoreSessionInterface openRepository(String repoName, int timeoutSeconds) throws Exception {
     	CoreSessionInterface result = null;
-    	
+
     	//
     	// If the called passed in a custom timeout setting, use it to configure Nuxeo's transaction manager.
     	//
@@ -190,30 +191,29 @@ public final class NuxeoClientEmbedded {
             		logger.debug("TransactionHelper's manager is different than NuxeoContainer's.");
             	}
             }
-    		
+
     		transactionMgr.setTransactionTimeout(timeoutSeconds); // For the current thread only
     		if (logger.isInfoEnabled()) {
-    			logger.info(String.format("Changing current request's transaction timeout period to %d seconds",
-    					timeoutSeconds));
+    			logger.info("Changing current request's transaction timeout period to {} seconds", timeoutSeconds);
     		}
     	}
-    	
+
     	//
     	// Start a new Nuxeo transaction
     	//
     	boolean startedTransaction = false;
-    	if (TransactionHelper.isTransactionActive() == false) {
+    	if (!TransactionHelper.isTransactionActive()) {
     		startedTransaction = startTransaction();
-	    	if (startedTransaction == false) {
+	    	if (!startedTransaction) {
 	    		String errMsg = String.format("Could not start a Nuxeo transaction with the TransactionHelper class on thread '%d'.",
-	    				Thread.currentThread().getId());
+                                              Thread.currentThread().threadId());
 	    		logger.error(errMsg);
 	    		throw new Exception(errMsg);
 	    	}
     	} else {
     		logger.warn("A request to start a new transaction was made, but a transaction is already open.");
     	}
-    	
+
     	//
     	// From the repository name that the caller passed in, get an instance of Nuxeo's Repository class.
     	// The Repository class is just a metadata description of the repository.
@@ -223,9 +223,9 @@ public final class NuxeoClientEmbedded {
         	repository = getRepositoryManager().getRepository(repoName);
         } else {
         	repository = getRepositoryManager().getDefaultRepository();
-        	logger.warn(String.format("Using default repository '%s' because no name was specified.", repository.getName()));
+        	logger.warn("Using default repository '{}' because no name was specified.", repository.getName());
         }
-        
+
         //
         // Using the Repository class, get a Spring AOP proxied instance.  We use Spring AOP to "wrap" all calls to the
         // Nuxeo repository so we can check for network related failures and perform a series of retries.
@@ -233,28 +233,28 @@ public final class NuxeoClientEmbedded {
         if (repository != null) {
             result = getCoreSessionWrapper(repository);
             if (result != null) {
-	        	logger.trace(String.format("A new transaction was started on thread '%d' : %s.",
-	        			Thread.currentThread().getId(), startedTransaction ? "true" : "false"));
-	        	logger.trace(String.format("Added a new repository instance to our repo list.  Current count is now: %d",
-	        			repositoryInstances.size()));
+	        	logger.trace("A new transaction was started on thread '{}' : {}.", Thread.currentThread().threadId(),
+                             startedTransaction ? "true" : "false");
+	        	logger.trace("Added a new repository instance to our repo list.  Current count is now: {}",
+                             repositoryInstances.size());
             }
         }
-        
+
         if (repository == null || result == null) {
         	//
         	// If we couldn't open a repo session, we need to close the transaction we started.
         	//
-        	if (startedTransaction == true) {
+        	if (startedTransaction) {
         		TransactionHelper.commitOrRollbackTransaction();
         	}
         	String errMsg = String.format("Could not open a session to the Nuxeo repository='%s'", repoName);
         	logger.error(errMsg);
         	throw new Exception(errMsg);
-        }    	
-    	
+        }
+
         return result;
     }
-    
+
     //
     // Returns a proxied interface to a Nuxeo repository instance.  Our proxy uses Spring AOP to
     // wrap each call to the Nuxeo repo with code that catches network related errors/exceptions and
@@ -262,19 +262,19 @@ public final class NuxeoClientEmbedded {
     //
     private CoreSessionInterface getAOPProxy(CoreSession repositoryInstance) {
     	CoreSessionInterface result = null;
-    	
+
     	try {
 			ProxyFactory factory = new ProxyFactory(new CoreSessionWrapper(repositoryInstance));
 			factory.addAdvice(new RepositoryInstanceWrapperAdvice());
 			factory.setExposeProxy(true);
 			result = (CoreSessionInterface)factory.getProxy();
     	} catch (Exception e) {
-    		logger.error("Could not create AOP proxy for: " + CoreSessionWrapper.class.getName(), e);
+            logger.error("Could not create AOP proxy for: {}", CoreSessionWrapper.class.getName(), e);
     	}
-    	
+
     	return result;
     }
-    
+
 	private NuxeoPrincipal getSystemPrincipal() {
         return new SystemPrincipal(null);
 	}
@@ -314,22 +314,22 @@ public final class NuxeoClientEmbedded {
     	return result;
     }
 
-    public void releaseRepository(CoreSessionInterface repoSession) throws Exception {
-    	String key = repoSession.getSessionId();
-    	String name = repoSession.getRepositoryName();
+	public void releaseRepository(CoreSessionInterface repoSession) throws Exception {
+		String key = repoSession.getSessionId();
+		String name = repoSession.getRepositoryName();
 
-    	//
-    	// The caller should have already called the .save() method, but just in
-    	// case they didn't, let's try calling it again.
-    	//
-        try {
-        	repoSession.save();
-        } catch (Exception e) {
-        	String errMsg = String.format("Possible data loss.  Could not save and/or close the Nuxeo repository name = '%s'.", name);
-        	logger.warn(errMsg, e);
-        	throw e;
-        } finally {
-        	repoSession.close();
+		//
+		// The caller should have already called the .save() method, but just in
+		// case they didn't, let's try calling it again.
+		//
+		try {
+			repoSession.save();
+		} catch (Exception e) {
+			String errMsg = String.format("Possible data loss.  Could not save and/or close the Nuxeo repository name = '%s'.", name);
+			logger.warn(errMsg, e);
+			throw e;
+		} finally {
+			repoSession.close();
 
 			long now = System.nanoTime();
 			long sessionTime = repoSession.getAcquisitionTime();
@@ -340,27 +340,27 @@ public final class NuxeoClientEmbedded {
 				logger.warn("CoreSession used for {} ms", elapsed);
 			}
 
-        	CoreSessionInterface wasRemoved = repositoryInstances.remove(key);
-            if (logger.isTraceEnabled()) {
-            	if (wasRemoved != null) {
-	            	logger.trace("Removed a repository instance from our repo list.  Current count is now: "
-	            			+ repositoryInstances.size());
-            	} else {
-            		logger.trace("Could not remove a repository instance from our repo list.  Current count is now: "
-	            			+ repositoryInstances.size());
-            	}
-            }            
-            //
-            // Last but not least, try to commit the current Nuxeo-related transaction.
-            //
-            if (TransactionHelper.isTransactionActiveOrMarkedRollback() == true) {
-            	TransactionHelper.commitOrRollbackTransaction();
-            	logger.trace(String.format("Transaction closed on thread '%d'", Thread.currentThread().getId()));
-            } else {
-            	String warnMsg = String.format("Closed a Nuxeo repository session on thread '%d' without closing the containing transaction.",
-            			Thread.currentThread().getId());
-            	logger.warn(warnMsg);
-            }
-        }
-    }    
+			CoreSessionInterface wasRemoved = repositoryInstances.remove(key);
+			if (logger.isTraceEnabled()) {
+				if (wasRemoved != null) {
+					logger.trace("Removed a repository instance from our repo list.  Current count is now: {}",
+								 repositoryInstances.size());
+				} else {
+					logger.trace("Could not remove a repository instance from our repo list.  Current count is now: {}",
+								 repositoryInstances.size());
+				}
+			}
+			//
+			// Last but not least, try to commit the current Nuxeo-related transaction.
+			//
+			if (TransactionHelper.isTransactionActiveOrMarkedRollback()) {
+				TransactionHelper.commitOrRollbackTransaction();
+				logger.trace("Transaction closed on thread '{}'", Thread.currentThread().threadId());
+			} else {
+				String warnMsg = String.format("Closed a Nuxeo repository session on thread '%d' without closing the containing transaction.",
+											   Thread.currentThread().threadId());
+				logger.warn(warnMsg);
+			}
+		}
+	}
 }


### PR DESCRIPTION
**What does this do?**
Adds logging for total time elapsed when using a CoreSession

**Why are we doing this? (with JIRA link)**
No jira. This is an idea I had to try and track which sessions are being held on to longer than the default timeout.

It would be good to discuss the default value. Initially I was thinking of using 1 second, but when thinking further it seemed like maybe 250ms is a good starting point. My only concern would be that is too short and we might see many sessions being used for that long.

Also, at the moment you need to correlate the log with the http thread its being executed on. This could be extended to include the query, or some other bookkeeping to make it easier, however I wanted to keep this fairly simple for now (and some of the housekeeping has already made the PR larger than it needs to be). 

**How should this be tested? Do these changes have associated tests?**
* Rebuild and start collectionspace
* Query against an endpoint, ideally with a large number of records
  * If you have a small instance, it's possible to connect with a debugger and set a breakpoint after the CoreSession is created (e.g. in `NuxeoRepositoryClientImpl#getFiltered` after `getRepositorySession(ctx)`)
* See the log show up in catalina.out or cspace-services.log

**Dependencies for merging? Releasing to production?**
No dependencies.

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@mikejritter ran locally

**Have any new security vulnerabilities been handled?**
n/a
